### PR TITLE
Add buildscan-additional-repo option for running profiler in Intranet

### DIFF
--- a/src/main/java/org/gradle/profiler/bs/BuildScanInitScript.java
+++ b/src/main/java/org/gradle/profiler/bs/BuildScanInitScript.java
@@ -22,15 +22,28 @@ import java.io.PrintWriter;
 public class BuildScanInitScript extends GeneratedInitScript {
 
     private final String version;
+    private final String additionalRepo;
 
-    public BuildScanInitScript(String version) {
+    public BuildScanInitScript(String version, String additionalRepo) {
         this.version = version;
+        this.additionalRepo = additionalRepo;
     }
 
     @Override
     public void writeContents(final PrintWriter writer) {
         writer.write("initscript {\n");
         writer.write("    repositories {\n");
+        if (additionalRepo != null) {
+            /*
+            Additional repository, if provided, is added before the default repository
+            so that the profiler will access this repo first and won't access the default repo
+            if not needed.
+             */
+            System.out.println("Build Scan additional repo: " + additionalRepo);
+            writer.write("      maven {\n");
+            writer.write("          url \"" + additionalRepo + "\"\n");
+            writer.write("        }\n");
+        }
         writer.write("      maven {\n");
         writer.write("          url \"https://plugins.gradle.org/m2\"\n");
         writer.write("        }\n");

--- a/src/main/java/org/gradle/profiler/bs/BuildScanProfiler.java
+++ b/src/main/java/org/gradle/profiler/bs/BuildScanProfiler.java
@@ -21,14 +21,20 @@ public class BuildScanProfiler extends Profiler {
     public final static String VERSION = "1.11";
 
     private final String buildScanVersion;
+    /*
+    buildScanAdditionalRepo may be needed if users run gradle-profiler in an environment that
+    only has access to intranet (internal repo or artifacts) but does not have access to
+    internet (plugins.gradle.org, the default repo)
+     */
+    private final String buildScanAdditionalRepo;
 
     public BuildScanProfiler() {
-        this(null);
+        this(null, null);
     }
 
-    private BuildScanProfiler(String buildScanVersion) {
+    private BuildScanProfiler(String buildScanVersion, String buildScanAdditionalRepo) {
         this.buildScanVersion = buildScanVersion == null ? VERSION : buildScanVersion;
-        ;
+        this.buildScanAdditionalRepo = buildScanAdditionalRepo == null ? null : buildScanAdditionalRepo;
     }
 
     @Override
@@ -95,7 +101,8 @@ public class BuildScanProfiler extends Profiler {
         return new GradleArgsCalculator() {
             @Override
             public void calculateGradleArgs(List<String> gradleArgs) {
-                gradleArgs.addAll(new BuildScanInitScript(buildScanVersion).getArgs());
+                gradleArgs.addAll(new BuildScanInitScript(buildScanVersion, buildScanAdditionalRepo)
+                    .getArgs());
             }
         };
     }
@@ -113,7 +120,8 @@ public class BuildScanProfiler extends Profiler {
 
     @Override
     public Profiler withConfig(OptionSet parsedOptions) {
-        return new BuildScanProfiler((String) parsedOptions.valueOf("buildscan-version"));
+        return new BuildScanProfiler((String) parsedOptions.valueOf("buildscan-version"),
+            (String) parsedOptions.valueOf("buildscan-additional-repo"));
     }
 
     @Override
@@ -121,5 +129,8 @@ public class BuildScanProfiler extends Profiler {
         parser.accepts("buildscan-version", "Version of the Build Scan plugin")
                 .availableIf("profile")
                 .withOptionalArg();
+        parser.accepts("buildscan-additional-repo", "Additional repository for Build Scan")
+            .availableIf("profile")
+            .withOptionalArg();
     }
 }


### PR DESCRIPTION
When users run gradle-profiler to profile buildscan on Intranet environment that does not have access to Internet/default repo (https://plugins.gradle.org/m2), it gets 'Network is unreachable' error.

Adding --buildscan-additional-repo option would allow the users to provide their internal repository/artifacts (their internal repo that mirrors github), hence the profiler could get all required files from internal repo.

E.g.: --buildscan-additional-repo https://artifactory.mycompany.com/java-virtual

