### PR TITLE
Allow profiling multiple iterations

### DIFF
--- a/src/main/java/org/gradle/profiler/CompositeProfiler.java
+++ b/src/main/java/org/gradle/profiler/CompositeProfiler.java
@@ -38,16 +38,30 @@ class CompositeProfiler extends Profiler {
                 .collect(Collectors.toList());
         return new ProfilerController() {
             @Override
-            public void start() throws IOException, InterruptedException {
+            public void startSession() throws IOException, InterruptedException {
                 for (ProfilerController controller : controllers) {
-                    controller.start();
+                    controller.startSession();
                 }
             }
 
             @Override
-            public void stop() throws IOException, InterruptedException {
+            public void startRecording() throws IOException, InterruptedException {
                 for (ProfilerController controller : controllers) {
-                    controller.stop();
+                    controller.startRecording();
+                }
+            }
+
+            @Override
+            public void stopRecording() throws IOException, InterruptedException {
+                for (ProfilerController controller : controllers) {
+                    controller.stopRecording();
+                }
+            }
+
+            @Override
+            public void stopSession() throws IOException, InterruptedException {
+                for (ProfilerController controller : controllers) {
+                    controller.stopSession();
                 }
             }
         };

--- a/src/main/java/org/gradle/profiler/ProfilerController.java
+++ b/src/main/java/org/gradle/profiler/ProfilerController.java
@@ -20,17 +20,52 @@ import java.io.IOException;
 public interface ProfilerController {
     ProfilerController EMPTY = new ProfilerController() {
         @Override
-        public void start() throws IOException, InterruptedException {
+        public void startSession() throws IOException, InterruptedException {
 
         }
 
         @Override
-        public void stop() throws IOException, InterruptedException {
+        public void startRecording() throws IOException, InterruptedException {
+
+        }
+
+        @Override
+        public void stopRecording() throws IOException, InterruptedException {
+
+        }
+
+        @Override
+        public void stopSession() throws IOException, InterruptedException {
 
         }
     };
 
-    void start() throws IOException, InterruptedException;
+    /**
+     * Connects the profiler to the daemon and does any other one-time setup work.
+     * The profiler should not start collecting data yet. If the profiler cannot
+     * connect without starting data collection, it should defer startup to {@link #startRecording()}
+     * instead.
+     */
+    void startSession() throws IOException, InterruptedException;
 
-    void stop() throws IOException, InterruptedException;
+    /**
+     * Tells the profiler to start collecting data (again). Profilers may chose to throw an
+     * exception if they don't support multiple start/stop operations.
+     */
+    void startRecording() throws IOException, InterruptedException;
+
+    /**
+     * Tells the profiler to stop collecting data for now, e.g. so it doesn't
+     * profile cleanup tasks. If the data collection can only be stopped by
+     * stopping the session, the profiler should implement this as a no-op
+     * and throw an exception when {@link #startRecording()} is called another
+     * time.
+     */
+    void stopRecording() throws IOException, InterruptedException;
+
+    /**
+     * Ends the profiling session, writing the collected results to disk
+     * and disconnecting the profiler from the daemon.
+     */
+    void stopSession() throws IOException, InterruptedException;
 }

--- a/src/main/java/org/gradle/profiler/SingleIterationProfilerController.java
+++ b/src/main/java/org/gradle/profiler/SingleIterationProfilerController.java
@@ -1,0 +1,36 @@
+package org.gradle.profiler;
+
+import java.io.IOException;
+
+public abstract class SingleIterationProfilerController implements ProfilerController {
+
+    private boolean recordedBefore = false;
+
+    @Override
+    public final void startSession() throws IOException, InterruptedException {
+
+    }
+
+    @Override
+    public final void startRecording() throws IOException, InterruptedException {
+        if (recordedBefore) {
+            throw new RuntimeException("Recording multiple iterations with cleanup runs in between is not supported by " + getName());
+        }
+
+        doStartRecording();
+    }
+
+    protected abstract void doStartRecording() throws IOException, InterruptedException;
+
+    @Override
+    public final void stopRecording() throws IOException, InterruptedException {
+        recordedBefore = true;
+    }
+
+    @Override
+    public void stopSession() throws IOException, InterruptedException {
+
+    }
+
+    public abstract String getName();
+}

--- a/src/main/java/org/gradle/profiler/hp/HonestProfilerControl.java
+++ b/src/main/java/org/gradle/profiler/hp/HonestProfilerControl.java
@@ -35,6 +35,7 @@ public class HonestProfilerControl implements ProfilerController {
 
     private final HonestProfilerArgs args;
     private final ScenarioSettings scenarioSettings;
+    private boolean recordedBefore = false;
 
     public HonestProfilerControl(final HonestProfilerArgs args, ScenarioSettings scenarioSettings) {
         this.args = args;
@@ -42,13 +43,26 @@ public class HonestProfilerControl implements ProfilerController {
     }
 
     @Override
-    public void start() throws IOException, InterruptedException {
+    public void startSession() throws IOException, InterruptedException {
+
+    }
+
+    @Override
+    public void startRecording() throws IOException, InterruptedException {
+        if (recordedBefore) {
+            throw new RuntimeException("Recording multiple iterations with cleanup runs in between is not supported by Honest Profiler");
+        }
         System.out.println("Starting profiling with Honest Profiler on port " + args.getPort());
         sendCommand("start");
     }
 
     @Override
-    public void stop() throws IOException, InterruptedException {
+    public void stopRecording() throws IOException, InterruptedException {
+        recordedBefore = true;
+    }
+
+    @Override
+    public void stopSession() throws IOException, InterruptedException {
         System.out.println("Stopping profiling with Honest Profiler on port " + args.getPort());
         sendCommand("stop");
         File hplFile = new File(getOuptutDir(), getProfileName() + PROFILE_HPL_SUFFIX);

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
@@ -1,6 +1,5 @@
 package org.gradle.profiler.jprofiler;
 
-import org.gradle.profiler.Invoker;
 import org.gradle.profiler.OperatingSystem;
 import org.gradle.profiler.ScenarioSettings;
 
@@ -18,10 +17,6 @@ public class JProfiler {
         } else {
             return "/opt/jprofiler" + MAJOR_VERSION;
         }
-    }
-
-    public static boolean profileWholeLifeTime(ScenarioSettings settings) {
-        return settings.getInvocationSettings().getInvoker().equals(Invoker.NoDaemon);
     }
 
     public static String getSnapshotPath(ScenarioSettings settings) {

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerController.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerController.java
@@ -28,16 +28,11 @@ public class JProfilerController implements ProfilerController {
 
     @Override
     public void startSession() throws IOException, InterruptedException {
-        if (!profileWholeLifeTime()) {
-            ensureConnected();
-        }
+        ensureConnected();
     }
 
     @Override
     public void startRecording() throws IOException, InterruptedException {
-        if (profileWholeLifeTime()) {
-            return;
-        }
         invoke("startCPURecording", true);
         if (jProfilerConfig.isRecordAlloc()) {
             invoke("startAllocRecording", true);
@@ -57,9 +52,6 @@ public class JProfilerController implements ProfilerController {
 
     @Override
     public void stopRecording() throws IOException, InterruptedException {
-        if (profileWholeLifeTime()) {
-            return;
-        }
         invoke("stopCPURecording");
         if (jProfilerConfig.isRecordAlloc()) {
             invoke("stopAllocRecording");
@@ -74,9 +66,6 @@ public class JProfilerController implements ProfilerController {
 
     @Override
     public void stopSession() throws IOException, InterruptedException {
-        if (profileWholeLifeTime()) {
-            return;
-        }
         if (jProfilerConfig.isHeapDump()) {
             invoke("triggerHeapDump");
         }
@@ -148,9 +137,5 @@ public class JProfilerController implements ProfilerController {
         } catch (InstanceNotFoundException | ReflectionException | IntrospectionException e) {
             throw new RuntimeException(e);
         }
-    }
-
-    private boolean profileWholeLifeTime() {
-        return JProfiler.profileWholeLifeTime(settings);
     }
 }

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerJvmArgsCalculator.java
@@ -1,5 +1,6 @@
 package org.gradle.profiler.jprofiler;
 
+import org.gradle.profiler.Invoker;
 import org.gradle.profiler.JvmArgsCalculator;
 import org.gradle.profiler.OperatingSystem;
 import org.gradle.profiler.ScenarioSettings;
@@ -156,7 +157,7 @@ public class JProfilerJvmArgsCalculator extends JvmArgsCalculator {
     }
 
     private boolean profileWholeLifeTime() {
-        return JProfiler.profileWholeLifeTime(settings);
+        return settings.getInvocationSettings().getInvoker() == Invoker.NoDaemon;
     }
 
 }

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerProfiler.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerProfiler.java
@@ -4,10 +4,7 @@ import joptsimple.ArgumentAcceptingOptionSpec;
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
 import joptsimple.OptionSpecBuilder;
-import org.gradle.profiler.JvmArgsCalculator;
-import org.gradle.profiler.Profiler;
-import org.gradle.profiler.ProfilerController;
-import org.gradle.profiler.ScenarioSettings;
+import org.gradle.profiler.*;
 
 import java.io.File;
 import java.util.Collections;
@@ -47,7 +44,11 @@ public class JProfilerProfiler extends Profiler {
 
     @Override
     public ProfilerController newController(String pid, ScenarioSettings settings) {
-        return new JProfilerController(settings, jProfilerConfig);
+        if (settings.getInvocationSettings().getInvoker() == Invoker.NoDaemon) {
+            return ProfilerController.EMPTY;
+        } else {
+            return new JProfilerController(settings, jProfilerConfig);
+        }
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/perf/PerfProfilerController.java
+++ b/src/main/java/org/gradle/profiler/perf/PerfProfilerController.java
@@ -62,6 +62,7 @@ public class PerfProfilerController implements ProfilerController {
     private final CommandExec commandExec;
     private final CommandExec sudoCommandExec;
     private CommandExec.RunHandle perfHandle;
+    private boolean recordedBefore = false;
 
     PerfProfilerController(final PerfProfilerArgs args, ScenarioSettings scenarioSettings) {
         this.args = args;
@@ -70,9 +71,16 @@ public class PerfProfilerController implements ProfilerController {
         this.sudoCommandExec = new SudoCommandExec();
     }
 
+    @Override
+    public void startSession() throws IOException, InterruptedException {
+
+    }
 
     @Override
-    public void start() throws IOException, InterruptedException {
+    public void startRecording() throws IOException, InterruptedException {
+        if (recordedBefore) {
+            throw new RuntimeException("Recording multiple iterations with cleanup runs in between is not supported by Perf");
+        }
         System.out.println("Starting profiling with Perf");
 
         checkPrerequisites();
@@ -86,7 +94,12 @@ public class PerfProfilerController implements ProfilerController {
     }
 
     @Override
-    public void stop() throws IOException, InterruptedException {
+    public void stopRecording() throws IOException, InterruptedException {
+        recordedBefore = true;
+    }
+
+    @Override
+    public void stopSession() throws IOException, InterruptedException {
         println("Stopping profiling with Perf");
 
         perfHandle.interrupt();
@@ -96,6 +109,7 @@ public class PerfProfilerController implements ProfilerController {
         /*
         generatePackageFlameGraph();
         */
+
     }
 
     private void println(String message) {

--- a/src/main/java/org/gradle/profiler/yjp/YourKitProfilerController.java
+++ b/src/main/java/org/gradle/profiler/yjp/YourKitProfilerController.java
@@ -14,7 +14,12 @@ public class YourKitProfilerController implements ProfilerController {
     }
 
     @Override
-    public void start() throws IOException, InterruptedException {
+    public void startSession() throws IOException, InterruptedException {
+
+    }
+
+    @Override
+    public void startRecording() throws IOException, InterruptedException {
         if (options.isMemorySnapshot()) {
             runYourKitCommand("start-alloc-recording-adaptive");
         } else if (options.isUseSampling()) {
@@ -25,15 +30,20 @@ public class YourKitProfilerController implements ProfilerController {
     }
 
     @Override
-    public void stop() throws IOException, InterruptedException {
+    public void stopRecording() throws IOException, InterruptedException {
         if (options.isMemorySnapshot()) {
             runYourKitCommand("stop-alloc-recording");
-            runYourKitCommand("capture-memory-snapshot");
-            runYourKitCommand("clear-alloc-data");
         } else {
             runYourKitCommand("stop-cpu-profiling");
+        }
+    }
+
+    @Override
+    public void stopSession() throws IOException, InterruptedException {
+        if (options.isMemorySnapshot()) {
+            runYourKitCommand("capture-memory-snapshot");
+        } else {
             runYourKitCommand("capture-performance-snapshot");
-            runYourKitCommand("clear-cpu-data");
         }
     }
 

--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -156,7 +156,7 @@ println "<daemon: " + gradle.services.get(org.gradle.internal.environment.Gradle
         logFile.contains("* Running scenario using Gradle $versionUnderTest (scenario 1/1)")
         logFile.grep("* Running warm-up build").size() == 2
         logFile.grep("* Running build").size() == 1
-        logFile.grep("* Starting recording for daemon with pid").size() == 1
+        logFile.grep("* starting profiler for daemon with pid").size() == 1
         logFile.grep("<gradle-version: $versionUnderTest>").size() == 4
         logFile.grep("<daemon: true").size() == 4
         logFile.grep("<tasks: [assemble]>").size() == 3
@@ -212,7 +212,7 @@ println "<tasks: " + gradle.startParameter.taskNames + ">"
         logFile.contains("* Running scenario using Gradle $minimalSupportedGradleVersion (scenario 1/1)")
         logFile.grep("* Running warm-up build").size() == 3
         logFile.grep("* Running build").size() == 2
-        logFile.grep("* Starting recording for daemon with pid").size() == 2
+        logFile.grep("* starting profiler for daemon with pid").size() == 2
         logFile.grep("<gradle-version: $minimalSupportedGradleVersion>").size() == 6
         logFile.grep("<tasks: [assemble]>").size() == 5
 


### PR DESCRIPTION
When using --profile together with --iterations,
the profiler used to overwrite the result for every
iteration, which was not very helpful.

Instead the profiler can now aggregate the data
from multiple iterations into one snapshot. It
pauses data collection when cleanup tasks are run.
Some profilers don't support pausing. These will
throw an exception if both cleanup tasks and multiple
iterations are requested.

This helps a lot when profiling fast-running scenarios
like configuration time or up-to-date tasks. A single
invocation usually doesn't contain enough samples to
trust it. Averaging over a dozen invocations however
gives results that show the real hotspots clearly.

Build scans and chrome traces remain unchanged and
create one snapshot per iteration.
