### PR TITLE
JProfiler support

### DIFF
--- a/src/main/java/org/gradle/profiler/Profiler.java
+++ b/src/main/java/org/gradle/profiler/Profiler.java
@@ -203,6 +203,7 @@ public class Profiler {
         private ArgumentAcceptingOptionSpec<String> homeDir;
         private ArgumentAcceptingOptionSpec<String> configOption;
         private ArgumentAcceptingOptionSpec<String> sessionIdOption;
+        private ArgumentAcceptingOptionSpec<String> configFileOption;
         private OptionSpecBuilder allocOption;
         private OptionSpecBuilder monitorsOption;
         private OptionSpecBuilder heapDumpOption;
@@ -222,10 +223,12 @@ public class Profiler {
         void addOptions(OptionParser parser) {
             homeDir = parser.accepts("jprofiler-home", "JProfiler installation directory").availableIf("profile")
                     .withOptionalArg().ofType(String.class).defaultsTo(JProfiler.getDefaultHomeDir());
-            configOption = parser.accepts("jprofiler-config", "JProfiler built-in configuration name (sampling|instrumentation)")
+            configOption = parser.accepts("jprofiler-config", "JProfiler built-in configuration name (sampling|sampling-all|instrumentation)")
                     .availableIf("profile").withOptionalArg().ofType(String.class).defaultsTo("sampling");
             sessionIdOption = parser.accepts("jprofiler-session-id", "Use session with this id from the JProfiler installation instead of using the built-in config")
-                    .availableUnless("jprofiler-config").withOptionalArg().ofType(String.class);
+                    .availableUnless("jprofiler-config").withRequiredArg().ofType(String.class);
+            configFileOption = parser.accepts("jprofiler-config-file", "Use another config file for --jprofiler-session-id instead of the global config file")
+                    .availableIf("jprofiler-session-id").withRequiredArg().ofType(String.class);
             allocOption = parser.accepts("jprofiler-alloc", "Record allocations")
                     .availableIf("profile");
             monitorsOption = parser.accepts("jprofiler-monitors", "Record monitor usage")
@@ -242,6 +245,7 @@ public class Profiler {
                     parsedOptions.valueOf(homeDir),
                     parsedOptions.valueOf(configOption),
                     parsedOptions.valueOf(sessionIdOption),
+                    parsedOptions.valueOf(configFileOption),
                     parsedOptions.has(allocOption),
                     parsedOptions.has(monitorsOption),
                     parsedOptions.has(heapDumpOption),

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerConfig.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerConfig.java
@@ -7,6 +7,7 @@ public class JProfilerConfig {
     private final String homeDir;
     private final String config;
     private final String sessionId;
+    private String configFile;
     private final boolean recordAlloc;
     private final boolean recordMonitors;
     private final List<String> recordedProbes;
@@ -16,9 +17,10 @@ public class JProfilerConfig {
 
     private int port;
 
-    public JProfilerConfig(String homeDir, String config, String sessionId, boolean recordAlloc, boolean recordMonitors, boolean heapDump, List<String> recordedProbeSpecs) {
+    public JProfilerConfig(String homeDir, String config, String sessionId, String configFile, boolean recordAlloc, boolean recordMonitors, boolean heapDump, List<String> recordedProbeSpecs) {
         this.homeDir = homeDir;
         this.sessionId = sessionId;
+        this.configFile = configFile;
         this.recordAlloc = recordAlloc;
         this.config = config;
         this.recordMonitors = recordMonitors;
@@ -58,6 +60,10 @@ public class JProfilerConfig {
 
     public String getSessionId() {
         return sessionId;
+    }
+
+    public String getConfigFile() {
+        return configFile;
     }
 
     public boolean isRecordAlloc() {

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerController.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerController.java
@@ -38,6 +38,9 @@ public class JProfilerController implements ProfilerController {
             boolean specialRecording = config.getProbesWithSpecialRecording().contains(probeName);
             invoke("startProbeRecording", probeName, eventRecording, specialRecording);
         }
+        if (config.isHeapDump() && hasOperation("markHeap")) { // available in JProfiler 10
+            invoke("markHeap");
+        }
     }
 
     @Override
@@ -115,6 +118,16 @@ public class JProfilerController implements ProfilerController {
             return Integer.TYPE;
         } else {
             return c;
+        }
+    }
+
+    private boolean hasOperation(String operationName) throws IOException {
+        try {
+            ensureConnected();
+            return Arrays.stream(connection.getMBeanInfo(objectName).getOperations())
+                    .anyMatch(operationInfo -> operationInfo.getName().equals(operationName));
+        } catch (InstanceNotFoundException | ReflectionException | MalformedObjectNameException | IntrospectionException e) {
+            throw new RuntimeException(e);
         }
     }
 

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerJvmArgsCalculator.java
@@ -71,6 +71,10 @@ public class JProfilerJvmArgsCalculator extends JvmArgsCalculator {
         String sessionId = getJProfilerConfig().getSessionId();
         if (sessionId != null) {
             builder.append("id=").append(sessionId);
+            String configFile = getJProfilerConfig().getConfigFile();
+            if (configFile != null) {
+                builder.append(",config=").append(configFile);
+            }
         } else {
             builder.append("id=1,config=").append(getConfigFile());
         }

--- a/src/main/resources/jprofiler/config/instrumentation.xml
+++ b/src/main/resources/jprofiler/config/instrumentation.xml
@@ -3,7 +3,8 @@
   <sessions>
     <session id="1" name="Gradle Instrumentation" instrumentationType="1">
       <filters>
-        <filter type="inclusive" name="org.gradle."/>
+        <filter type="inclusive" name="*gradle*"/>
+        <filter type="inclusive" name="com.android."/>
       </filters>
       <triggers/>
       <probes/>

--- a/src/main/resources/jprofiler/config/sampling-all.xml
+++ b/src/main/resources/jprofiler/config/sampling-all.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<config version="9.2">
+  <sessions>
+    <session id="1" name="Gradle Sampling No Filters" instrumentationType="3" samplingNoFilters="true">
+      <filters/>
+      <triggers/>
+      <probes/>
+    </session>
+  </sessions>
+</config>

--- a/src/main/resources/jprofiler/config/sampling.xml
+++ b/src/main/resources/jprofiler/config/sampling.xml
@@ -3,7 +3,8 @@
   <sessions>
     <session id="1" name="Gradle Sampling" instrumentationType="3">
       <filters>
-        <filter type="inclusive" name="org.gradle."/>
+        <filter type="inclusive" name="*gradle*"/>
+        <filter type="inclusive" name="com.android."/>
       </filters>
       <triggers/>
       <probes/>


### PR DESCRIPTION
* Mark the heap before the build starts (available in JProfiler 10), so the heap dump can show new objects without the need for allocation recording
* Profile all packages that contain "gradle", profile "com.android.**"
* Added a new built-in config "sampling-all" without any call tree filters
* Added option --jprofiler-config-file for using an exported config file
