### PR TITLE
Add support for Honest Profiler

### DIFF
--- a/src/main/java/net/rubygrapefruit/gradle/profiler/InvocationSettings.java
+++ b/src/main/java/net/rubygrapefruit/gradle/profiler/InvocationSettings.java
@@ -6,7 +6,8 @@ import java.util.Map;
 
 class InvocationSettings {
     private final File projectDir;
-    private final boolean profile;
+    private final Profiler profiler;
+    private final Object profilerOptions;
     private final boolean benchmark;
     private final boolean dryRun;
     private final File configFile;
@@ -16,10 +17,11 @@ class InvocationSettings {
     private final List<String> tasks;
     private final Map<String, String> sysProperties;
 
-    public InvocationSettings(File projectDir, boolean profile, boolean benchmark, File outputDir, Invoker invoker, boolean dryRun, File configFile, List<String> versions, List<String> tasks, Map<String, String> sysProperties) {
+    public InvocationSettings(File projectDir, Profiler profiler, final Object profilerOptions, boolean benchmark, File outputDir, Invoker invoker, boolean dryRun, File configFile, List<String> versions, List<String> tasks, Map<String, String> sysProperties) {
+        this.profilerOptions = profilerOptions;
         this.benchmark = benchmark;
         this.projectDir = projectDir;
-        this.profile = profile;
+        this.profiler = profiler;
         this.outputDir = outputDir;
         this.invoker = invoker;
         this.dryRun = dryRun;
@@ -46,7 +48,15 @@ class InvocationSettings {
     }
 
     public boolean isProfile() {
-        return profile;
+        return profiler != Profiler.none;
+    }
+
+    public Profiler getProfiler() {
+        return profiler;
+    }
+
+    public Object getProfilerOptions() {
+        return profilerOptions;
     }
 
     public File getConfigFile() {

--- a/src/main/java/net/rubygrapefruit/gradle/profiler/JvmArgsCalculator.java
+++ b/src/main/java/net/rubygrapefruit/gradle/profiler/JvmArgsCalculator.java
@@ -2,7 +2,9 @@ package net.rubygrapefruit.gradle.profiler;
 
 import java.util.List;
 
-class JvmArgsCalculator {
-    void calculateJvmArgs(List<String> jvmArgs) {
+public class JvmArgsCalculator {
+    public static final JvmArgsCalculator DEFAULT = new JvmArgsCalculator();
+
+    public void calculateJvmArgs(List<String> jvmArgs) {
     }
 }

--- a/src/main/java/net/rubygrapefruit/gradle/profiler/Profiler.java
+++ b/src/main/java/net/rubygrapefruit/gradle/profiler/Profiler.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2003-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.rubygrapefruit.gradle.profiler;
+
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import net.rubygrapefruit.gradle.profiler.hp.HonestProfilerArgs;
+import net.rubygrapefruit.gradle.profiler.hp.HonestProfilerControl;
+import net.rubygrapefruit.gradle.profiler.hp.HonestProfilerJvmArgsCalculator;
+import net.rubygrapefruit.gradle.profiler.jfr.JFRArgs;
+import net.rubygrapefruit.gradle.profiler.jfr.JFRControl;
+import net.rubygrapefruit.gradle.profiler.jfr.JFRJvmArgsCalculator;
+
+import java.io.File;
+
+public enum Profiler {
+    none,
+    jfr {
+        @Override
+        public ProfilerController newController(final String pid, final InvocationSettings settings) {
+            JFRArgs jfrArgs = new JFRArgs(pid, new File(settings.getOutputDir(), "profile.jfr"));
+            return new JFRControl(jfrArgs);
+        }
+
+        @Override
+        public JvmArgsCalculator newJvmArgsCalculator(InvocationSettings settings) {
+            return new JFRJvmArgsCalculator();
+        }
+    },
+    hp {
+        @Override
+        public Object newConfigObject(final OptionSet parsedOptions) {
+            File tmpLog = new File(System.getProperty("java.io.tmpdir"), "hp.log");
+            int i = 0;
+            while (tmpLog.exists()) {
+                tmpLog = new File(System.getProperty("java.io.tmpdir"), "hp.log."+(++i));
+            }
+            HonestProfilerArgs args = new HonestProfilerArgs(
+                    new File((String) parsedOptions.valueOf("hp-home")),
+                    tmpLog,
+                    Integer.valueOf((String) parsedOptions.valueOf("hp-port")),
+                    Integer.valueOf((String) parsedOptions.valueOf("hp-interval"))
+            );
+            return args;
+        }
+
+        @Override
+        public ProfilerController newController(final String pid, final InvocationSettings settings) {
+            HonestProfilerArgs args = (HonestProfilerArgs) settings.getProfilerOptions();
+            return new HonestProfilerControl(args, settings.getOutputDir());
+        }
+
+        @Override
+        public JvmArgsCalculator newJvmArgsCalculator(InvocationSettings settings) {
+            return new HonestProfilerJvmArgsCalculator((HonestProfilerArgs) settings.getProfilerOptions());
+        }
+
+        @Override
+        public void addOptions(final OptionParser parser) {
+            parser.accepts("hp-port", "Honest Profiler port")
+                    .availableIf("profile")
+                    .withOptionalArg()
+                    .defaultsTo("18000");
+            parser.accepts("hp-home", "Honest Profiler home directory")
+                    .availableIf("profile")
+                    .withOptionalArg()
+                    .defaultsTo(System.getenv().getOrDefault("HP_HOME_DIR", ""));
+            parser.accepts("hp-interval", "Honest Profiler sampling interval")
+                    .availableIf("profile")
+                    .withOptionalArg()
+                    .defaultsTo("7");
+        }
+    };
+
+    public ProfilerController newController(final String pid, final InvocationSettings settings) {
+        return ProfilerController.EMPTY;
+    }
+
+    public JvmArgsCalculator newJvmArgsCalculator(final InvocationSettings settings) {
+        return JvmArgsCalculator.DEFAULT;
+    }
+
+    public Object newConfigObject(OptionSet parsedOptions) {
+        return null;
+    }
+
+    void addOptions(OptionParser parser) {
+
+    }
+
+    static void configureParser(OptionParser parser) {
+        for (Profiler profiler : values()) {
+            profiler.addOptions(parser);
+        }
+    }
+}

--- a/src/main/java/net/rubygrapefruit/gradle/profiler/ProfilerController.java
+++ b/src/main/java/net/rubygrapefruit/gradle/profiler/ProfilerController.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2003-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.rubygrapefruit.gradle.profiler;
+
+import java.io.IOException;
+
+public interface ProfilerController {
+    ProfilerController EMPTY = new ProfilerController() {
+        @Override
+        public void start() throws IOException, InterruptedException {
+
+        }
+
+        @Override
+        public void stop() throws IOException, InterruptedException {
+
+        }
+    };
+
+    void start() throws IOException, InterruptedException;
+
+    void stop() throws IOException, InterruptedException;
+}

--- a/src/main/java/net/rubygrapefruit/gradle/profiler/hp/HonestProfilerArgs.java
+++ b/src/main/java/net/rubygrapefruit/gradle/profiler/hp/HonestProfilerArgs.java
@@ -1,0 +1,33 @@
+package net.rubygrapefruit.gradle.profiler.hp;
+
+import java.io.File;
+
+public class HonestProfilerArgs {
+    private final File hpHomeDir;
+    private final File logPath;
+    private final int port;
+    private final int interval;
+
+    public HonestProfilerArgs(final File hpHomeDir, final File logPath, final int port, final int interval) {
+        this.hpHomeDir = hpHomeDir;
+        this.logPath = logPath;
+        this.port = port;
+        this.interval = interval;
+    }
+
+    public File getHpHomeDir() {
+        return hpHomeDir;
+    }
+
+    public File getLogPath() {
+        return logPath;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public int getInterval() {
+        return interval;
+    }
+}

--- a/src/main/java/net/rubygrapefruit/gradle/profiler/hp/HonestProfilerControl.java
+++ b/src/main/java/net/rubygrapefruit/gradle/profiler/hp/HonestProfilerControl.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2003-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.rubygrapefruit.gradle.profiler.hp;
+
+import net.rubygrapefruit.gradle.profiler.ProfilerController;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.file.Files;
+
+public class HonestProfilerControl implements ProfilerController {
+    private static final String PROFILE_HPL = "profile.hpl";
+
+    private final HonestProfilerArgs args;
+    private final File outputDir;
+
+    public HonestProfilerControl(final HonestProfilerArgs args, final File outputDir) {
+        this.args = args;
+        this.outputDir = outputDir;
+    }
+
+    @Override
+    public void start() throws IOException, InterruptedException {
+        System.out.println("Starting profiling with Honest Profiler on port " + args.getPort());
+        sendCommand("start");
+    }
+
+    @Override
+    public void stop() throws IOException, InterruptedException {
+        System.out.println("Stopping profiling with Honest Profiler on port " + args.getPort());
+        sendCommand("stop");
+        Files.copy(args.getLogPath().toPath(), new File(outputDir, PROFILE_HPL).toPath());
+    }
+
+    private void sendCommand(String command) throws IOException {
+        Socket socket = new Socket("localhost", args.getPort());
+        try (OutputStream out = socket.getOutputStream()) {
+            out.write(commandBytes(command));
+        }
+    }
+
+    private byte[] commandBytes(final String command) {
+        return (command + "\r\n").getBytes();
+    }
+
+}

--- a/src/main/java/net/rubygrapefruit/gradle/profiler/hp/HonestProfilerJvmArgsCalculator.java
+++ b/src/main/java/net/rubygrapefruit/gradle/profiler/hp/HonestProfilerJvmArgsCalculator.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2003-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.rubygrapefruit.gradle.profiler.hp;
+
+import net.rubygrapefruit.gradle.profiler.JvmArgsCalculator;
+
+import java.util.List;
+
+public class HonestProfilerJvmArgsCalculator extends JvmArgsCalculator {
+
+    private final HonestProfilerArgs args;
+
+    public HonestProfilerJvmArgsCalculator(final HonestProfilerArgs honestProfilerArgs) {
+        this.args = honestProfilerArgs;
+    }
+
+    @Override
+    public void calculateJvmArgs(final List<String> jvmArgs) {
+        jvmArgs.add("-XX:+UnlockDiagnosticVMOptions");
+        jvmArgs.add("-XX:+DebugNonSafepoints");
+        jvmArgs.add("-agentpath:" + args.getHpHomeDir().getAbsolutePath() + "/liblagent.so=interval=" + args.getInterval() + ",logPath=" + args.getLogPath().getAbsolutePath() + ",port=" + args.getPort() + ",host=localhost,start=0'");
+    }
+}

--- a/src/main/java/net/rubygrapefruit/gradle/profiler/jfr/JFRArgs.java
+++ b/src/main/java/net/rubygrapefruit/gradle/profiler/jfr/JFRArgs.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2003-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.rubygrapefruit.gradle.profiler.jfr;
+
+import java.io.File;
+
+public class JFRArgs {
+    private final String pid;
+    private final File recordingFile;
+
+    public JFRArgs(final String pid, final File recordingFile) {
+        this.pid = pid;
+        this.recordingFile = recordingFile;
+    }
+
+    public String getPid() {
+        return pid;
+    }
+
+    public File getRecordingFile() {
+        return recordingFile;
+    }
+}

--- a/src/main/java/net/rubygrapefruit/gradle/profiler/jfr/JFRControl.java
+++ b/src/main/java/net/rubygrapefruit/gradle/profiler/jfr/JFRControl.java
@@ -1,12 +1,15 @@
-package net.rubygrapefruit.gradle.profiler;
+package net.rubygrapefruit.gradle.profiler.jfr;
+
+import net.rubygrapefruit.gradle.profiler.ProfilerController;
 
 import java.io.File;
 import java.io.IOException;
 
-class JFRControl {
+public class JFRControl implements ProfilerController {
     private final File jcmd;
+    private final JFRArgs jfrArgs;
 
-    public JFRControl() {
+    public JFRControl(final JFRArgs args) {
         File javaHome = new File(System.getProperty("java.home"));
         File jcmd = new File(javaHome, "bin/jcmd");
         if (!jcmd.isFile() && javaHome.getName().equals("jre")) {
@@ -16,13 +19,18 @@ class JFRControl {
             throw new RuntimeException("Could not find 'jcmd' executable for Java home directory " + javaHome);
         }
         this.jcmd = jcmd;
+        this.jfrArgs = args;
     }
 
-    public void start(String pid) throws IOException, InterruptedException {
-        run(jcmd.getAbsolutePath(), pid, "JFR.start", "name=profile", "settings=profile", "duration=0");
+    @Override
+    public void start() throws IOException, InterruptedException {
+        run(jcmd.getAbsolutePath(), jfrArgs.getPid(), "JFR.start", "name=profile", "settings=profile", "duration=0");
     }
 
-    public void stop(String pid, File recordingFile) throws IOException, InterruptedException {
+    @Override
+    public void stop() throws IOException, InterruptedException {
+        String pid = jfrArgs.getPid();
+        File recordingFile = jfrArgs.getRecordingFile();
         run(jcmd.getAbsolutePath(), pid, "JFR.stop", "name=profile", "filename=" + recordingFile.getAbsolutePath());
         System.out.println("Wrote profiling data to " + recordingFile.getPath());
     }

--- a/src/main/java/net/rubygrapefruit/gradle/profiler/jfr/JFRJvmArgsCalculator.java
+++ b/src/main/java/net/rubygrapefruit/gradle/profiler/jfr/JFRJvmArgsCalculator.java
@@ -1,10 +1,12 @@
-package net.rubygrapefruit.gradle.profiler;
+package net.rubygrapefruit.gradle.profiler.jfr;
+
+import net.rubygrapefruit.gradle.profiler.JvmArgsCalculator;
 
 import java.util.List;
 
-class JFRJvmArgsCalculator extends JvmArgsCalculator{
+public class JFRJvmArgsCalculator extends JvmArgsCalculator {
     @Override
-    void calculateJvmArgs(List<String> jvmArgs) {
+    public void calculateJvmArgs(List<String> jvmArgs) {
         jvmArgs.add("-XX:+UnlockCommercialFeatures");
         jvmArgs.add("-XX:+FlightRecorder");
         jvmArgs.add("-XX:FlightRecorderOptions=stackdepth=1024");


### PR DESCRIPTION
This commit adds support for an additional profiler (Honest Profiler) instead of just JFR.
For this, it adds a `Profiler` abstraction, and now the `--profile` option requires to tell
which profiler to use. Honest Profiler requires either the `HP_HOME_DIR` environment variable
to be set, or the `hp-home` option to be set.

This does *not* add support for flame graph generation yet.