### PR TITLE
No-daemon mode for JProfiler without MBean-polling

### DIFF
--- a/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
@@ -36,4 +36,9 @@ public class JProfiler {
         } while (snapshotFile.exists());
         return snapshotFile.getAbsolutePath();
     }
+
+    public static File deleteOnExit(File tmpFile) {
+        tmpFile.deleteOnExit();
+        return tmpFile;
+    }
 }

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
@@ -8,7 +8,7 @@ import java.io.File;
 
 public class JProfiler {
 
-    private static final String MAJOR_VERSION = "9";
+    private static final String MAJOR_VERSION = "10";
 
     public static String getDefaultHomeDir() {
         if (OperatingSystem.isWindows()) {

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
@@ -1,6 +1,10 @@
 package org.gradle.profiler.jprofiler;
 
+import org.gradle.profiler.Invoker;
 import org.gradle.profiler.OperatingSystem;
+import org.gradle.profiler.ScenarioSettings;
+
+import java.io.File;
 
 public class JProfiler {
 
@@ -16,4 +20,20 @@ public class JProfiler {
         }
     }
 
+    public static boolean profileWholeLifeTime(ScenarioSettings settings) {
+        return settings.getInvocationSettings().getInvoker().equals(Invoker.NoDaemon);
+    }
+
+    public static String getSnapshotPath(ScenarioSettings settings) {
+        File outputDir = settings.getScenario().getOutputDir();
+        String snapshotName = settings.getScenario().getProfileName();
+
+        int i = 0;
+        File snapshotFile;
+        do {
+            snapshotFile = new File(outputDir, snapshotName  + ( i == 0 ? "" : ("_" + i)) + ".jps");
+            ++i;
+        } while (snapshotFile.exists());
+        return snapshotFile.getAbsolutePath();
+    }
 }

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
@@ -36,9 +36,4 @@ public class JProfiler {
         } while (snapshotFile.exists());
         return snapshotFile.getAbsolutePath();
     }
-
-    public static File deleteOnExit(File tmpFile) {
-        tmpFile.deleteOnExit();
-        return tmpFile;
-    }
 }

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerConfigFileTransformer.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerConfigFileTransformer.java
@@ -1,0 +1,64 @@
+package org.gradle.profiler.jprofiler;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.*;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+
+public class JProfilerConfigFileTransformer {
+
+    public static File transform(File configFile, String id, JProfilerConfig jProfilerConfig, String snapshotPath) {
+        try {
+            File transformedConfigFile = JProfiler.deleteOnExit(File.createTempFile("jprofiler", ".xml"));
+            File probesFile = createProbesDocument(jProfilerConfig);
+            URL resource = JProfilerConfigFileTransformer.class.getResource("/jprofiler/transform.xsl");
+            Templates template = TransformerFactory.newInstance().newTemplates(new StreamSource(resource.openStream()));
+            Source source = new StreamSource(new FileInputStream(configFile));
+            Result result = new StreamResult(new FileOutputStream(transformedConfigFile));
+            Transformer transformer = template.newTransformer();
+            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+            transformer.setParameter("id", id);
+            transformer.setParameter("allocRecording", jProfilerConfig.isRecordAlloc());
+            transformer.setParameter("monitorRecording", jProfilerConfig.isRecordMonitors());
+            transformer.setParameter("probesFile", probesFile.getPath());
+            transformer.setParameter("snapshotPath", snapshotPath);
+            transformer.transform(source, result);
+            if (Boolean.getBoolean("jprofiler.debugTransform")) {
+                Files.readAllLines(transformedConfigFile.toPath()).forEach(System.out::println);
+            }
+            return transformedConfigFile;
+        } catch (TransformerException | IOException | ParserConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static File createProbesDocument(JProfilerConfig jProfilerConfig) throws ParserConfigurationException, TransformerException, IOException {
+        File probesFile = JProfiler.deleteOnExit(File.createTempFile("jprofiler", ".xml"));
+        Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element probesElement = document.createElement("probes");
+        for (String probeName : jProfilerConfig.getRecordedProbes()) {
+            Element probeElement = document.createElement("probe");
+            probeElement.setAttribute("name", probeName);
+            probeElement.setAttribute("events", String.valueOf(jProfilerConfig.getProbesWithEventRecording().contains(probeName)));
+            probeElement.setAttribute("recordSpecial", String.valueOf(jProfilerConfig.getProbesWithSpecialRecording().contains(probeName)));
+            probesElement.appendChild(probeElement);
+        }
+        document.appendChild(probesElement);
+        DOMSource source = new DOMSource(document);
+        StreamResult result = new StreamResult(new FileOutputStream(probesFile));
+        TransformerFactory.newInstance().newTransformer().transform(source, result);
+        return probesFile;
+    }
+
+}

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerConfigFileTransformer.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerConfigFileTransformer.java
@@ -20,7 +20,8 @@ public class JProfilerConfigFileTransformer {
 
     public static File transform(File configFile, String id, JProfilerConfig jProfilerConfig, String snapshotPath) {
         try {
-            File transformedConfigFile = JProfiler.deleteOnExit(File.createTempFile("jprofiler", ".xml"));
+            File transformedConfigFile = File.createTempFile("jprofiler", ".xml");
+            transformedConfigFile.deleteOnExit();
             File probesFile = createProbesDocument(jProfilerConfig);
             URL resource = JProfilerConfigFileTransformer.class.getResource("/jprofiler/transform.xsl");
             Templates template = TransformerFactory.newInstance().newTemplates(new StreamSource(resource.openStream()));
@@ -44,7 +45,8 @@ public class JProfilerConfigFileTransformer {
     }
 
     private static File createProbesDocument(JProfilerConfig jProfilerConfig) throws ParserConfigurationException, TransformerException, IOException {
-        File probesFile = JProfiler.deleteOnExit(File.createTempFile("jprofiler", ".xml"));
+        File probesFile = File.createTempFile("jprofiler", ".xml");
+        probesFile.deleteOnExit();
         Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
         Element probesElement = document.createElement("probes");
         for (String probeName : jProfilerConfig.getRecordedProbes()) {

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerController.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerController.java
@@ -28,25 +28,26 @@ public class JProfilerController implements ProfilerController {
 
     @Override
     public void start() throws IOException, InterruptedException {
-        if (!profileWholeLifeTime()) {
-            invoke("startCPURecording", true);
-            if (jProfilerConfig.isRecordAlloc()) {
-                invoke("startAllocRecording", true);
-            }
-            if (jProfilerConfig.isRecordMonitors()) {
-                invoke("startMonitorRecording");
-            }
-            for (String probeName : jProfilerConfig.getRecordedProbes()) {
-                boolean eventRecording = jProfilerConfig.getProbesWithEventRecording().contains(probeName);
-                boolean specialRecording = jProfilerConfig.getProbesWithSpecialRecording().contains(probeName);
-                invoke("startProbeRecording", probeName, eventRecording, specialRecording);
-            }
-            if (jProfilerConfig.isHeapDump() && hasOperation("markHeap")) { // available in JProfiler 10
-                invoke("markHeap");
-            }
-            if (profileWholeLifeTime()) {
-                invoke("saveSnapshotOnExit", getSnapshotPath());
-            }
+        if (profileWholeLifeTime()) {
+            return;
+        }
+        invoke("startCPURecording", true);
+        if (jProfilerConfig.isRecordAlloc()) {
+            invoke("startAllocRecording", true);
+        }
+        if (jProfilerConfig.isRecordMonitors()) {
+            invoke("startMonitorRecording");
+        }
+        for (String probeName : jProfilerConfig.getRecordedProbes()) {
+            boolean eventRecording = jProfilerConfig.getProbesWithEventRecording().contains(probeName);
+            boolean specialRecording = jProfilerConfig.getProbesWithSpecialRecording().contains(probeName);
+            invoke("startProbeRecording", probeName, eventRecording, specialRecording);
+        }
+        if (jProfilerConfig.isHeapDump() && hasOperation("markHeap")) { // available in JProfiler 10
+            invoke("markHeap");
+        }
+        if (profileWholeLifeTime()) {
+            invoke("saveSnapshotOnExit", getSnapshotPath());
         }
     }
 

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerController.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerController.java
@@ -46,9 +46,6 @@ public class JProfilerController implements ProfilerController {
         if (jProfilerConfig.isHeapDump() && hasOperation("markHeap")) { // available in JProfiler 10
             invoke("markHeap");
         }
-        if (profileWholeLifeTime()) {
-            invoke("saveSnapshotOnExit", getSnapshotPath());
-        }
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerController.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerController.java
@@ -1,6 +1,5 @@
 package org.gradle.profiler.jprofiler;
 
-import org.gradle.profiler.Invoker;
 import org.gradle.profiler.Logging;
 import org.gradle.profiler.ProfilerController;
 import org.gradle.profiler.ScenarioSettings;
@@ -9,15 +8,11 @@ import javax.management.*;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
-import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.logging.Logger;
 
 public class JProfilerController implements ProfilerController {
-
-    public static final int CONNECT_TIMEOUT = 5000;
 
     private final JProfilerConfig jProfilerConfig;
     private final ScenarioSettings settings;
@@ -33,60 +28,25 @@ public class JProfilerController implements ProfilerController {
 
     @Override
     public void start() throws IOException, InterruptedException {
-        if (profileWholeLifeTime()) {
-            startOnceGradleStarts();
-        } else {
-            startNow();
-        }
-    }
-
-    private void startOnceGradleStarts() {
-        Thread thread = new Thread(this::tryStartNow);
-        thread.setName("JProfiler connector");
-        thread.start();
-    }
-
-    private void tryStartNow() {
-        long start = System.currentTimeMillis();
-        Exception lastProblem = null;
-        boolean started = false;
-
-        while (!started && System.currentTimeMillis() - start < CONNECT_TIMEOUT) {
-            try {
-                startNow();
-                started = true;
-            } catch (Exception e) {
-                lastProblem = e;
-                try {
-                    Thread.sleep(10);
-                } catch (InterruptedException interrupt) {
-                    throw new RuntimeException(interrupt);
-                }
+        if (!profileWholeLifeTime()) {
+            invoke("startCPURecording", true);
+            if (jProfilerConfig.isRecordAlloc()) {
+                invoke("startAllocRecording", true);
             }
-        }
-        if (!started) {
-            throw new IllegalStateException("Failed to connect to build VM after " + CONNECT_TIMEOUT + "ms", lastProblem);
-        }
-    }
-
-    private void startNow() throws IOException {
-        invoke("startCPURecording", true);
-        if (jProfilerConfig.isRecordAlloc()) {
-            invoke("startAllocRecording", true);
-        }
-        if (jProfilerConfig.isRecordMonitors()) {
-            invoke("startMonitorRecording");
-        }
-        for (String probeName : jProfilerConfig.getRecordedProbes()) {
-            boolean eventRecording = jProfilerConfig.getProbesWithEventRecording().contains(probeName);
-            boolean specialRecording = jProfilerConfig.getProbesWithSpecialRecording().contains(probeName);
-            invoke("startProbeRecording", probeName, eventRecording, specialRecording);
-        }
-        if (jProfilerConfig.isHeapDump() && hasOperation("markHeap")) { // available in JProfiler 10
-            invoke("markHeap");
-        }
-        if (profileWholeLifeTime()) {
-            invoke("saveSnapshotOnExit", getSnapshotPath());
+            if (jProfilerConfig.isRecordMonitors()) {
+                invoke("startMonitorRecording");
+            }
+            for (String probeName : jProfilerConfig.getRecordedProbes()) {
+                boolean eventRecording = jProfilerConfig.getProbesWithEventRecording().contains(probeName);
+                boolean specialRecording = jProfilerConfig.getProbesWithSpecialRecording().contains(probeName);
+                invoke("startProbeRecording", probeName, eventRecording, specialRecording);
+            }
+            if (jProfilerConfig.isHeapDump() && hasOperation("markHeap")) { // available in JProfiler 10
+                invoke("markHeap");
+            }
+            if (profileWholeLifeTime()) {
+                invoke("saveSnapshotOnExit", getSnapshotPath());
+            }
         }
     }
 
@@ -112,16 +72,7 @@ public class JProfilerController implements ProfilerController {
     }
 
     private String getSnapshotPath() {
-        File outputDir = settings.getScenario().getOutputDir();
-        String snapshotName = settings.getScenario().getProfileName();
-
-        int i = 0;
-        File snapshotFile;
-        do {
-            snapshotFile = new File(outputDir, snapshotName  + ( i == 0 ? "" : ("_" + i)) + ".jps");
-            ++i;
-        } while (snapshotFile.exists());
-        return snapshotFile.getAbsolutePath();
+        return JProfiler.getSnapshotPath(settings);
     }
 
     private void ensureConnected() throws IOException, MalformedObjectNameException {
@@ -139,12 +90,14 @@ public class JProfilerController implements ProfilerController {
     }
 
     private void closeConnection() {
-        try {
-            connector.close();
-        } catch (IOException e) {
-            Logging.detailed().println("Could not close connection to profiled VM. This is normal when running in no-daemon mode");
-        } finally {
-            connector = null;
+        if (connector != null) {
+            try {
+                connector.close();
+            } catch (IOException e) {
+                Logging.detailed().println("Could not close connection to profiled VM.");
+            } finally {
+                connector = null;
+            }
         }
     }
 
@@ -183,6 +136,6 @@ public class JProfilerController implements ProfilerController {
     }
 
     private boolean profileWholeLifeTime() {
-        return settings.getInvocationSettings().getInvoker().equals(Invoker.NoDaemon);
+        return JProfiler.profileWholeLifeTime(settings);
     }
 }

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerJvmArgsCalculator.java
@@ -116,11 +116,13 @@ public class JProfilerJvmArgsCalculator extends JvmArgsCalculator {
             if (resource == null) {
                 throw new RuntimeException("Classpath resource \"" + resourceName + "\" not found");
             } else {
-                Path tmpFile = Files.createTempFile("jprofiler", ".xml");
+                Path tmpPath = Files.createTempFile("jprofiler", ".xml");
                 try (InputStream inputStream = resource.openStream()) {
-                    Files.copy(inputStream, tmpFile, StandardCopyOption.REPLACE_EXISTING);
+                    Files.copy(inputStream, tmpPath, StandardCopyOption.REPLACE_EXISTING);
                 }
-                return JProfiler.deleteOnExit(tmpFile.toFile());
+                File tmpFile = tmpPath.toFile();
+                tmpFile.deleteOnExit();
+                return tmpFile;
             }
         } catch (IOException e) {
             throw new RuntimeException("Could not create JProfiler config file.", e);

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerJvmArgsCalculator.java
@@ -2,10 +2,17 @@ package org.gradle.profiler.jprofiler;
 
 import org.gradle.profiler.JvmArgsCalculator;
 import org.gradle.profiler.OperatingSystem;
+import org.gradle.profiler.ScenarioSettings;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.*;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
+import java.io.*;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.SocketAddress;
@@ -17,9 +24,11 @@ import java.util.List;
 
 public class JProfilerJvmArgsCalculator extends JvmArgsCalculator {
     private final JProfilerConfig jProfilerConfig;
+    private ScenarioSettings settings;
 
-    public JProfilerJvmArgsCalculator(JProfilerConfig jProfilerConfig) {
+    public JProfilerJvmArgsCalculator(JProfilerConfig jProfilerConfig, ScenarioSettings settings) {
         this.jProfilerConfig = jProfilerConfig;
+        this.settings = settings;
     }
 
     @Override
@@ -67,17 +76,73 @@ public class JProfilerJvmArgsCalculator extends JvmArgsCalculator {
 
         builder.append("=offline,");
         String sessionId = jProfilerConfig.getSessionId();
+        File configFile;
+        String id;
         if (sessionId != null) {
-            builder.append("id=").append(sessionId);
-            String configFile = jProfilerConfig.getConfigFile();
-            if (configFile != null) {
-                builder.append(",config=").append(configFile);
+            if (jProfilerConfig.getConfigFile() != null) {
+                configFile = new File(jProfilerConfig.getConfigFile());
+                id = sessionId;
+            } else {
+                configFile = null;
+                id = null;
             }
         } else {
-            builder.append("id=1,config=").append(getConfigFile());
+            configFile = getConfigFile();
+            id = "1";
         }
+        if (configFile != null) {
+            builder.append("id=").append(id).append(",config=").append(transformConfigFile(configFile, id));
+        }
+
         builder.append(",sysprop=jprofiler.jmxServerPort=").append(port);
         return builder.toString();
+    }
+
+    private File transformConfigFile(File configFile, String id) {
+        if (profileWholeLifeTime()) {
+            try {
+                File transformedConfigFile = deleteOnExit(File.createTempFile("jprofiler", ".xml"));
+                File probesFile = createProbesDocument();
+                URL resource = getClass().getResource("/jprofiler/transform.xsl");
+                Templates template = TransformerFactory.newInstance().newTemplates(new StreamSource(resource.openStream()));
+                Source source = new StreamSource(new FileInputStream(configFile));
+                Result result = new StreamResult(new FileOutputStream(transformedConfigFile));
+                Transformer transformer = template.newTransformer();
+                transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+                transformer.setParameter("id", id);
+                transformer.setParameter("allocRecording", jProfilerConfig.isRecordAlloc());
+                transformer.setParameter("monitorRecording", jProfilerConfig.isRecordMonitors());
+                transformer.setParameter("probesFile", probesFile.getPath());
+                transformer.setParameter("snapshotPath", getSnapshotPath());
+                transformer.transform(source, result);
+                if (Boolean.getBoolean("jprofiler.debugTransform")) {
+                    Files.readAllLines(transformedConfigFile.toPath()).forEach(System.out::println);
+                }
+                return transformedConfigFile;
+            } catch (TransformerException | IOException | ParserConfigurationException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            return configFile;
+        }
+    }
+
+    private File createProbesDocument() throws ParserConfigurationException, TransformerException, IOException {
+        File probesFile = deleteOnExit(File.createTempFile("jprofiler", ".xml"));
+        Document document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+        Element probesElement = document.createElement("probes");
+        for (String probeName : jProfilerConfig.getRecordedProbes()) {
+            Element probeElement = document.createElement("probe");
+            probeElement.setAttribute("name", probeName);
+            probeElement.setAttribute("events", String.valueOf(jProfilerConfig.getProbesWithEventRecording().contains(probeName)));
+            probeElement.setAttribute("recordSpecial", String.valueOf(jProfilerConfig.getProbesWithSpecialRecording().contains(probeName)));
+            probesElement.appendChild(probeElement);
+        }
+        document.appendChild(probesElement);
+        DOMSource source = new DOMSource(document);
+        StreamResult result = new StreamResult(new FileOutputStream(probesFile));
+        TransformerFactory.newInstance().newTransformer().transform(source, result);
+        return probesFile;
     }
 
     private File getJProfilerDir() {
@@ -100,11 +165,16 @@ public class JProfilerJvmArgsCalculator extends JvmArgsCalculator {
                 try (InputStream inputStream = resource.openStream()) {
                     Files.copy(inputStream, tmpFile, StandardCopyOption.REPLACE_EXISTING);
                 }
-                return tmpFile.toFile();
+                return deleteOnExit(tmpFile.toFile());
             }
         } catch (IOException e) {
             throw new RuntimeException("Could not create JProfiler config file.", e);
         }
+    }
+
+    private File deleteOnExit(File tmpFile) {
+        tmpFile.deleteOnExit();
+        return tmpFile;
     }
 
     private static int findUnusedPort() {
@@ -132,4 +202,13 @@ public class JProfilerJvmArgsCalculator extends JvmArgsCalculator {
             }
         }
     }
+
+    private boolean profileWholeLifeTime() {
+        return JProfiler.profileWholeLifeTime(settings);
+    }
+
+    private String getSnapshotPath() {
+        return JProfiler.getSnapshotPath(settings);
+    }
+
 }

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerProfiler.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerProfiler.java
@@ -52,7 +52,7 @@ public class JProfilerProfiler extends Profiler {
 
     @Override
     public JvmArgsCalculator newJvmArgsCalculator(ScenarioSettings settings) {
-        return new JProfilerJvmArgsCalculator(jProfilerConfig);
+        return new JProfilerJvmArgsCalculator(jProfilerConfig, settings);
     }
 
     @Override

--- a/src/main/resources/jprofiler/transform.xsl
+++ b/src/main/resources/jprofiler/transform.xsl
@@ -1,0 +1,44 @@
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+  <xsl:param name="id"/>
+  <xsl:param name="allocRecording"/>
+  <xsl:param name="monitorRecording"/>
+  <xsl:param name="probesFile"/>
+  <xsl:param name="snapshotPath"/>
+
+  <xsl:template match="/|@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="/config/sessions/session[@id=$id]/triggers">
+    <xsl:copy>
+      <jvmStart enabled="true">
+        <actions>
+          <startRecording>
+            <cpu enabled="true" resetData="true"/>
+            <allocation enabled="{$allocRecording}" resetData="true"/>
+            <thread enabled="false"/>
+            <telemetry enabled="false"/>
+            <methodStats enabled="false"/>
+            <complexity enabled="false"/>
+          </startRecording>
+          <xsl:if test="$monitorRecording">
+            <startMonitorRecording blockingThreshold="1000" waitingThreshold="100000"/>
+          </xsl:if>
+          <xsl:for-each select="document($probesFile)//probe">
+            <startProbeRecording name="{@name}" events="{@events}" recordSpecial="{@recordSpecial}"/>
+          </xsl:for-each>
+        </actions>
+      </jvmStart>
+      <jvmStop enabled="true">
+        <actions>
+          <saveSnapshot file="{$snapshotPath}" number="false"/>
+        </actions>
+      </jvmStop>
+      <xsl:apply-templates/>
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/src/test/groovy/org/gradle/profiler/JProfilerConfigFileTransformTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/JProfilerConfigFileTransformTest.groovy
@@ -1,0 +1,40 @@
+package org.gradle.profiler
+
+import org.gradle.profiler.jprofiler.JProfilerConfig
+import org.gradle.profiler.jprofiler.JProfilerConfigFileTransformer
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class JProfilerConfigFileTransformTest extends Specification {
+    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+
+    def "transforms the JProfiler config file"() {
+
+        setup:
+        def sourceFile = tmpDir.newFile("source.xml")
+        sourceFile << getClass().getResourceAsStream('/jprofiler/config/instrumentation.xml')
+        assert sourceFile.text.length() > 0
+
+        when:
+        JProfilerConfig jProfilerConfig = new JProfilerConfig(null, null, null, null, true, true, false, ['builtin.JdbcProbe:+events+special', 'builtin.FileProbe'])
+        def xml = new XmlSlurper().parse(JProfilerConfigFileTransformer.transform(sourceFile, '1', jProfilerConfig, "output/snapshot.jps"))
+        def triggers = xml.sessions.session[0].triggers
+        def startActions = triggers.jvmStart.actions
+        def stopActions = triggers.jvmStop.actions
+
+        then:
+        startActions.startRecording.cpu.@enabled == 'true'
+        startActions.startRecording.allocation.@enabled == 'true'
+        startActions.startMonitorRecording.size() == 1
+        def jdbcProbe = startActions.startProbeRecording.findAll { it.@name == 'builtin.JdbcProbe' }
+        jdbcProbe.size() == 1
+        jdbcProbe.@events == 'true'
+        jdbcProbe.@recordSpecial == 'true'
+        def fileProbe = startActions.startProbeRecording.findAll { it.@name == 'builtin.FileProbe' }
+        fileProbe.size() == 1
+        fileProbe.@events == 'false'
+        fileProbe.@recordSpecial == 'false'
+        stopActions.saveSnapshot.@file == 'output/snapshot.jps'
+    }
+}

--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -400,6 +400,7 @@ apply plugin: BasePlugin
         when:
         new Main().
                 run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", minimalSupportedGradleVersion, "--profile", "jprofiler",
+                        "--jprofiler-monitors", "--jprofiler-probes", "builtin.JdbcProbe:+special,builtin.FileProbe,builtin.ClassLoaderProbe:+events",
                         "--no-daemon", "assemble")
 
         then:


### PR DESCRIPTION
Instead of polling whether the JProfiler MBean has been published,
provide all the profiling commands upfront by adding the appropriate
triggers to the config file with an XSL transform.