### PR TITLE
Add support for running on Windows

### DIFF
--- a/src/main/java/org/gradle/profiler/CommandExec.java
+++ b/src/main/java/org/gradle/profiler/CommandExec.java
@@ -2,12 +2,17 @@ package org.gradle.profiler;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class CommandExec {
+    public void run(Collection<String> commandLine) {
+        run(commandLine.toArray(new String[commandLine.size()]));
+    }
+
     public void run(String... commandLine) {
         ProcessBuilder processBuilder = new ProcessBuilder(commandLine);
         run(processBuilder);

--- a/src/main/java/org/gradle/profiler/DaemonControl.java
+++ b/src/main/java/org/gradle/profiler/DaemonControl.java
@@ -1,9 +1,7 @@
 package org.gradle.profiler;
 
-import java.io.File;
-
 public class DaemonControl {
     public void stop(GradleVersion version) {
-        new CommandExec().run(new File(version.getGradleHome(), "bin/gradle").getAbsolutePath(), "--stop");
+        version.runGradle("--stop");
     }
 }

--- a/src/main/java/org/gradle/profiler/GradleVersion.java
+++ b/src/main/java/org/gradle/profiler/GradleVersion.java
@@ -1,8 +1,13 @@
 package org.gradle.profiler;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 class GradleVersion {
+
+    private static final String OS = System.getProperty("os.name");
+
     private final String version;
     private final File gradleHome;
 
@@ -17,5 +22,23 @@ class GradleVersion {
 
     public File getGradleHome() {
         return gradleHome;
+    }
+
+    public void runGradle(String... arguments) {
+        List<String> commandLine = new ArrayList<>();
+        addGradleCommand(commandLine);
+        new CommandExec().run(commandLine);
+    }
+
+    public void addGradleCommand(List<String> commandLine) {
+        if (isWindows()) {
+            commandLine.add("cmd.exe");
+            commandLine.add("/C");
+        }
+        commandLine.add(new File(gradleHome, "bin/gradle").getAbsolutePath());
+    }
+
+    private static boolean isWindows() {
+        return OS.toLowerCase().startsWith("windows");
     }
 }

--- a/src/main/java/org/gradle/profiler/NoDaemonInvoker.java
+++ b/src/main/java/org/gradle/profiler/NoDaemonInvoker.java
@@ -21,7 +21,7 @@ public class NoDaemonInvoker extends BuildInvoker {
     @Override
     protected void run(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
         List<String> commandLine = new ArrayList<>();
-        commandLine.add(new File(gradleVersion.getGradleHome(), "bin/gradle").getAbsolutePath());
+        gradleVersion.addGradleCommand(commandLine);
         commandLine.addAll(gradleArgs);
         commandLine.add("--no-daemon");
         commandLine.addAll(tasks);


### PR DESCRIPTION
gradle batch files cannot be executed directly on Windows, they have to be started via `cmd /C`