### PR TITLE
Add error message for missing warm-up for profile

### DIFF
--- a/src/main/java/org/gradle/profiler/Main.java
+++ b/src/main/java/org/gradle/profiler/Main.java
@@ -209,6 +209,9 @@ public class Main {
             BuildInvoker instrumentedBuildInvoker = invoker.withJvmArgs(instrumentedBuildJvmArgs).withGradleArgs(instrumentedBuildGradleArgs);
 
             if (settings.isProfile()) {
+                if (pid == null) {
+                    throw new IllegalStateException("Using the --profile option requires at least one warm-up");
+                }
                 Logging.startOperation("Starting profiler for daemon with pid " + pid);
                 control.startSession();
             }


### PR DESCRIPTION
- a pid is required for the profiler to start recording but without a warm-up a pid won't be supplied. This provides a better error message than an NPE.