### PR TITLE
Fix failing integration tests for Maven and Bazel

### DIFF
--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -539,18 +539,19 @@ println "<daemon: " + gradle.services.get(org.gradle.internal.environment.Gradle
         logFile.grep("<tasks: [assemble]>").size() == 16
 
         resultFile.isFile()
-        resultFile.text.readLines().size() == 26 // 3 headers, 16 executions, 7 stats
-        resultFile.text.readLines().get(0) == "scenario,default"
-        resultFile.text.readLines().get(1) == "version,${minimalSupportedGradleVersion}"
-        resultFile.text.readLines().get(2) == "tasks,assemble"
-        resultFile.text.readLines().get(3).matches("warm-up build #1,\\d+")
-        resultFile.text.readLines().get(8).matches("warm-up build #6,\\d+")
-        resultFile.text.readLines().get(9).matches("measured build #1,\\d+")
-        resultFile.text.readLines().get(10).matches("measured build #2,\\d+")
-        resultFile.text.readLines().get(18).matches("measured build #10,\\d+")
-        resultFile.text.readLines().get(19).matches("mean,\\d+\\.\\d+")
-        resultFile.text.readLines().get(22).matches("median,\\d+\\.\\d+")
-        resultFile.text.readLines().get(25).matches("stddev,\\d+\\.\\d+")
+        List<String> lines = resultFile.text.readLines()
+        lines.size() == 26 // 3 headers, 16 executions, 7 stats
+        lines.get(0) == "scenario,default"
+        lines.get(1) == "version,${minimalSupportedGradleVersion}"
+        lines.get(2) == "tasks,assemble"
+        lines.get(3).matches("warm-up build #1,\\d+")
+        lines.get(8).matches("warm-up build #6,\\d+")
+        lines.get(9).matches("measured build #1,\\d+")
+        lines.get(10).matches("measured build #2,\\d+")
+        lines.get(18).matches("measured build #10,\\d+")
+        lines.get(19).matches("mean,\\d+\\.\\d+")
+        lines.get(22).matches("median,\\d+\\.\\d+")
+        lines.get(25).matches("stddev,\\d+\\.\\d+")
     }
 
     def "runs benchmarks using CLI for specified Gradle version and tasks"() {
@@ -577,18 +578,19 @@ println "<daemon: " + gradle.services.get(org.gradle.internal.environment.Gradle
         logFile.grep("<tasks: [assemble]>").size() == 16
 
         resultFile.isFile()
-        resultFile.text.readLines().size() == 26 // 3 headers, 16 executions, 7 stats
-        resultFile.text.readLines().get(0) == "scenario,default"
-        resultFile.text.readLines().get(1) == "version,${minimalSupportedGradleVersion}"
-        resultFile.text.readLines().get(2) == "tasks,assemble"
-        resultFile.text.readLines().get(3).matches("warm-up build #1,\\d+")
-        resultFile.text.readLines().get(8).matches("warm-up build #6,\\d+")
-        resultFile.text.readLines().get(9).matches("measured build #1,\\d+")
-        resultFile.text.readLines().get(10).matches("measured build #2,\\d+")
-        resultFile.text.readLines().get(18).matches("measured build #10,\\d+")
-        resultFile.text.readLines().get(19).matches("mean,\\d+\\.\\d+")
-        resultFile.text.readLines().get(22).matches("median,\\d+\\.\\d+")
-        resultFile.text.readLines().get(25).matches("stddev,\\d+\\.\\d+")
+        List<String> lines = resultFile.text.readLines()
+        lines.size() == 26 // 3 headers, 16 executions, 7 stats
+        lines.get(0) == "scenario,default"
+        lines.get(1) == "version,${minimalSupportedGradleVersion}"
+        lines.get(2) == "tasks,assemble"
+        lines.get(3).matches("warm-up build #1,\\d+")
+        lines.get(8).matches("warm-up build #6,\\d+")
+        lines.get(9).matches("measured build #1,\\d+")
+        lines.get(10).matches("measured build #2,\\d+")
+        lines.get(18).matches("measured build #10,\\d+")
+        lines.get(19).matches("mean,\\d+\\.\\d+")
+        lines.get(22).matches("median,\\d+\\.\\d+")
+        lines.get(25).matches("stddev,\\d+\\.\\d+")
     }
 
     def "runs benchmarks using no-daemon for specified Gradle version and tasks"() {
@@ -616,10 +618,11 @@ println "<daemon: " + gradle.services.get(org.gradle.internal.environment.Gradle
         logFile.grep("<tasks: [assemble]>").size() == 11
 
         resultFile.isFile()
-        resultFile.text.readLines().get(0) == "scenario,default"
-        resultFile.text.readLines().get(1) == "version,${minimalSupportedGradleVersion}"
-        resultFile.text.readLines().get(2) == "tasks,assemble"
-        resultFile.text.readLines().size() == 21 // 3 headers, 11 executions, 7 stats
+        List<String> lines = resultFile.text.readLines()
+        lines.size() == 21 // 3 headers, 11 executions, 7 stats
+        lines.get(0) == "scenario,default"
+        lines.get(1) == "version,${minimalSupportedGradleVersion}"
+        lines.get(2) == "tasks,assemble"
     }
 
     def "runs benchmarks using scenarios defined in scenario file"() {
@@ -662,10 +665,11 @@ println "<daemon: " + gradle.services.get(org.gradle.internal.environment.Gradle
         logFile.contains("* Running scenario help using Gradle $minimalSupportedGradleVersion (scenario 3/3)")
 
         resultFile.isFile()
-        resultFile.text.readLines().get(0) == "scenario,assemble,assemble,help"
-        resultFile.text.readLines().get(1) == "version,3.0,${minimalSupportedGradleVersion},${minimalSupportedGradleVersion}"
-        resultFile.text.readLines().get(2) == "tasks,assemble,assemble,help"
-        resultFile.text.readLines().size() == 26 // 3 headers, 16 executions, 7 stats
+        List<String> lines = resultFile.text.readLines()
+        lines.size() == 26 // 3 headers, 16 executions, 7 stats
+        lines.get(0) == "scenario,assemble,assemble,help"
+        lines.get(1) == "version,3.0,${minimalSupportedGradleVersion},${minimalSupportedGradleVersion}"
+        lines.get(2) == "tasks,assemble,assemble,help"
     }
 
     def "profiles scenarios defined in scenario file"() {
@@ -739,10 +743,11 @@ plugins.withId("idea") {
         logFile.contains("* Running scenario ideaModel using Gradle $minimalSupportedGradleVersion (scenario 2/2)")
 
         resultFile.isFile()
-        resultFile.text.readLines().get(0) == "scenario,ideaModel,ideaModel"
-        resultFile.text.readLines().get(1) == "version,3.0,${minimalSupportedGradleVersion}"
-        resultFile.text.readLines().get(2) == "tasks,,"
-        resultFile.text.readLines().size() == 26 // 3 headers, 16 executions, 7 stats
+        List<String> lines = resultFile.text.readLines()
+        lines.size() == 26 // 3 headers, 16 executions, 7 stats
+        lines.get(0) == "scenario,ideaModel,ideaModel"
+        lines.get(1) == "version,3.0,${minimalSupportedGradleVersion}"
+        lines.get(2) == "tasks,,"
     }
 
     def "profiles scenarios defined in scenario file using multiple Gradle versions"() {
@@ -858,15 +863,16 @@ println "<daemon: " + gradle.services.get(org.gradle.internal.environment.Gradle
         logFile.grep("<tasks: [help]>").size() == 17
 
         resultFile.isFile()
-        resultFile.text.readLines().get(0) == "scenario,help"
-        resultFile.text.readLines().get(1) == "version,${minimalSupportedGradleVersion}"
-        resultFile.text.readLines().get(2) == "tasks,help"
-        resultFile.text.readLines().get(3).matches("warm-up build #1,\\d+")
-        resultFile.text.readLines().get(8).matches("warm-up build #6,\\d+")
-        resultFile.text.readLines().get(9).matches("measured build #1,\\d+")
-        resultFile.text.readLines().get(10).matches("measured build #2,\\d+")
-        resultFile.text.readLines().get(18).matches("measured build #10,\\d+")
-        resultFile.text.readLines().size() == 26 // 3 headers, 16 executions, 7 stats
+        List<String> lines = resultFile.text.readLines()
+        lines.size() == 26 // 3 headers, 16 executions, 7 stats
+        lines.get(0) == "scenario,help"
+        lines.get(1) == "version,${minimalSupportedGradleVersion}"
+        lines.get(2) == "tasks,help"
+        lines.get(3).matches("warm-up build #1,\\d+")
+        lines.get(8).matches("warm-up build #6,\\d+")
+        lines.get(9).matches("measured build #1,\\d+")
+        lines.get(10).matches("measured build #2,\\d+")
+        lines.get(18).matches("measured build #10,\\d+")
     }
 
     def "runs benchmarks using single scenario defined in scenario file"() {
@@ -934,12 +940,13 @@ println "<dry-run: " + gradle.startParameter.dryRun + ">"
         logFile.grep("<tasks: [clean, assemble]>").size() == 2
 
         resultFile.isFile()
-        resultFile.text.readLines().get(0) == "scenario,s1,s1,s2"
-        resultFile.text.readLines().get(1) == "version,3.0,${minimalSupportedGradleVersion},${minimalSupportedGradleVersion}"
-        resultFile.text.readLines().get(2) == "tasks,assemble,assemble,clean assemble"
-        resultFile.text.readLines().get(3).matches("warm-up build #1,\\d+,\\d+,\\d+")
-        resultFile.text.readLines().get(4).matches("measured build #1,\\d+,\\d+,\\d+")
-        resultFile.text.readLines().size() == 12
+        List<String> lines = resultFile.text.readLines()
+        lines.size() == 12
+        lines.get(0) == "scenario,s1,s1,s2"
+        lines.get(1) == "version,3.0,${minimalSupportedGradleVersion},${minimalSupportedGradleVersion}"
+        lines.get(2) == "tasks,assemble,assemble,clean assemble"
+        lines.get(3).matches("warm-up build #1,\\d+,\\d+,\\d+")
+        lines.get(4).matches("measured build #1,\\d+,\\d+,\\d+")
     }
 
     def "recovers from failure in warmup while running benchmarks"() {
@@ -978,22 +985,23 @@ assemble.doFirst {
         logFile.grep("<tasks: [assemble]>").size() == 4 + 16
 
         resultFile.isFile()
-        resultFile.text.readLines().size() == 26 // 3 headers, 16 executions, 7 stats
-        resultFile.text.readLines().get(0) == "scenario,default,default"
-        resultFile.text.readLines().get(1) == "version,${minimalSupportedGradleVersion},3.0"
-        resultFile.text.readLines().get(2) == "tasks,assemble,assemble"
-        resultFile.text.readLines().get(3).matches("warm-up build #1,\\d+,\\d+")
-        resultFile.text.readLines().get(4).matches("warm-up build #2,\\d+,\\d+")
-        resultFile.text.readLines().get(5).matches("warm-up build #3,\\d+,\\d+")
-        resultFile.text.readLines().get(6).matches("warm-up build #4,,\\d+")
-        resultFile.text.readLines().get(7).matches("warm-up build #5,,\\d+")
-        resultFile.text.readLines().get(8).matches("warm-up build #6,,\\d+")
-        resultFile.text.readLines().get(9).matches("measured build #1,,\\d+")
-        resultFile.text.readLines().get(10).matches("measured build #2,,\\d+")
-        resultFile.text.readLines().get(18).matches("measured build #10,,\\d+")
-        resultFile.text.readLines().get(19).matches("mean,NaN,\\d+\\.\\d+")
-        resultFile.text.readLines().get(22).matches("median,NaN,\\d+\\.\\d+")
-        resultFile.text.readLines().get(25).matches("stddev,NaN,\\d+\\.\\d+")
+        List<String> lines = resultFile.text.readLines()
+        lines.size() == 26 // 3 headers, 16 executions, 7 stats
+        lines.get(0) == "scenario,default,default"
+        lines.get(1) == "version,${minimalSupportedGradleVersion},3.0"
+        lines.get(2) == "tasks,assemble,assemble"
+        lines.get(3).matches("warm-up build #1,\\d+,\\d+")
+        lines.get(4).matches("warm-up build #2,\\d+,\\d+")
+        lines.get(5).matches("warm-up build #3,\\d+,\\d+")
+        lines.get(6).matches("warm-up build #4,,\\d+")
+        lines.get(7).matches("warm-up build #5,,\\d+")
+        lines.get(8).matches("warm-up build #6,,\\d+")
+        lines.get(9).matches("measured build #1,,\\d+")
+        lines.get(10).matches("measured build #2,,\\d+")
+        lines.get(18).matches("measured build #10,,\\d+")
+        lines.get(19).matches("mean,NaN,\\d+\\.\\d+")
+        lines.get(22).matches("median,NaN,\\d+\\.\\d+")
+        lines.get(25).matches("stddev,NaN,\\d+\\.\\d+")
     }
 
     def "recovers from failure running benchmarks"() {
@@ -1032,19 +1040,20 @@ assemble.doFirst {
         logFile.grep("<tasks: [assemble]>").size() == 9 + 16
 
         resultFile.isFile()
-        resultFile.text.readLines().size() == 26 // 3 headers, 16 executions, 7 stats
-        resultFile.text.readLines().get(0) == "scenario,default,default"
-        resultFile.text.readLines().get(1) == "version,${minimalSupportedGradleVersion},3.0"
-        resultFile.text.readLines().get(2) == "tasks,assemble,assemble"
-        resultFile.text.readLines().get(3).matches("warm-up build #1,\\d+,\\d+")
-        resultFile.text.readLines().get(8).matches("warm-up build #6,\\d+,\\d+")
-        resultFile.text.readLines().get(9).matches("measured build #1,\\d+,\\d+")
-        resultFile.text.readLines().get(10).matches("measured build #2,\\d+,\\d+")
-        resultFile.text.readLines().get(11).matches("measured build #3,,\\d+")
-        resultFile.text.readLines().get(18).matches("measured build #10,,\\d+")
-        resultFile.text.readLines().get(19).matches("mean,\\d+\\.\\d+,\\d+\\.\\d+")
-        resultFile.text.readLines().get(22).matches("median,\\d+\\.\\d+,\\d+\\.\\d+")
-        resultFile.text.readLines().get(25).matches("stddev,\\d+\\.\\d+,\\d+\\.\\d+")
+        List<String> lines = resultFile.text.readLines()
+        lines.size() == 26 // 3 headers, 16 executions, 7 stats
+        lines.get(0) == "scenario,default,default"
+        lines.get(1) == "version,${minimalSupportedGradleVersion},3.0"
+        lines.get(2) == "tasks,assemble,assemble"
+        lines.get(3).matches("warm-up build #1,\\d+,\\d+")
+        lines.get(8).matches("warm-up build #6,\\d+,\\d+")
+        lines.get(9).matches("measured build #1,\\d+,\\d+")
+        lines.get(10).matches("measured build #2,\\d+,\\d+")
+        lines.get(11).matches("measured build #3,,\\d+")
+        lines.get(18).matches("measured build #10,,\\d+")
+        lines.get(19).matches("mean,\\d+\\.\\d+,\\d+\\.\\d+")
+        lines.get(22).matches("median,\\d+\\.\\d+,\\d+\\.\\d+")
+        lines.get(25).matches("stddev,\\d+\\.\\d+,\\d+\\.\\d+")
     }
 
     def "can define system property when benchmarking using tooling API"() {
@@ -1449,18 +1458,19 @@ help {
         logFile.contains("* Buck targets: [//target:android_binary_1, //target:android_binary_2, //target/child:android_binary_3, //target/child:android_binary_4]")
 
         resultFile.isFile()
-        resultFile.text.readLines().size() == 26 // 3 headers, 16 executions, 7 stats
-        resultFile.text.readLines().get(0) == "scenario,buildAll,buildTarget,buildType"
-        resultFile.text.readLines().get(1) == "version,buck,buck,buck"
-        resultFile.text.readLines().get(2) == "tasks,,//some/target,"
-        resultFile.text.readLines().get(3).matches("warm-up build #1,\\d+,\\d+,\\d+")
-        resultFile.text.readLines().get(8).matches("warm-up build #6,\\d+,\\d+,\\d+")
-        resultFile.text.readLines().get(9).matches("measured build #1,\\d+,\\d+,\\d+")
-        resultFile.text.readLines().get(10).matches("measured build #2,\\d+,\\d+,\\d+")
-        resultFile.text.readLines().get(18).matches("measured build #10,\\d+,\\d+,\\d+")
-        resultFile.text.readLines().get(19).matches("mean,\\d+\\.\\d+,\\d+\\.\\d+,\\d+\\.\\d+")
-        resultFile.text.readLines().get(22).matches("median,\\d+\\.\\d+,\\d+\\.\\d+,\\d+\\.\\d+")
-        resultFile.text.readLines().get(25).matches("stddev,\\d+\\.\\d+,\\d+\\.\\d+,\\d+\\.\\d+")
+        List<String> lines = resultFile.text.readLines()
+        lines.size() == 26 // 3 headers, 16 executions, 7 stats
+        lines.get(0) == "scenario,buildAll,buildTarget,buildType"
+        lines.get(1) == "version,buck,buck,buck"
+        lines.get(2) == "tasks,,//some/target,"
+        lines.get(3).matches("warm-up build #1,\\d+,\\d+,\\d+")
+        lines.get(8).matches("warm-up build #6,\\d+,\\d+,\\d+")
+        lines.get(9).matches("measured build #1,\\d+,\\d+,\\d+")
+        lines.get(10).matches("measured build #2,\\d+,\\d+,\\d+")
+        lines.get(18).matches("measured build #10,\\d+,\\d+,\\d+")
+        lines.get(19).matches("mean,\\d+\\.\\d+,\\d+\\.\\d+,\\d+\\.\\d+")
+        lines.get(22).matches("median,\\d+\\.\\d+,\\d+\\.\\d+,\\d+\\.\\d+")
+        lines.get(25).matches("stddev,\\d+\\.\\d+,\\d+\\.\\d+,\\d+\\.\\d+")
     }
 
     def "cannot profile a buck build"() {
@@ -1551,17 +1561,19 @@ buildTarget {
         logFile.contains("* Bazel targets: [:hello]")
 
         resultFile.isFile()
-        resultFile.text.readLines().size() == 26 // 3 headers, 16 executions, 7 stats
-        resultFile.text.readLines().get(0) == "build,buildTarget bazel"
-        resultFile.text.readLines().get(1) == "tasks,"
-        resultFile.text.readLines().get(2).matches("warm-up build #1,\\d+")
-        resultFile.text.readLines().get(7).matches("warm-up build #6,\\d+")
-        resultFile.text.readLines().get(8).matches("measured build #1,\\d+")
-        resultFile.text.readLines().get(9).matches("measured build #2,\\d+")
-        resultFile.text.readLines().get(17).matches("measured build #10,\\d+")
-        resultFile.text.readLines().get(18).matches("mean,\\d+\\.\\d+")
-        resultFile.text.readLines().get(19).matches("median,\\d+\\.\\d+")
-        resultFile.text.readLines().get(20).matches("stddev,\\d+\\.\\d+")
+        List<String> lines =resultFile.text.readLines()
+        lines.size() == 26 // 3 headers, 16 executions, 7 stats
+        lines.get(0) == "scenario,buildTarget"
+        lines.get(1) == "version,bazel"
+        lines.get(2) == "tasks,some:assemble"
+        lines.get(3).matches("warm-up build #1,\\d+")
+        lines.get(8).matches("warm-up build #6,\\d+")
+        lines.get(9).matches("measured build #1,\\d+")
+        lines.get(10).matches("measured build #2,\\d+")
+        lines.get(18).matches("measured build #10,\\d+")
+        lines.get(19).matches("mean,\\d+\\.\\d+")
+        lines.get(22).matches("median,\\d+\\.\\d+")
+        lines.get(25).matches("stddev,\\d+\\.\\d+")
     }
 
     def "cannot profile a bazel build"() {
@@ -1647,17 +1659,19 @@ buildGoal {
         logFile.contains("* Maven targets: [-v]")
 
         resultFile.isFile()
-        resultFile.text.readLines().size() == 26 // 3 headers, 16 executions, 7 stats
-        resultFile.text.readLines().get(0) == "build,buildGoal maven"
-        resultFile.text.readLines().get(1) == "tasks,"
-        resultFile.text.readLines().get(2).matches("warm-up build #1,\\d+")
-        resultFile.text.readLines().get(7).matches("warm-up build #6,\\d+")
-        resultFile.text.readLines().get(8).matches("measured build #1,\\d+")
-        resultFile.text.readLines().get(9).matches("measured build #2,\\d+")
-        resultFile.text.readLines().get(17).matches("measured build #10,\\d+")
-        resultFile.text.readLines().get(18).matches("mean,\\d+\\.\\d+")
-        resultFile.text.readLines().get(19).matches("median,\\d+\\.\\d+")
-        resultFile.text.readLines().get(20).matches("stddev,\\d+\\.\\d+")
+        List<String> lines =resultFile.text.readLines()
+        lines.size() == 26 // 3 headers, 16 executions, 7 stats
+        lines.get(0) == "scenario,buildGoal"
+        lines.get(1) == "version,maven"
+        lines.get(2) == "tasks,-v"
+        lines.get(3).matches("warm-up build #1,\\d+")
+        lines.get(8).matches("warm-up build #6,\\d+")
+        lines.get(9).matches("measured build #1,\\d+")
+        lines.get(10).matches("measured build #2,\\d+")
+        lines.get(18).matches("measured build #10,\\d+")
+        lines.get(19).matches("mean,\\d+\\.\\d+")
+        lines.get(22).matches("median,\\d+\\.\\d+")
+        lines.get(25).matches("stddev,\\d+\\.\\d+")
     }
 
     def "clears build cache when asked"() {


### PR DESCRIPTION
- Fix conditions for the Maven and Bazel tests which seem to be outdated
- Slightly optimized code to read results file only once instead of for
  each condition

Issue #108 