### PR TITLE
Use sudo to run perf profiler

### DIFF
--- a/src/main/java/org/gradle/profiler/CommandExec.java
+++ b/src/main/java/org/gradle/profiler/CommandExec.java
@@ -18,7 +18,7 @@ public class CommandExec {
         this.directory = null;
     }
 
-    private CommandExec(File directory) {
+    protected CommandExec(File directory) {
         this.directory = directory;
     }
 
@@ -82,7 +82,7 @@ public class CommandExec {
         return run(new ProcessBuilder(commandLine), outputStream, null, null);
     }
 
-    private RunHandle run(ProcessBuilder processBuilder, OutputStream outputStream, @Nullable OutputStream errorStream, @Nullable InputStream inputStream) {
+    protected RunHandle run(ProcessBuilder processBuilder, OutputStream outputStream, @Nullable OutputStream errorStream, @Nullable InputStream inputStream) {
         if (directory != null) {
             processBuilder.directory(directory);
         }

--- a/src/main/java/org/gradle/profiler/SudoCommandExec.java
+++ b/src/main/java/org/gradle/profiler/SudoCommandExec.java
@@ -1,0 +1,51 @@
+package org.gradle.profiler;
+
+import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.regex.Pattern;
+
+public class SudoCommandExec extends CommandExec {
+    private static final List<String> SUDO_PREFIX = Collections.unmodifiableList(Arrays.asList("sudo", "-n")); // -n = --non-interactive, don't prompt for password
+    private static final Pattern PREFIXED_WITH_SUDO = Pattern.compile("^sudo($| .*)");
+    private final boolean useSudo;
+
+    public SudoCommandExec() {
+        this(null);
+    }
+
+    protected SudoCommandExec(File dir) {
+        super(dir);
+        useSudo = shouldUseSudo();
+    }
+
+    @Override
+    public CommandExec inDir(File directory) {
+        return new SudoCommandExec(directory);
+    }
+
+    protected boolean shouldUseSudo() {
+        return !System.getProperty("user.name").equals("root");
+    }
+
+    @Override
+    protected RunHandle run(ProcessBuilder processBuilder, OutputStream outputStream, OutputStream errorStream, InputStream inputStream) {
+        maybeAddSudo(processBuilder);
+        return super.run(processBuilder, outputStream, errorStream, inputStream);
+    }
+
+    void maybeAddSudo(ProcessBuilder processBuilder) {
+        if (useSudo) {
+            List<String> commandLine = new ArrayList<>(processBuilder.command());
+            String firstCommand = commandLine.get(0);
+            if (!PREFIXED_WITH_SUDO.matcher(firstCommand).matches()) {
+                commandLine.addAll(0, SUDO_PREFIX);
+            }
+            processBuilder.command(commandLine);
+        }
+    }
+}

--- a/src/main/resources/org/gradle/profiler/perf/configure_sudo_access.sh
+++ b/src/main/resources/org/gradle/profiler/perf/configure_sudo_access.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+realuser=${1:-$USER}
+gradle_user_home=${2:-$HOME/.gradle-profiler}
+if [ "$realuser" = "root" ]; then
+    echo "usage: $0 [userid] [gradle_user_home]"
+    exit 1
+fi
+
+cat >/tmp/sudoers_perf$$ <<EOF
+Defaults!/usr/bin/perf use_pty
+$realuser ALL=(ALL) NOPASSWD: /usr/bin/perf, /bin/kill, $gradle_user_home/tools/brendangregg/Misc/java/jmaps-updated
+EOF
+
+# verify configuration in temp file
+sudo visudo -c -f /tmp/sudoers_perf$$ || { echo "sudo configuration couldn't be verified."; exit 1; }
+
+# install to /etc/sudoers.d directory
+sudo chmod 0660 /tmp/sudoers_perf$$ \
+ && sudo chown root:root /tmp/sudoers_perf$$ \
+ && sudo mv /tmp/sudoers_perf$$ /etc/sudoers.d/gradle-profiler_$realuser
+
+# verify configuration
+sudo visudo -c -f /etc/sudoers.d/gradle-profiler_$realuser && echo "sudo configuration successful."

--- a/src/test/groovy/org/gradle/profiler/SudoCommandExecTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/SudoCommandExecTest.groovy
@@ -1,0 +1,56 @@
+package org.gradle.profiler
+
+import spock.lang.Specification
+import spock.util.environment.RestoreSystemProperties
+
+@RestoreSystemProperties
+class SudoCommandExecTest extends Specification {
+
+    def "should add sudo when running as non-root"() {
+        given:
+        System.setProperty("user.name", "non-root")
+        SudoCommandExec sudoCommandExec = new SudoCommandExec()
+        ProcessBuilder processBuilder = new ProcessBuilder()
+        processBuilder.command(commandLine)
+
+        when:
+        sudoCommandExec.maybeAddSudo(processBuilder)
+
+        then:
+        processBuilder.command() == (["sudo", "-n"] + commandLine)
+
+        where:
+        commandLine << [["perf", "record"], ["sudoedit"], "visudo"]
+    }
+
+    def "should not add sudo when sudo is already part of the command"() {
+        given:
+        System.setProperty("user.name", "non-root")
+        SudoCommandExec sudoCommandExec = new SudoCommandExec()
+        ProcessBuilder processBuilder = new ProcessBuilder()
+        processBuilder.command(commandLine)
+
+        when:
+        sudoCommandExec.maybeAddSudo(processBuilder)
+
+        then:
+        processBuilder.command() == commandLine
+
+        where:
+        commandLine << [["sudo", "perf", "record"], ["sudo perf record"], ["sudo perf", "record"]]
+    }
+
+    def "should not add sudo when running as root"() {
+        given:
+        System.setProperty("user.name", "root")
+        SudoCommandExec sudoCommandExec = new SudoCommandExec()
+        ProcessBuilder processBuilder = new ProcessBuilder()
+        processBuilder.command("perf", "record")
+
+        when:
+        sudoCommandExec.maybeAddSudo(processBuilder)
+
+        then:
+        processBuilder.command() == ["perf", "record"]
+    }
+}


### PR DESCRIPTION
- slightly improves the amazing effort that @DanielThomas did for integrating [Linux Perf](https://perf.wiki.kernel.org) and all the required tooling to create Flamegraphs from the `perf` profiling results. That required [running `gradle-profiler` (and the builds) as `root`](https://github.com/gradle/gradle-profiler/blob/467626e0cb5a1669fdebb8dd5bffd645eb72cd4f/src/main/java/org/gradle/profiler/perf/PerfProfilerController.java#L106).
- this PR makes it possible to run the build as a normal user.
  - requires certain `sudo` configuration that is documented in the readme file.
  - requires running `gradle-profiler` with the `--gradle-user-home` location that is specified in the `sudo` configuration (`$HOME/.gradle-profiler` in the example configuration)
