### PR TITLE
Resolve placeholders in configuration

### DIFF
--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -70,7 +70,7 @@ class ScenarioLoader {
 
     private List<ScenarioDefinition> loadScenarios(File scenarioFile, InvocationSettings settings, GradleVersionInspector inspector) {
         List<ScenarioDefinition> definitions = new ArrayList<>();
-        Config config = ConfigFactory.parseFile(scenarioFile, ConfigParseOptions.defaults().setAllowMissing(false));
+        Config config = ConfigFactory.parseFile(scenarioFile, ConfigParseOptions.defaults().setAllowMissing(false)).resolve();
         Set<String> selectedScenarios = new TreeSet<>(config.root().keySet());
         if (!settings.getTargets().isEmpty()) {
             for (String target : settings.getTargets()) {


### PR DESCRIPTION
In this way, placeholders can be used in the scenario file.
E.g. one can define
```
defaults {
  run-using = tooling-api
  cleanup-tasks = ["clean"]
}

buildCache = ${defaults} {
  tasks = ["compileJava"]
  gradle-args = ["--build-cache"]
}
```