### PR TITLE
JProfiler support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+classes
 /.gradle
 /.idea
 /profile-out

--- a/src/main/java/org/gradle/profiler/GradleVersion.java
+++ b/src/main/java/org/gradle/profiler/GradleVersion.java
@@ -27,6 +27,7 @@ class GradleVersion {
     public void runGradle(String... arguments) {
         List<String> commandLine = new ArrayList<>();
         addGradleCommand(commandLine);
+        commandLine.addAll(Arrays.asList(arguments));
         new CommandExec().run(commandLine);
     }
 

--- a/src/main/java/org/gradle/profiler/GradleVersion.java
+++ b/src/main/java/org/gradle/profiler/GradleVersion.java
@@ -2,11 +2,10 @@ package org.gradle.profiler;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 class GradleVersion {
-
-    private static final String OS = System.getProperty("os.name");
 
     private final String version;
     private final File gradleHome;
@@ -32,14 +31,10 @@ class GradleVersion {
     }
 
     public void addGradleCommand(List<String> commandLine) {
-        if (isWindows()) {
+        if (OperatingSystem.isWindows()) {
             commandLine.add("cmd.exe");
             commandLine.add("/C");
         }
         commandLine.add(new File(gradleHome, "bin/gradle").getAbsolutePath());
-    }
-
-    private static boolean isWindows() {
-        return OS.toLowerCase().startsWith("windows");
     }
 }

--- a/src/main/java/org/gradle/profiler/OperatingSystem.java
+++ b/src/main/java/org/gradle/profiler/OperatingSystem.java
@@ -1,0 +1,19 @@
+package org.gradle.profiler;
+
+public class OperatingSystem {
+
+    private static final String OS_NAME = System.getProperty("os.name").toLowerCase();
+    private static final String OS_ARCH = System.getProperty("os.arch").toLowerCase();
+
+    public static boolean isWindows() {
+        return OS_NAME.startsWith("windows");
+    }
+
+    public static boolean isMacOS() {
+        return OS_NAME.startsWith("mac");
+    }
+
+    public static boolean isLinuxX86() {
+        return OS_NAME.startsWith("linux") && (OS_ARCH.equals("amd64") || OS_ARCH.equals("x86_64") || OS_ARCH.equals("x86"));
+    }
+}

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
@@ -1,0 +1,19 @@
+package org.gradle.profiler.jprofiler;
+
+import org.gradle.profiler.OperatingSystem;
+
+public class JProfiler {
+
+    private static final String MAJOR_VERSION = "9";
+
+    public static String getDefaultHomeDir() {
+        if (OperatingSystem.isWindows()) {
+            return "c:\\Program Files\\jprofiler" + MAJOR_VERSION;
+        } else if (OperatingSystem.isMacOS()) {
+            return "/Applications/JProfiler.app";
+        } else {
+            return "/opt/jprofiler" + MAJOR_VERSION;
+        }
+    }
+
+}

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerConfig.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerConfig.java
@@ -1,0 +1,94 @@
+package org.gradle.profiler.jprofiler;
+
+import java.util.*;
+
+public class JProfilerConfig {
+
+    private final String homeDir;
+    private final String config;
+    private final String sessionId;
+    private final boolean recordAlloc;
+    private final boolean recordMonitors;
+    private final List<String> recordedProbes;
+    private final Set<String> probesWithEventRecording;
+    private final Set<String> probesWithSpecialRecording;
+    private final boolean heapDump;
+
+    private int port;
+
+    public JProfilerConfig(String homeDir, String config, String sessionId, boolean recordAlloc, boolean recordMonitors, boolean heapDump, List<String> recordedProbeSpecs) {
+        this.homeDir = homeDir;
+        this.sessionId = sessionId;
+        this.recordAlloc = recordAlloc;
+        this.config = config;
+        this.recordMonitors = recordMonitors;
+        this.heapDump = heapDump;
+
+        List<String> recordedProbes = new ArrayList<>();
+        Set<String> probesWithEventRecording = new HashSet<>();
+        Set<String> probesWithSpecialRecording = new HashSet<>();
+        for (String probeSpec : recordedProbeSpecs) {
+            int separatorPos = probeSpec.indexOf(':');
+            if (separatorPos > -1) {
+                String probeName = probeSpec.substring(0, separatorPos);
+                String probeOptions = probeSpec.substring(separatorPos + 1);
+                recordedProbes.add(probeName);
+                if (probeOptions.contains("+events")) {
+                    probesWithEventRecording.add(probeName);
+                }
+                if (probeOptions.contains("+special")) {
+                    probesWithSpecialRecording.add(probeName);
+                }
+            } else {
+                recordedProbes.add(probeSpec);
+            }
+        }
+        this.recordedProbes = Collections.unmodifiableList(recordedProbes);
+        this.probesWithEventRecording = Collections.unmodifiableSet(probesWithEventRecording);
+        this.probesWithSpecialRecording = Collections.unmodifiableSet(probesWithSpecialRecording);
+    }
+
+    public String getHomeDir() {
+        return homeDir;
+    }
+
+    public String getConfig() {
+        return config;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public boolean isRecordAlloc() {
+        return recordAlloc;
+    }
+
+    public boolean isRecordMonitors() {
+        return recordMonitors;
+    }
+
+    public List<String> getRecordedProbes() {
+        return recordedProbes;
+    }
+
+    public Set<String> getProbesWithEventRecording() {
+        return probesWithEventRecording;
+    }
+
+    public Set<String> getProbesWithSpecialRecording() {
+        return probesWithSpecialRecording;
+    }
+
+    public boolean isHeapDump() {
+        return heapDump;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public void setPort(int port) {
+        this.port = port;
+    }
+}

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerController.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerController.java
@@ -1,0 +1,124 @@
+package org.gradle.profiler.jprofiler;
+
+import org.gradle.profiler.ProfilerController;
+import org.gradle.profiler.ScenarioSettings;
+
+import javax.management.*;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.remote.JMXServiceURL;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+
+public class JProfilerController implements ProfilerController {
+
+    private MBeanServerConnection connection;
+    private JMXConnector connector;
+    private ObjectName objectName;
+    private ScenarioSettings settings;
+
+    public JProfilerController(ScenarioSettings settings) {
+        this.settings = settings;
+    }
+
+    @Override
+    public void start() throws IOException, InterruptedException {
+        JProfilerConfig config = getJProfilerConfig();
+        invoke("startCPURecording", true);
+        if (config.isRecordAlloc()) {
+            invoke("startAllocRecording", true);
+        }
+        if (config.isRecordMonitors()) {
+            invoke("startMonitorRecording");
+        }
+        for (String probeName : config.getRecordedProbes()) {
+            boolean eventRecording = config.getProbesWithEventRecording().contains(probeName);
+            boolean specialRecording = config.getProbesWithSpecialRecording().contains(probeName);
+            invoke("startProbeRecording", probeName, eventRecording, specialRecording);
+        }
+    }
+
+    @Override
+    public void stop() throws IOException, InterruptedException {
+        JProfilerConfig config = getJProfilerConfig();
+        invoke("stopCPURecording");
+        if (config.isRecordAlloc()) {
+            invoke("stopAllocRecording");
+        }
+        if (config.isRecordMonitors()) {
+            invoke("stopMonitorRecording");
+        }
+        for (String probeName : config.getRecordedProbes()) {
+            invoke("stopProbeRecording", probeName);
+        }
+        if (config.isHeapDump()) {
+            invoke("triggerHeapDump");
+        }
+        invoke("saveSnapshot", getSnapshotPath());
+        closeConnection();
+    }
+
+    private String getSnapshotPath() {
+        File outputDir = settings.getScenarioOutputDir();
+        String snapshotName = settings.getScenario().getName();
+
+        int i = 0;
+        File snapshotFile;
+        do {
+            snapshotFile = new File(outputDir, snapshotName  + ( i == 0 ? "" : ("_" + i)) + ".jps");
+            ++i;
+        } while (snapshotFile.exists());
+        return snapshotFile.getAbsolutePath();
+    }
+
+    private void ensureConnected() throws IOException, MalformedObjectNameException {
+        if (connector == null) {
+            JMXServiceURL jmxUrl = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://localhost:" + getJProfilerConfig().getPort() + "/jmxrmi");
+            connector = JMXConnectorFactory.newJMXConnector(jmxUrl, Collections.emptyMap());
+            connector.connect();
+            connection = connector.getMBeanServerConnection();
+            objectName = new ObjectName("com.jprofiler.api.agent.mbean:type=RemoteController");
+            if (!connection.isRegistered(objectName)) {
+                throw new RuntimeException("JProfiler MBean not found");
+            }
+        }
+    }
+
+    private void closeConnection() throws IOException {
+        try {
+            connector.close();
+        } finally {
+            connector = null;
+        }
+    }
+
+    private void invoke(String operationName, Object... parameterValues) throws IOException {
+        String[] parameterTypes = Arrays.stream(parameterValues)
+                .map(Object::getClass)
+                .map(this::replaceWrapperWithPrimitive)
+                .map(Class::getName)
+                .toArray(String[]::new);
+        try {
+            ensureConnected();
+            connection.invoke(objectName, operationName, parameterValues, parameterTypes);
+        } catch (InstanceNotFoundException | MBeanException | ReflectionException | MalformedObjectNameException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Class replaceWrapperWithPrimitive(Class c) {
+        if (c == Boolean.class) {
+            return Boolean.TYPE;
+        } else if (c == Integer.class) {
+            return Integer.TYPE;
+        } else {
+            return c;
+        }
+    }
+
+    private JProfilerConfig getJProfilerConfig() {
+        return (JProfilerConfig)settings.getInvocationSettings().getProfilerOptions();
+    }
+}

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerJvmArgsCalculator.java
@@ -1,0 +1,129 @@
+package org.gradle.profiler.jprofiler;
+
+import org.gradle.profiler.JvmArgsCalculator;
+import org.gradle.profiler.OperatingSystem;
+import org.gradle.profiler.ScenarioSettings;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.*;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class JProfilerJvmArgsCalculator extends JvmArgsCalculator {
+
+    private final ScenarioSettings settings;
+
+    public JProfilerJvmArgsCalculator(ScenarioSettings settings) {
+        this.settings = settings;
+    }
+
+    @Override
+    public void calculateJvmArgs(List<String> jvmArgs) {
+        int port = findUnusedPort();
+        getJProfilerConfig().setPort(port);
+        jvmArgs.add(getAgentPathParameter(port));
+    }
+
+    private String getAgentPathParameter(int port) {
+        File jprofilerDir = getJProfilerDir();
+        if (!jprofilerDir.exists()) {
+            throw new RuntimeException("JProfiler home directory " + jprofilerDir + " does not exist, please specify a different directory with --jprofiler-home");
+        }
+        boolean is64Bit = System.getProperty("sun.arch.data.model", "64").equals("64");
+
+        StringBuilder builder = new StringBuilder();
+        builder.append("-agentpath:").append(jprofilerDir);
+        if (!jprofilerDir.getPath().endsWith(File.separator)) {
+            builder.append(File.separator);
+        }
+        builder.append("bin").append(File.separator);
+        if (OperatingSystem.isWindows()) {
+            builder.append("windows");
+            if (is64Bit) {
+                builder.append("-x64");
+            }
+            builder.append(File.separator);
+            builder.append("jprofilerti.dll");
+        } else if (OperatingSystem.isMacOS()) {
+            builder.append("macos").append(File.separator);
+            builder.append("libjprofilerti.jnilib");
+        } else if (OperatingSystem.isLinuxX86()) {
+            builder.append("linux");
+            if (is64Bit) {
+                builder.append("-x64");
+            } else {
+                builder.append("-x86");
+            }
+            builder.append(File.separator);
+            builder.append("libjprofilerti.so");
+        } else {
+            throw new RuntimeException("Currently only Windows, macOS and Linux-x86 are detected for the native JProfiler agent library");
+        }
+
+        builder.append("=offline,");
+        String sessionId = getJProfilerConfig().getSessionId();
+        if (sessionId != null) {
+            builder.append("id=").append(sessionId);
+        } else {
+            builder.append("id=1,config=").append(getConfigFile());
+        }
+        builder.append(",sysprop=jprofiler.jmxServerPort=").append(port);
+        return builder.toString();
+    }
+
+    private File getJProfilerDir() {
+        JProfilerConfig profilerOptions = getJProfilerConfig();
+        String homeDir = profilerOptions.getHomeDir();
+        if (OperatingSystem.isMacOS() && !new File(homeDir, "bin").exists()) {
+            return new File(homeDir, "Contents/Resources/app");
+        } else {
+            return new File(homeDir);
+        }
+    }
+
+    private JProfilerConfig getJProfilerConfig() {
+        return (JProfilerConfig)settings.getInvocationSettings().getProfilerOptions();
+    }
+
+    private File getConfigFile() {
+        try {
+            String config = getJProfilerConfig().getConfig();
+            String resourceName = "/jprofiler/config/" + config + ".xml";
+            URL resource = getClass().getResource(resourceName);
+            if (resource == null) {
+                throw new RuntimeException("Classpath resource \"" + resourceName + "\" not found");
+            } else {
+                return Paths.get(resource.toURI()).toFile();
+            }
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static int findUnusedPort() {
+        ServerSocket ss = null;
+        try {
+            if (OperatingSystem.isWindows() || OperatingSystem.isMacOS()) {
+                ss = new ServerSocket();
+                SocketAddress sa = new InetSocketAddress("127.0.0.1", 0);
+                ss.bind(sa);
+                ss.setReuseAddress(true);
+                return ss.getLocalPort();
+            } else {
+                ss = new ServerSocket(0);
+                ss.setReuseAddress(true);
+                return ss.getLocalPort();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Cannot find an unused port", e);
+        } finally {
+            if (ss != null) {
+                try {
+                    ss.close();
+                } catch (IOException ioe) {
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/gradle/profiler/yjp/YourKitJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/yjp/YourKitJvmArgsCalculator.java
@@ -1,7 +1,7 @@
 package org.gradle.profiler.yjp;
 
-import org.gradle.profiler.InvocationSettings;
 import org.gradle.profiler.JvmArgsCalculator;
+import org.gradle.profiler.OperatingSystem;
 import org.gradle.profiler.ScenarioSettings;
 
 import java.io.File;
@@ -16,7 +16,7 @@ public class YourKitJvmArgsCalculator extends JvmArgsCalculator {
 
     @Override
     public void calculateJvmArgs(List<String> jvmArgs) {
-        if (!System.getProperty("os.name").toLowerCase().contains("os x")) {
+        if (!OperatingSystem.isMacOS()) {
             throw new IllegalArgumentException("YourKit is currently supported on OS X only.");
         }
         File yourKitHome = YourKit.findYourKitHome();

--- a/src/main/resources/jprofiler/config/instrumentation.xml
+++ b/src/main/resources/jprofiler/config/instrumentation.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config version="9.2">
+  <sessions>
+    <session id="1" name="Gradle Instrumentation" instrumentationType="1">
+      <filters>
+        <filter type="inclusive" name="org.gradle."/>
+      </filters>
+      <triggers/>
+      <probes/>
+    </session>
+  </sessions>
+</config>

--- a/src/main/resources/jprofiler/config/sampling.xml
+++ b/src/main/resources/jprofiler/config/sampling.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config version="9.2">
+  <sessions>
+    <session id="1" name="Gradle Sampling" instrumentationType="3">
+      <filters>
+        <filter type="inclusive" name="org.gradle."/>
+      </filters>
+      <triggers/>
+      <probes/>
+    </session>
+  </sessions>
+</config>


### PR DESCRIPTION
Requires the as of yet unreleased JProfiler version 9.2.2 because the gradle daemon limits VM parameters on the command line so that the JMX server port could not be set.

 To try it out, the current build can be downloaded at

 http://download.ej-technologies.com/jprofiler/jprofiler_macos_9_2_2.dmg