### PR TITLE
Make JFR profiling more detailed

### DIFF
--- a/src/main/java/org/gradle/profiler/jfr/JfrProfiler.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrProfiler.java
@@ -8,11 +8,16 @@ import org.gradle.profiler.ProfilerController;
 import org.gradle.profiler.ScenarioSettings;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Collections;
 import java.util.List;
 
 public class JfrProfiler extends Profiler {
     private final JFRArgs jfrArgs;
+    private final File config;
 
     public JfrProfiler() {
         this(null);
@@ -20,6 +25,20 @@ public class JfrProfiler extends Profiler {
 
     private JfrProfiler(JFRArgs jfrArgs) {
         this.jfrArgs = jfrArgs;
+        this.config = createConfig();
+    }
+
+    private static File createConfig() {
+        try {
+            File jfcFile = File.createTempFile("gradle", ".jfc");
+            try (InputStream stream = JfrProfiler.class.getResource("gradle.jfc").openStream()) {
+                Files.copy(stream, jfcFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+            }
+            jfcFile.deleteOnExit();
+            return jfcFile;
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override
@@ -40,15 +59,15 @@ public class JfrProfiler extends Profiler {
         return new JfrProfiler(newConfigObject(parsedOptions));
     }
 
-    private JFRArgs newConfigObject(OptionSet parsedOptions ) {
+    private JFRArgs newConfigObject(OptionSet parsedOptions) {
         String jfrSettings = (String) parsedOptions.valueOf("jfr-settings");
         if (jfrSettings.endsWith(".jfc")) {
             jfrSettings = new File(jfrSettings).getAbsolutePath();
         }
         return new JFRArgs(
-            new File((String) parsedOptions.valueOf( "jfr-fg-home" )),
-            new File((String) parsedOptions.valueOf( "fg-home" )),
-            jfrSettings
+                new File((String) parsedOptions.valueOf("jfr-fg-home")),
+                new File((String) parsedOptions.valueOf("fg-home")),
+                jfrSettings
         );
     }
 
@@ -63,19 +82,18 @@ public class JfrProfiler extends Profiler {
     }
 
     @Override
-    public void addOptions( final OptionParser parser )
-    {
+    public void addOptions(final OptionParser parser) {
         parser.accepts("jfr-fg-home", "JFR FlameGraph home directory - https://github.com/chrishantha/jfr-flame-graph")
-              .availableIf("profile")
-              .withOptionalArg()
-              .defaultsTo(System.getenv().getOrDefault("JFR_FG_HOME_DIR", ""));
+                .availableIf("profile")
+                .withOptionalArg()
+                .defaultsTo(System.getenv().getOrDefault("JFR_FG_HOME_DIR", ""));
         parser.accepts("fg-home", "FlameGraph home directory")
-              .availableIf("profile")
-              .withOptionalArg()
-              .defaultsTo(System.getenv().getOrDefault("FG_HOME_DIR", ""));
+                .availableIf("profile")
+                .withOptionalArg()
+                .defaultsTo(System.getenv().getOrDefault("FG_HOME_DIR", ""));
         parser.accepts("jfr-settings", "JFR settings - Either a .jfc file or the name of a template known to your JFR installation")
                 .availableIf("profile")
                 .withOptionalArg()
-                .defaultsTo("profile");
+                .defaultsTo(config.getAbsolutePath());
     }
 }

--- a/src/main/resources/org/gradle/profiler/jfr/gradle.jfc
+++ b/src/main/resources/org/gradle/profiler/jfr/gradle.jfc
@@ -1,0 +1,432 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration version="1.0" name="Gradle Profiling" description="Profiling settings optimized for insights into Gradle builds" provider="Oracle">
+
+  <producer uri="http://www.oracle.com/hotspot/jvm/" label="Oracle JDK">
+
+    <event path="java/statistics/thread_allocation">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="java/statistics/class_loading">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 ms</setting>
+    </event>
+
+    <event path="java/statistics/threads">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 ms</setting>
+    </event>
+
+    <event path="java/thread_start">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="java/thread_end">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="java/thread_sleep">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">1 ms</setting>
+    </event>
+
+    <event path="java/thread_park">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">1 ms</setting>
+    </event>
+
+    <event path="java/monitor_enter">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">1 ms</setting>
+    </event>
+
+    <event path="java/monitor_wait">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">1 ms</setting>
+    </event>
+
+    <event path="vm/class/load">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/class/unload">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event path="vm/info">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/initial_system_property">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/prof/execution_sample">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 ms</setting>
+    </event>
+
+    <event path="vm/prof/execution_sampling_info">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">1 ms</setting>
+    </event>
+
+    <event path="vm/runtime/execute_vm_operation">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">10 ms</setting>
+    </event>
+
+    <event path="vm/runtime/thread_dump">
+      <setting name="enabled">false</setting>
+      <setting name="period">999 d</setting>
+    </event>
+
+    <event path="vm/flag/long">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/flag/ulong">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/flag/double">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/flag/boolean">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/flag/string">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/flag/long_changed">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/flag/ulong_changed">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/flag/double_changed">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/flag/boolean_changed">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/flag/string_changed">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/detailed/object_count">
+      <setting name="enabled">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/gc/configuration/gc">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/gc/configuration/heap">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/gc/configuration/young_generation">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/gc/configuration/tlab">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/gc/configuration/survivor">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/gc/detailed/object_count_after_gc">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event path="vm/gc/heap/summary">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/heap/ps_summary">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/heap/metaspace_summary">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/metaspace/gc_threshold">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/metaspace/allocation_failure">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event path="vm/gc/metaspace/out_of_memory">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event path="vm/gc/metaspace/chunk_free_list_summary">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/collector/garbage_collection">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/collector/parold_garbage_collection">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/collector/young_garbage_collection">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/collector/old_garbage_collection">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/collector/g1_garbage_collection">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/phases/pause">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/phases/pause_level_1">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/phases/pause_level_2">
+      <setting name="enabled">true</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/phases/pause_level_3">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">0 ms</setting>
+    </event>
+
+    <event path="vm/gc/reference/statistics">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/detailed/promotion_failed">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/detailed/evacuation_failed">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/detailed/evacuation_info">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/detailed/concurrent_mode_failure">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="vm/gc/detailed/allocation_requiring_gc">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event path="vm/compiler/config">
+      <setting name="enabled">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/compiler/stats">
+      <setting name="enabled">false</setting>
+      <setting name="period">1000 ms</setting>
+    </event>
+
+    <event path="vm/compiler/compilation">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">100 ms</setting>
+    </event>
+
+    <event path="vm/compiler/phase">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">10 s</setting>
+    </event>
+
+    <event path="vm/compiler/failure">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event path="vm/code_sweeper/config">
+      <setting name="enabled">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/code_sweeper/stats">
+      <setting name="enabled">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/code_sweeper/sweep">
+      <setting name="enabled">false</setting>
+      <setting name="threshold">100 ms</setting>
+    </event>
+
+    <event path="vm/code_cache/config">
+      <setting name="enabled">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/code_cache/stats">
+      <setting name="enabled">false</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="vm/code_cache/full">
+      <setting name="enabled">false</setting>
+    </event>
+
+    <event path="os/information">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="os/processor/cpu_information">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="os/processor/context_switch_rate">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 ms</setting>
+    </event>
+
+    <event path="os/processor/cpu_load">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 ms</setting>
+    </event>
+
+    <event path="os/processor/cpu_tsc">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="os/system_process">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="os/initial_environment_variable">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="os/memory/physical_memory">
+      <setting name="enabled">true</setting>
+      <setting name="period">everyChunk</setting>
+    </event>
+
+    <event path="java/object_alloc_in_new_TLAB">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event path="java/object_alloc_outside_TLAB">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+  </producer>
+
+  <producer uri="http://www.oracle.com/hotspot/jdk/" label="Oracle JDK">
+
+    <event path="java/file_read">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">1 ms</setting>
+    </event>
+
+    <event path="java/file_write">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">1 ms</setting>
+    </event>
+
+    <event path="java/socket_read">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">1 ms</setting>
+    </event>
+
+    <event path="java/socket_write">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+      <setting name="threshold">1 ms</setting>
+    </event>
+
+    <event path="java/exception_throw">
+      <setting name="enabled">false</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event path="java/error_throw">
+      <setting name="enabled">true</setting>
+      <setting name="stackTrace">true</setting>
+    </event>
+
+    <event path="java/statistics/throwables">
+      <setting name="enabled">true</setting>
+      <setting name="period">10 ms</setting>
+    </event>
+
+  </producer>
+
+  <producer uri="http://www.oracle.com/hotspot/jfr-info/" label="Oracle JDK">
+
+    <event path="recordings/recording">
+      <setting name="enabled">true</setting>
+    </event>
+
+    <event path="recordings/recording_setting">
+      <setting name="enabled">true</setting>
+    </event>
+
+  </producer>
+
+</configuration>


### PR DESCRIPTION
Use custom settings to get more IO and locking events.
These settings are still pretty low overhead, but give
very valuable insights. They are the same that we use in
Gradle's performance test suite.