### PR TITLE
Simpler flamegraphs

### DIFF
--- a/src/main/java/org/gradle/profiler/fg/FlameGraphSanitizer.java
+++ b/src/main/java/org/gradle/profiler/fg/FlameGraphSanitizer.java
@@ -4,17 +4,15 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Maps;
+import com.google.common.collect.Lists;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
 
 /**
  * Simplifies stacks to make flame graphs more readable.
@@ -22,11 +20,35 @@ import static java.util.Arrays.asList;
 public class FlameGraphSanitizer {
     private static final Splitter STACKTRACE_SPLITTER = Splitter.on(";").omitEmptyStrings();
     private static final Joiner STACKTRACE_JOINER = Joiner.on(";");
+    private static final String GRADLE_INFRASTRUCTURE = "Gradle infrastructure";
+
+    public static final SanitizeFunction COLLAPSE_BUILD_SCRIPTS = new ReplaceRegex(
+            ImmutableMap.of(
+                    Pattern.compile("build_[a-z0-9]+"), "build script",
+                    Pattern.compile("settings_[a-z0-9]+"), "settings script"
+            )
+    );
+
+    public static final SanitizeFunction COLLAPSE_GRADLE_INFRASTRUCTURE = new CompositeSanitizeFunction(
+            new ChopPrefix("DefaultGradleLauncher.loadSettings()"),
+            new ChopPrefix("DefaultGradleLauncher.configureBuild()"),
+            new ChopPrefix("DefaultGradleLauncher.constructTaskGraph()"),
+            new ChopPrefix("DefaultGradleLauncher.executeTasks()"),
+            new ChopPrefix("CatchExceptionTaskExecuter.execute(...)"),
+            new ReplaceContainment(asList("DynamicObject", "Closure.call", "MetaClass", "MetaMethod", "CallSite", "ConfigureDelegate", "Method.invoke", "MethodAccessor", "Proxy", "ConfigureUtil", "Script.invoke", "ClosureBackedAction", "getProperty("), "dynamic invocation"),
+            new ReplaceContainment(asList("BuildOperation", "PluginManager", "ObjectConfigurationAction", "PluginTarget", "PluginAware", "Script.apply", "ScriptPlugin", "ScriptTarget", "ScriptRunner", "ProjectEvaluator", "Project.evaluate"), GRADLE_INFRASTRUCTURE),
+            new ReplaceContainment(singletonList("TaskExecuter"), "task executer")
+    );
 
     private final SanitizeFunction sanitizeFunction;
 
     public FlameGraphSanitizer(SanitizeFunction... sanitizeFunctions) {
-        this.sanitizeFunction = new CompositeSanitizeFunction(sanitizeFunctions);
+        ;
+        ImmutableList<SanitizeFunction> functions = ImmutableList.<SanitizeFunction>builder()
+                .addAll(Arrays.asList(sanitizeFunctions))
+                .add(new CollapseDuplicateFrames())
+                .build();
+        this.sanitizeFunction = new CompositeSanitizeFunction(functions);
     }
 
     public void sanitize(final File in, File out) {
@@ -35,32 +57,21 @@ public class FlameGraphSanitizer {
                 String line;
                 StringBuilder sb = new StringBuilder();
                 while ((line = reader.readLine()) != null) {
-                    if (sanitizeFunction.skipLine(line)) {
+                    int endOfStack = line.lastIndexOf(" ");
+                    if (endOfStack <= 0) {
                         continue;
                     }
-                    int endOfStack = line.lastIndexOf(" ");
-                    if (endOfStack > 0) {
-                        String stackTrace = line.substring(0, endOfStack);
-                        String invocationCount = line.substring(endOfStack + 1);
-                        List<String> stackTraceElements = STACKTRACE_SPLITTER.splitToList(stackTrace);
-                        List<String> sanitizedStackElements = new ArrayList<String>(stackTraceElements.size());
-                        for (String stackTraceElement : stackTraceElements) {
-                            String sanitizedStackElement = sanitizeFunction.map(stackTraceElement);
-                            if (sanitizedStackElement != null) {
-                                String previousStackElement = Iterables.getLast(sanitizedStackElements, null);
-                                if (!sanitizedStackElement.equals(previousStackElement)) {
-                                    sanitizedStackElements.add(sanitizedStackElement);
-                                }
-                            }
-                        }
-                        if (!sanitizedStackElements.isEmpty()) {
-                            sb.setLength(0);
-                            STACKTRACE_JOINER.appendTo(sb, sanitizedStackElements);
-                            sb.append(" ");
-                            sb.append(invocationCount);
-                            sb.append("\n");
-                            writer.write(sb.toString());
-                        }
+                    String stackTrace = line.substring(0, endOfStack);
+                    String invocationCount = line.substring(endOfStack + 1);
+                    List<String> stackTraceElements = STACKTRACE_SPLITTER.splitToList(stackTrace);
+                    List<String> sanitizedStackElements = sanitizeFunction.map(stackTraceElements);
+                    if (!sanitizedStackElements.isEmpty()) {
+                        sb.setLength(0);
+                        STACKTRACE_JOINER.appendTo(sb, sanitizedStackElements);
+                        sb.append(" ");
+                        sb.append(invocationCount);
+                        sb.append("\n");
+                        writer.write(sb.toString());
                     }
                 }
             }
@@ -71,25 +82,7 @@ public class FlameGraphSanitizer {
     }
 
     public interface SanitizeFunction {
-        SanitizeFunction COLLAPSE_BUILD_SCRIPTS = new FlameGraphSanitizer.RegexBasedSanitizeFunction(
-                ImmutableMap.of(
-                        Pattern.compile("build_[a-z0-9]+"), "build script",
-                        Pattern.compile("settings_[a-z0-9]+"), "settings script"
-                )
-        );
-        SanitizeFunction COLLAPSE_GRADLE_INFRASTRUCTURE = new FlameGraphSanitizer.ContainmentBasedSanitizeFunction(
-                ImmutableMap.of(
-                        asList("BuildOperation"), "build operations",
-                        asList("PluginManager", "ObjectConfigurationAction", "PluginTarget", "PluginAware", "Script.apply", "ScriptPlugin", "ScriptTarget", "ScriptRunner"), "plugin management",
-                        asList("DynamicObject", "Closure.call", "MetaClass", "MetaMethod", "CallSite", "ConfigureDelegate", "Method.invoke", "MethodAccessor", "Proxy", "ConfigureUtil", "Script.invoke", "ClosureBackedAction", "getProperty("), "dynamic invocation",
-                        asList("ProjectEvaluator", "Project.evaluate"), "project evaluation",
-                        asList("CommandLine", "Executer", "Executor", "Execution", "Runner", "BuildController", "Bootstrap", "EntryPoint", "Main"), "execution infrastructure"
-                )
-        );
-
-        String map(String entry);
-
-        boolean skipLine(String line);
+        List<String> map(List<String> stack);
     }
 
     private static class CompositeSanitizeFunction implements SanitizeFunction {
@@ -97,68 +90,67 @@ public class FlameGraphSanitizer {
         private final List<SanitizeFunction> sanitizeFunctions;
 
         private CompositeSanitizeFunction(SanitizeFunction... sanitizeFunctions) {
+            this(Arrays.asList(sanitizeFunctions));
+        }
+
+        private CompositeSanitizeFunction(Collection<SanitizeFunction> sanitizeFunctions) {
             this.sanitizeFunctions = ImmutableList.copyOf(sanitizeFunctions);
         }
 
         @Override
-        public String map(String entry) {
-            String result = entry;
+        public List<String> map(List<String> stack) {
+            List<String> result = stack;
             for (SanitizeFunction sanitizeFunction : sanitizeFunctions) {
                 result = sanitizeFunction.map(result);
             }
             return result;
         }
+    }
+
+    private static abstract class FrameWiseSanitizeFunction implements SanitizeFunction {
+        @Override
+        public final List<String> map(List<String> stack) {
+            List<String> result = Lists.newArrayListWithCapacity(stack.size());
+            for (String frame : stack) {
+                result.add(mapFrame(frame));
+            }
+            return result;
+        }
+
+        protected abstract String mapFrame(String frame);
+    }
+
+    private static class ReplaceContainment extends FrameWiseSanitizeFunction {
+        private final Collection<String> keyWords;
+        private final String replacement;
+
+        private ReplaceContainment(Collection<String> keyWords, String replacement) {
+            this.keyWords = keyWords;
+            this.replacement = replacement;
+        }
 
         @Override
-        public boolean skipLine(String line) {
-            for (SanitizeFunction sanitizeFunction : sanitizeFunctions) {
-                if (sanitizeFunction.skipLine(line)) {
-                    return true;
+        protected String mapFrame(String frame) {
+            for (String keyWord : keyWords) {
+                if (frame.contains(keyWord)) {
+                    return replacement;
                 }
             }
-            return false;
+            return frame;
         }
     }
 
-    public static class ContainmentBasedSanitizeFunction implements SanitizeFunction {
-        private final Map<String, String> replacements;
-
-        public ContainmentBasedSanitizeFunction(Map<List<String>, String> replacements) {
-            this.replacements = Maps.newHashMap();
-            for (Map.Entry<List<String>, String> entry : replacements.entrySet()) {
-                for (String key : entry.getKey()) {
-                    this.replacements.put(key, entry.getValue());
-                }
-            }
-        }
-
-        @Override
-        public String map(String entry) {
-            for (Map.Entry<String, String> replacement : replacements.entrySet()) {
-                if (entry.contains(replacement.getKey())) {
-                    return replacement.getValue();
-                }
-            }
-            return entry;
-        }
-
-        @Override
-        public boolean skipLine(String line) {
-            return false;
-        }
-    }
-
-    public static class RegexBasedSanitizeFunction implements SanitizeFunction {
+    private static class ReplaceRegex extends FrameWiseSanitizeFunction {
         private final Map<Pattern, String> replacements;
 
-        public RegexBasedSanitizeFunction(Map<Pattern, String> replacements) {
+        private ReplaceRegex(Map<Pattern, String> replacements) {
             this.replacements = replacements;
         }
 
         @Override
-        public String map(String entry) {
+        protected String mapFrame(String frame) {
             for (Map.Entry<Pattern, String> replacement : replacements.entrySet()) {
-                Matcher matcher = replacement.getKey().matcher(entry);
+                Matcher matcher = replacement.getKey().matcher(frame);
                 String value = replacement.getValue();
                 StringBuffer sb = new StringBuffer();
                 while (matcher.find()) {
@@ -166,15 +158,45 @@ public class FlameGraphSanitizer {
                 }
                 matcher.appendTail(sb);
                 if (sb.length() > 0) {
-                    entry = sb.toString();
+                    frame = sb.toString();
                 }
             }
-            return entry;
+            return frame;
+        }
+    }
+
+    private static class CollapseDuplicateFrames implements SanitizeFunction {
+        @Override
+        public List<String> map(List<String> stack) {
+            List<String> result = Lists.newArrayList(stack);
+            ListIterator<String> iterator = result.listIterator();
+            String previous = null;
+            while (iterator.hasNext()) {
+                String next = iterator.next();
+                if (next.equals(previous)) {
+                    iterator.remove();
+                }
+                previous = next;
+            }
+            return result;
+        }
+    }
+
+    private static class ChopPrefix implements SanitizeFunction {
+        private final String prefix;
+
+        private ChopPrefix(String prefix) {
+            this.prefix = prefix;
         }
 
         @Override
-        public boolean skipLine(String line) {
-            return false;
+        public List<String> map(List<String> stack) {
+            int i = stack.indexOf(prefix);
+            if (i >= 0) {
+                return stack.subList(i, stack.size());
+            } else {
+                return stack;
+            }
         }
     }
 }

--- a/src/main/java/org/gradle/profiler/hp/HonestProfilerControl.java
+++ b/src/main/java/org/gradle/profiler/hp/HonestProfilerControl.java
@@ -18,8 +18,8 @@ package org.gradle.profiler.hp;
 import org.gradle.profiler.CommandExec;
 import org.gradle.profiler.ScenarioSettings;
 import org.gradle.profiler.SingleIterationProfilerController;
-import org.gradle.profiler.fg.FlameGraphTool;
 import org.gradle.profiler.fg.FlameGraphSanitizer;
+import org.gradle.profiler.fg.FlameGraphTool;
 
 import java.io.File;
 import java.io.IOException;
@@ -82,7 +82,7 @@ public class HonestProfilerControl extends SingleIterationProfilerController {
     }
 
     private void sanitizeFlameGraphTxtFile(final File txtFile, final File sanitizedTxtFile) {
-        new FlameGraphSanitizer(FlameGraphSanitizer.SanitizeFunction.COLLAPSE_BUILD_SCRIPTS).sanitize(txtFile, sanitizedTxtFile);
+        new FlameGraphSanitizer(FlameGraphSanitizer.COLLAPSE_BUILD_SCRIPTS).sanitize(txtFile, sanitizedTxtFile);
     }
 
     private void generateFlameGraph(final File sanitizedTxtFile, final File fgFile) {

--- a/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
@@ -103,10 +103,10 @@ class JfrFlameGraphGenerator {
                 new FlameGraphSanitizer(FlameGraphSanitizer.COLLAPSE_BUILD_SCRIPTS)
         ),
         SIMPLIFIED(
-                Arrays.asList("--hide-arguments", "--ignore-line-numbers", "--use-simple-names"),
+                Arrays.asList("--hide-arguments", "--ignore-line-numbers"),
                 Arrays.asList("--minwidth", "1"),
                 Arrays.asList("--minwidth", "2"),
-                new FlameGraphSanitizer(FlameGraphSanitizer.COLLAPSE_BUILD_SCRIPTS, FlameGraphSanitizer.COLLAPSE_GRADLE_INFRASTRUCTURE)
+                new FlameGraphSanitizer(FlameGraphSanitizer.COLLAPSE_BUILD_SCRIPTS, FlameGraphSanitizer.COLLAPSE_GRADLE_INFRASTRUCTURE, FlameGraphSanitizer.SIMPLE_NAMES)
         );
 
         private List<String> stackConversionOptions;

--- a/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
@@ -100,13 +100,13 @@ class JfrFlameGraphGenerator {
                 emptyList(),
                 Arrays.asList("--minwidth", "0.5"),
                 Arrays.asList("--minwidth", "1"),
-                new FlameGraphSanitizer(FlameGraphSanitizer.SanitizeFunction.COLLAPSE_BUILD_SCRIPTS)
+                new FlameGraphSanitizer(FlameGraphSanitizer.COLLAPSE_BUILD_SCRIPTS)
         ),
         SIMPLIFIED(
                 Arrays.asList("--hide-arguments", "--ignore-line-numbers", "--use-simple-names"),
                 Arrays.asList("--minwidth", "1"),
                 Arrays.asList("--minwidth", "2"),
-                new FlameGraphSanitizer(FlameGraphSanitizer.SanitizeFunction.COLLAPSE_BUILD_SCRIPTS, FlameGraphSanitizer.SanitizeFunction.COLLAPSE_GRADLE_INFRASTRUCTURE)
+                new FlameGraphSanitizer(FlameGraphSanitizer.COLLAPSE_BUILD_SCRIPTS, FlameGraphSanitizer.COLLAPSE_GRADLE_INFRASTRUCTURE)
         );
 
         private List<String> stackConversionOptions;


### PR DESCRIPTION
Improve the flame graph simplification so that stacks become much shorter and related stacks (e.g. task execution from multiple threads) are shown in the same "tower".