### PR TITLE
Add support for benchmarking Bazel builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Add the `--profile chrome-trace` option and open the result in Google Chrome. It
 - `-D<key>=<value>`: Defines a system property when running the build, overriding the default for the build.
 - `--warmups`: Specifies the number of warm-up builds to run for each scenario. Defaults to 2 for profiling, 6 for benchmarking.
 - `--iterations`: Specifies the number of builds to run for each scenario. Defaults to 1 for profiling, 10 for benchmarking.
+- `--bazel`: Benchmark scenarios using Bazel instead of Gradle. By default, only Gradle scenarios are run. You cannot `--profile` a Bazel build using this tool.
 - `--buck`: Benchmark scenarios using Buck instead of Gradle. By default, only Gradle scenarios are run. You cannot `--profile` a Buck build using this tool.
 - `--maven`: Benchmark scenarios using Maven instead of Gradle. By default, only Gradle scenarios are run. You cannot `--profile` a Maven build using this tool.
 
@@ -190,7 +191,7 @@ They can be added to a scenario file like this:
 
 ### Comparing against other build tools
 
-You can compare Gradle against Buck and Maven, by specifying their equivalent invocations in the scenario file. Only benchmarking mode is supported.
+You can compare Gradle against Bazel, Buck, and Maven by specifying their equivalent invocations in the scenario file. Only benchmarking mode is supported.
 
 #### Maven
 
@@ -204,6 +205,18 @@ You can compare Gradle against Buck and Maven, by specifying their equivalent in
         }
     }
 
+#### Bazel
+
+    > gradle-profiler --benchmark --bazel build_some_target
+
+    build_some_target {
+        tasks = ["assemble"]
+
+        bazel {
+            targets = ["//some/target"]
+        }
+    }
+    
 #### Buck
 
     > gradle-profiler --benchmark --buck build_binaries

--- a/src/main/java/org/gradle/profiler/BazelScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/BazelScenarioDefinition.java
@@ -1,0 +1,39 @@
+package org.gradle.profiler;
+
+import java.io.File;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class BazelScenarioDefinition extends ScenarioDefinition {
+    private final List<String> targets;
+
+    public BazelScenarioDefinition(String scenarioName, List<String> targets, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
+        super(scenarioName, buildMutator, warmUpCount, buildCount, outputDir);
+        this.targets = targets;
+    }
+
+    @Override
+    public String getShortDisplayName() {
+        return getName() + " bazel";
+    }
+
+    @Override
+    public String getDisplayName() {
+        return getName() + " using bazel";
+    }
+
+    @Override
+    public String getProfileName() {
+        throw new UnsupportedOperationException();
+    }
+
+    public List<String> getTargets() {
+        return targets;
+    }
+
+    @Override
+    protected void printDetail(PrintStream out) {
+        out.println("  Targets: " + getTargets());
+    }
+}

--- a/src/main/java/org/gradle/profiler/CommandLineParser.java
+++ b/src/main/java/org/gradle/profiler/CommandLineParser.java
@@ -42,6 +42,7 @@ class CommandLineParser {
         OptionSpecBuilder noDaemonOption = parser.accepts("no-daemon", "Do not use the Gradle daemon");
         OptionSpecBuilder cliOption = parser.accepts("cli", "Uses the command-line client to connect to the daemon");
         OptionSpecBuilder dryRunOption = parser.accepts("dry-run", "Verify configuration");
+        OptionSpecBuilder bazelOption = parser.accepts("bazel", "Benchmark scenarios using Bazel");
         OptionSpecBuilder buckOption = parser.accepts("buck", "Benchmark scenarios using buck");
         OptionSpecBuilder mavenOption = parser.accepts("maven", "Benchmark scenarios using Maven");
 
@@ -79,6 +80,9 @@ class CommandLineParser {
         }
         if (parsedOptions.has(noDaemonOption)) {
             invoker = Invoker.NoDaemon;
+        }
+        if (parsedOptions.has(bazelOption)) {
+            invoker = Invoker.Bazel;
         }
         if (parsedOptions.has(buckOption)) {
             invoker = Invoker.Buck;

--- a/src/main/java/org/gradle/profiler/InvocationSettings.java
+++ b/src/main/java/org/gradle/profiler/InvocationSettings.java
@@ -58,6 +58,10 @@ public class InvocationSettings {
         return profiler != Profiler.NONE;
     }
 
+    public boolean isBazel() {
+        return invoker == Invoker.Bazel;
+    }
+
     public boolean isBuck() {
         return invoker == Invoker.Buck;
     }

--- a/src/main/java/org/gradle/profiler/Invoker.java
+++ b/src/main/java/org/gradle/profiler/Invoker.java
@@ -1,5 +1,5 @@
 package org.gradle.profiler;
 
 public enum Invoker {
-    ToolingApi, Cli, NoDaemon, Buck, Maven
+    ToolingApi, Cli, NoDaemon, Bazel, Buck, Maven
 }


### PR DESCRIPTION
Allow Bazel builds to be invoked by the --bazel flag and bazel-
specific configuration. Discover and execute from BAZEL_HOME as is
done for Maven. Added initial setup instructions to README.