### PR TITLE
Add support for profiling/benchmarking a simulated Android Studio sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,12 @@ Here is an example:
     ideaModel {
         # Fetch the IDEA tooling model
         model = "org.gradle.tooling.model.idea.IdeaProject"
+        # Can also runs tasks
+        # tasks = ["assemble"]
+    }
+    androidStudioSync {
+        # Simulate an Android studio sync
+        android-studio-sync { }
     }
 
 Values are optional and default to the values provided on the command-line or defined in the build.

--- a/build.gradle
+++ b/build.gradle
@@ -17,20 +17,21 @@ configurations {
 }
 
 dependencies {
-    compile 'org.gradle:gradle-tooling-api:5.0'
-    compile 'com.google.code.findbugs:annotations:3.0.1'
-    compile 'com.google.guava:guava:21.0'
-    compile 'net.sf.jopt-simple:jopt-simple:5.0.2'
-    compile 'com.typesafe:config:1.3.1'
-    compile 'org.apache.commons:commons-math3:3.6.1'
-    compile 'com.github.javaparser:javaparser-core:3.1.3'
-    compile 'org.apache.ant:ant-compress:1.5'
-    compile 'commons-io:commons-io:2.6'
+    implementation 'org.gradle:gradle-tooling-api:5.0'
+    implementation 'com.google.code.findbugs:annotations:3.0.1'
+    implementation 'com.google.guava:guava:21.0'
+    implementation 'net.sf.jopt-simple:jopt-simple:5.0.2'
+    implementation 'com.typesafe:config:1.3.1'
+    implementation 'org.apache.commons:commons-math3:3.6.1'
+    implementation 'com.github.javaparser:javaparser-core:3.1.3'
+    implementation 'org.apache.ant:ant-compress:1.5'
+    implementation 'commons-io:commons-io:2.6'
     implementation 'org.openjdk.jmc:flightrecorder:7.0.0-SNAPSHOT'
+    implementation 'com.android.tools.build:builder-model:3.0.0'
 
     profilerPlugins project(':chrome-trace')
 
-    runtime 'org.slf4j:slf4j-simple:1.7.10'
+    runtimeOnly 'org.slf4j:slf4j-simple:1.7.10'
     testCompile 'org.codehaus.groovy:groovy:2.4.7'
     testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
     testRuntime 'cglib:cglib:3.2.6'

--- a/src/main/java/org/gradle/profiler/AdhocGradleScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/AdhocGradleScenarioDefinition.java
@@ -7,8 +7,8 @@ import java.util.Map;
 import java.util.function.Supplier;
 
 public class AdhocGradleScenarioDefinition extends GradleScenarioDefinition {
-    public AdhocGradleScenarioDefinition(GradleBuildConfiguration version, Invoker invoker, List<String> tasks, Map<String, String> systemProperties, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
-        super("default", invoker, version, tasks, null, Collections.emptyList(), Collections.emptyList(), systemProperties, buildMutator, warmUpCount, buildCount, outputDir);
+    public AdhocGradleScenarioDefinition(GradleBuildConfiguration version, Invoker invoker, BuildAction buildAction, List<String> tasks, Map<String, String> systemProperties, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
+        super("default", invoker, version, buildAction, tasks, Collections.emptyList(), Collections.emptyList(), systemProperties, buildMutator, warmUpCount, buildCount, outputDir);
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/AndroidStudioSyncAction.java
+++ b/src/main/java/org/gradle/profiler/AndroidStudioSyncAction.java
@@ -1,0 +1,56 @@
+package org.gradle.profiler;
+
+import com.android.builder.model.AndroidProject;
+import org.gradle.tooling.BuildController;
+import org.gradle.tooling.events.ProgressListener;
+import org.gradle.tooling.model.gradle.BasicGradleProject;
+import org.gradle.tooling.model.gradle.GradleBuild;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+/**
+ * A mock-up of Android studio sync.
+ */
+public class AndroidStudioSyncAction implements BuildAction {
+    @Override
+    public String getDisplayName() {
+        return "simulate Android Studio sync";
+    }
+
+    @Override
+    public void run(BuildInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
+        gradleArgs = new ArrayList<>(gradleArgs);
+        gradleArgs.add("-Dcom.android.build.gradle.overrideVersionCheck=true");
+        gradleArgs.add("-Pandroid.injected.build.model.only=true");
+        gradleArgs.add("-Pandroid.injected.build.model.only.versioned=3");
+        gradleArgs.add("-Pandroid.builder.sdkDownload=true");
+        tasks = new ArrayList<>(tasks);
+        tasks.add("generateDebugSources");
+        buildInvoker.runToolingAction(tasks, gradleArgs, jvmArgs, new GetModel(), (builder) -> {
+            builder.addProgressListener(noOpListener());
+        });
+    }
+
+    private static ProgressListener noOpListener() {
+        return event -> {
+            // Ignore, just measure the impact of receiving the events
+        };
+    }
+
+    public static class GetModel implements org.gradle.tooling.BuildAction<Map<String, AndroidProject>>, Serializable {
+        @Override
+        public Map<String, AndroidProject> execute(BuildController controller) {
+            GradleBuild build = controller.getBuildModel();
+            Map<String, AndroidProject> result = new TreeMap<String, AndroidProject>();
+            for (BasicGradleProject project : build.getProjects()) {
+                AndroidProject androidProject = controller.findModel(project, AndroidProject.class);
+                result.put(project.getPath(), androidProject);
+            }
+            return result;
+        }
+    }
+}

--- a/src/main/java/org/gradle/profiler/BuildAction.java
+++ b/src/main/java/org/gradle/profiler/BuildAction.java
@@ -6,6 +6,9 @@ import java.util.List;
  * Runs some particular action against a build.
  */
 public interface BuildAction {
+    /**
+     * A human consumable display name for this action.
+     */
     String getDisplayName();
 
     /**

--- a/src/main/java/org/gradle/profiler/BuildAction.java
+++ b/src/main/java/org/gradle/profiler/BuildAction.java
@@ -1,0 +1,15 @@
+package org.gradle.profiler;
+
+import java.util.List;
+
+/**
+ * Runs some particular action against a build.
+ */
+public interface BuildAction {
+    String getDisplayName();
+
+    /**
+     * Runs the measured work of this action.
+     */
+    void run(BuildInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs);
+}

--- a/src/main/java/org/gradle/profiler/BuildActionInvoker.java
+++ b/src/main/java/org/gradle/profiler/BuildActionInvoker.java
@@ -1,0 +1,68 @@
+package org.gradle.profiler;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.gradle.profiler.Logging.startOperation;
+
+public class BuildActionInvoker {
+    private final List<String> jvmArgs;
+    private final List<String> gradleArgs;
+    private final PidInstrumentation pidInstrumentation;
+    private final Consumer<BuildInvocationResult> resultsConsumer;
+    private final BuildInvoker buildInvoker;
+
+    public BuildActionInvoker(List<String> jvmArgs, List<String> gradleArgs, BuildInvoker buildInvoker, PidInstrumentation pidInstrumentation, Consumer<BuildInvocationResult> resultsConsumer) {
+        this.jvmArgs = jvmArgs;
+        this.gradleArgs = gradleArgs;
+        this.buildInvoker = buildInvoker;
+        this.pidInstrumentation = pidInstrumentation;
+        this.resultsConsumer = resultsConsumer;
+    }
+
+    public BuildInvocationResult runBuild(Phase phase, int buildNumber, BuildStep buildStep, List<String> tasks, BuildAction buildAction) {
+        String displayName = phase.displayBuildNumber(buildNumber);
+        startOperation("Running " + displayName + " with " + buildStep.name().toLowerCase() + " tasks " + tasks);
+
+        List<String> jvmArgs = new ArrayList<>(this.jvmArgs);
+        jvmArgs.add("-Dorg.gradle.profiler.phase=" + phase);
+        jvmArgs.add("-Dorg.gradle.profiler.number=" + buildNumber);
+        jvmArgs.add("-Dorg.gradle.profiler.step=" + buildStep);
+
+        Timer timer = new Timer();
+        buildAction.run(buildInvoker, tasks, gradleArgs, jvmArgs);
+        Duration executionTime = timer.elapsed();
+
+        String pid = pidInstrumentation.getPidForLastBuild();
+        Logging.detailed().println("Used daemon with pid " + pid);
+        Main.printExecutionTime(executionTime);
+
+        BuildInvocationResult results = new BuildInvocationResult(displayName, executionTime, pid);
+        resultsConsumer.accept(results);
+        return results;
+    }
+
+    public BuildActionInvoker notInstrumented() {
+        return copy(jvmArgs, gradleArgs, buildInvocationResult -> { });
+    }
+
+    public BuildActionInvoker withJvmArgs(List<String> jvmArgs) {
+        if (jvmArgs.equals(this.jvmArgs)) {
+            return this;
+        }
+        return copy(jvmArgs, gradleArgs, resultsConsumer);
+    }
+
+    public BuildActionInvoker withGradleArgs(List<String> gradleArgs) {
+        if (gradleArgs.equals(this.gradleArgs)) {
+            return this;
+        }
+        return copy(jvmArgs, gradleArgs, resultsConsumer);
+    }
+
+    private BuildActionInvoker copy(List<String> jvmArgs, List<String> gradleArgs, Consumer<BuildInvocationResult> resultsConsumer) {
+        return new BuildActionInvoker(jvmArgs, gradleArgs, buildInvoker, pidInstrumentation, resultsConsumer);
+    }
+}

--- a/src/main/java/org/gradle/profiler/BuildInvoker.java
+++ b/src/main/java/org/gradle/profiler/BuildInvoker.java
@@ -1,24 +1,15 @@
 package org.gradle.profiler;
 
-import org.gradle.tooling.GradleConnectionException;
-import org.gradle.tooling.LongRunningOperation;
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildActionExecuter;
 
 import java.util.List;
-import java.util.function.Function;
+import java.util.function.Consumer;
 
 public abstract class BuildInvoker {
-    public abstract void run(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, Class<?> toolingModel);
+    public abstract void runTasks(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs);
 
-    public static <T extends LongRunningOperation, R> R run(T operation, Function<T, R> function) {
-        operation.setStandardOutput(Logging.detailed());
-        operation.setStandardError(Logging.detailed());
-        try {
-            return function.apply(operation);
-        } catch (GradleConnectionException e) {
-            System.out.println();
-            System.out.println("ERROR: failed to run build. See log file for details.");
-            System.out.println();
-            throw e;
-        }
-    }
+    public abstract void loadToolingModel(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, Class<?> toolingModel);
+
+    public abstract <T> T runToolingAction(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, BuildAction<T> action, Consumer<BuildActionExecuter<?>> configureAction);
 }

--- a/src/main/java/org/gradle/profiler/BuildInvoker.java
+++ b/src/main/java/org/gradle/profiler/BuildInvoker.java
@@ -3,50 +3,11 @@ package org.gradle.profiler;
 import org.gradle.tooling.GradleConnectionException;
 import org.gradle.tooling.LongRunningOperation;
 
-import java.time.Duration;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
-import static org.gradle.profiler.Logging.startOperation;
-
 public abstract class BuildInvoker {
-    private final List<String> jvmArgs;
-    private final List<String> gradleArgs;
-    private final PidInstrumentation pidInstrumentation;
-    private final Consumer<BuildInvocationResult> resultsConsumer;
-
-    public BuildInvoker(List<String> jvmArgs, List<String> gradleArgs, PidInstrumentation pidInstrumentation, Consumer<BuildInvocationResult> resultsConsumer) {
-        this.jvmArgs = jvmArgs;
-        this.gradleArgs = gradleArgs;
-        this.pidInstrumentation = pidInstrumentation;
-        this.resultsConsumer = resultsConsumer;
-    }
-
-    public BuildInvocationResult runBuild(Phase phase, int buildNumber, BuildStep buildStep, List<String> tasks, Class<?> toolingModel) {
-        String displayName = phase.displayBuildNumber(buildNumber);
-        startOperation("Running " + displayName + " with " + buildStep.name().toLowerCase() + " tasks " + tasks);
-
-        List<String> jvmArgs = new ArrayList<>(this.jvmArgs);
-        jvmArgs.add("-Dorg.gradle.profiler.phase=" + phase);
-        jvmArgs.add("-Dorg.gradle.profiler.number=" + buildNumber);
-        jvmArgs.add("-Dorg.gradle.profiler.step=" + buildStep);
-
-        Timer timer = new Timer();
-        run(tasks, gradleArgs, jvmArgs, toolingModel);
-        Duration executionTime = timer.elapsed();
-
-        String pid = pidInstrumentation.getPidForLastBuild();
-        Logging.detailed().println("Used daemon with pid " + pid);
-        Main.printExecutionTime(executionTime);
-
-        BuildInvocationResult results = new BuildInvocationResult(displayName, executionTime, pid);
-        resultsConsumer.accept(results);
-        return results;
-    }
-
-    protected abstract void run(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, Class<?> toolingModel);
+    public abstract void run(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, Class<?> toolingModel);
 
     public static <T extends LongRunningOperation, R> R run(T operation, Function<T, R> function) {
         operation.setStandardOutput(Logging.detailed());
@@ -60,24 +21,4 @@ public abstract class BuildInvoker {
             throw e;
         }
     }
-
-    public BuildInvoker notInstrumented() {
-        return copy(jvmArgs, gradleArgs, pidInstrumentation, buildInvocationResult -> { });
-    }
-
-    public BuildInvoker withJvmArgs(List<String> jvmArgs) {
-        if (jvmArgs.equals(this.jvmArgs)) {
-            return this;
-        }
-        return copy(jvmArgs, gradleArgs, pidInstrumentation, resultsConsumer);
-    }
-
-    public BuildInvoker withGradleArgs(List<String> gradleArgs) {
-        if (gradleArgs.equals(this.gradleArgs)) {
-            return this;
-        }
-        return copy(jvmArgs, gradleArgs, pidInstrumentation, resultsConsumer);
-    }
-
-    protected abstract BuildInvoker copy(List<String> jvmArgs, List<String> gradleArgs, PidInstrumentation pidInstrumentation, Consumer<BuildInvocationResult> resultsConsumer);
 }

--- a/src/main/java/org/gradle/profiler/CliInvoker.java
+++ b/src/main/java/org/gradle/profiler/CliInvoker.java
@@ -1,8 +1,12 @@
 package org.gradle.profiler;
 
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildActionExecuter;
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class CliInvoker extends BuildInvoker {
@@ -19,10 +23,17 @@ public class CliInvoker extends BuildInvoker {
     }
 
     @Override
-    public void run(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, Class<?> toolingModel) {
-        if (toolingModel != null) {
-            throw new UnsupportedOperationException("Cannot fetch a tooling model using the Gradle CLI.");
-        }
+    public void loadToolingModel(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, Class<?> toolingModel) {
+        throw new UnsupportedOperationException("Cannot fetch a tooling API model using the Gradle CLI.");
+    }
+
+    @Override
+    public <T> T runToolingAction(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, BuildAction<T> action, Consumer<BuildActionExecuter<?>> configureAction) {
+        throw new UnsupportedOperationException("Cannot run a tooling API action using the Gradle CLI.");
+    }
+
+    @Override
+    public void runTasks(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
         String gradleOpts = jvmArgs.stream().map(arg -> '"' + arg + '"').collect(Collectors.joining(" "));
 
         List<String> commandLine = new ArrayList<>();

--- a/src/main/java/org/gradle/profiler/CliInvoker.java
+++ b/src/main/java/org/gradle/profiler/CliInvoker.java
@@ -3,7 +3,6 @@ package org.gradle.profiler;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class CliInvoker extends BuildInvoker {
@@ -12,9 +11,7 @@ public class CliInvoker extends BuildInvoker {
     private final File projectDir;
     private final boolean daemon;
 
-
-    public CliInvoker(GradleBuildConfiguration gradleBuildConfiguration, File javaHome, File projectDir, List<String> jvmArgs, List<String> gradleArgs, PidInstrumentation pidInstrumentation, Consumer<BuildInvocationResult> resultsConsumer, boolean daemon) {
-        super(jvmArgs, gradleArgs, pidInstrumentation, resultsConsumer);
+    public CliInvoker(GradleBuildConfiguration gradleBuildConfiguration, File javaHome, File projectDir, boolean daemon) {
         this.gradleBuildConfiguration = gradleBuildConfiguration;
         this.javaHome = javaHome;
         this.projectDir = projectDir;
@@ -22,16 +19,11 @@ public class CliInvoker extends BuildInvoker {
     }
 
     @Override
-    protected BuildInvoker copy(List<String> jvmArgs, List<String> gradleArgs, PidInstrumentation pidInstrumentation, Consumer<BuildInvocationResult> resultsConsumer) {
-        return new CliInvoker(gradleBuildConfiguration, javaHome, projectDir, jvmArgs, gradleArgs, pidInstrumentation, resultsConsumer, daemon);
-    }
-
-    @Override
-    protected void run(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, Class<?> toolingModel) {
+    public void run(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, Class<?> toolingModel) {
         if (toolingModel != null) {
             throw new UnsupportedOperationException("Cannot fetch a tooling model using the Gradle CLI.");
         }
-        String gradleOpts = jvmArgs.stream().map (arg -> '"' + arg + '"').collect(Collectors.joining(" "));
+        String gradleOpts = jvmArgs.stream().map(arg -> '"' + arg + '"').collect(Collectors.joining(" "));
 
         List<String> commandLine = new ArrayList<>();
         gradleBuildConfiguration.addGradleCommand(commandLine);
@@ -41,7 +33,7 @@ public class CliInvoker extends BuildInvoker {
         if (daemon) {
             commandLine.add("-Dorg.gradle.jvmargs=" + gradleOpts);
         } else {
-          commandLine.add("-Dorg.gradle.jvmargs");
+            commandLine.add("-Dorg.gradle.jvmargs");
         }
 
         Logging.detailed().println("Running command:");

--- a/src/main/java/org/gradle/profiler/ConfigUtil.java
+++ b/src/main/java/org/gradle/profiler/ConfigUtil.java
@@ -3,8 +3,6 @@ package org.gradle.profiler;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValue;
 
-import java.io.File;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -65,6 +63,10 @@ public class ConfigUtil {
 		} else {
 			return defaultValue;
 		}
+	}
+
+	public static List<String> strings(Config config, String key) {
+		return strings(config, key, Collections.emptyList());
 	}
 
 	public static List<String> strings(Config config, String key, List<String> defaults) {

--- a/src/main/java/org/gradle/profiler/DefaultGradleBuildConfigurationReader.java
+++ b/src/main/java/org/gradle/profiler/DefaultGradleBuildConfigurationReader.java
@@ -108,7 +108,7 @@ public class DefaultGradleBuildConfigurationReader implements GradleBuildConfigu
         ProjectConnection connection = connector.forProjectDirectory(projectDir).connect();
         try {
             BuildEnvironment buildEnvironment = connection.getModel(BuildEnvironment.class);
-            new ToolingApiInvoker(connection).run(ImmutableList.of("help"), ImmutableList.of("-I", initScript.getAbsolutePath()), ImmutableList.of(), null);
+            new ToolingApiInvoker(connection).runTasks(ImmutableList.of("help"), ImmutableList.of("-I", initScript.getAbsolutePath()), ImmutableList.of());
             List<String> buildDetails = readBuildDetails();
             JavaEnvironment javaEnvironment = buildEnvironment.getJava();
             List<String> allJvmArgs = new ArrayList<>(javaEnvironment.getJvmArguments());

--- a/src/main/java/org/gradle/profiler/DefaultGradleBuildConfigurationReader.java
+++ b/src/main/java/org/gradle/profiler/DefaultGradleBuildConfigurationReader.java
@@ -1,6 +1,7 @@
 package org.gradle.profiler;
 
 import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.Files;
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ProjectConnection;
@@ -107,12 +108,7 @@ public class DefaultGradleBuildConfigurationReader implements GradleBuildConfigu
         ProjectConnection connection = connector.forProjectDirectory(projectDir).connect();
         try {
             BuildEnvironment buildEnvironment = connection.getModel(BuildEnvironment.class);
-            BuildInvoker.run(connection.newBuild(), build -> {
-                build.withArguments("-I", initScript.getAbsolutePath());
-                build.forTasks("help");
-                build.run();
-                return null;
-            });
+            new ToolingApiInvoker(connection).run(ImmutableList.of("help"), ImmutableList.of("-I", initScript.getAbsolutePath()), ImmutableList.of(), null);
             List<String> buildDetails = readBuildDetails();
             JavaEnvironment javaEnvironment = buildEnvironment.getJava();
             List<String> allJvmArgs = new ArrayList<>(javaEnvironment.getJvmArguments());

--- a/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
@@ -11,18 +11,18 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
 
     private final Invoker invoker;
     private final GradleBuildConfiguration buildConfiguration;
-    private final Class<?> toolingModel;
+    private final BuildAction buildAction;
     private final List<String> cleanupTasks;
     private final List<String> tasks;
     private final List<String> gradleArgs;
     private final Map<String, String> systemProperties;
 
-    public GradleScenarioDefinition(String name, Invoker invoker, GradleBuildConfiguration buildConfiguration, List<String> tasks, Class<?> toolingModel, List<String> cleanupTasks, List<String> gradleArgs, Map<String, String> systemProperties, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
+    public GradleScenarioDefinition(String name, Invoker invoker, GradleBuildConfiguration buildConfiguration, BuildAction buildAction, List<String> tasks, List<String> cleanupTasks, List<String> gradleArgs, Map<String, String> systemProperties, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
         super(name, buildMutator, warmUpCount, buildCount, outputDir);
         this.invoker = invoker;
+        this.buildAction = buildAction;
         this.tasks = tasks;
         this.buildConfiguration = buildConfiguration;
-        this.toolingModel = toolingModel;
         this.cleanupTasks = cleanupTasks;
         this.gradleArgs = gradleArgs;
         this.systemProperties = systemProperties;
@@ -60,8 +60,8 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
         return tasks;
     }
 
-    public Class<?> getToolingModel() {
-        return toolingModel;
+    public BuildAction getAction() {
+        return buildAction;
     }
 
     public List<String> getCleanupTasks() {
@@ -79,12 +79,9 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
     @Override
     protected void printDetail(PrintStream out) {
         out.println("  " + getBuildConfiguration().getGradleVersion() + " (" + getBuildConfiguration().getGradleHome() + ")");
-        out.println("  Run using: " + getInvoker());
+        out.println("  Run using: " + getInvoker() + " to " + buildAction.getDisplayName());
         out.println("  Cleanup Tasks: " + getCleanupTasks());
         out.println("  Tasks: " + getTasks());
-        if (toolingModel != null) {
-            out.println("  Tooling model: " + getToolingModel());
-        }
         out.println("  Gradle args: " + getGradleArgs());
         if (!getSystemProperties().isEmpty()) {
             out.println("  System properties:");

--- a/src/main/java/org/gradle/profiler/LoadToolingModelAction.java
+++ b/src/main/java/org/gradle/profiler/LoadToolingModelAction.java
@@ -1,0 +1,21 @@
+package org.gradle.profiler;
+
+import java.util.List;
+
+public class LoadToolingModelAction implements BuildAction {
+    private final Class<?> toolingModel;
+
+    public LoadToolingModelAction(Class<?> toolingModel) {
+        this.toolingModel = toolingModel;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "load tooling model " + toolingModel.getSimpleName();
+    }
+
+    @Override
+    public void run(BuildInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
+        buildInvoker.run(tasks, gradleArgs, jvmArgs, toolingModel);
+    }
+}

--- a/src/main/java/org/gradle/profiler/LoadToolingModelAction.java
+++ b/src/main/java/org/gradle/profiler/LoadToolingModelAction.java
@@ -16,6 +16,6 @@ public class LoadToolingModelAction implements BuildAction {
 
     @Override
     public void run(BuildInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
-        buildInvoker.run(tasks, gradleArgs, jvmArgs, toolingModel);
+        buildInvoker.loadToolingModel(tasks, gradleArgs, jvmArgs, toolingModel);
     }
 }

--- a/src/main/java/org/gradle/profiler/RunTasksAction.java
+++ b/src/main/java/org/gradle/profiler/RunTasksAction.java
@@ -1,0 +1,15 @@
+package org.gradle.profiler;
+
+import java.util.List;
+
+public class RunTasksAction implements BuildAction {
+    @Override
+    public String getDisplayName() {
+        return "run tasks";
+    }
+
+    @Override
+    public void run(BuildInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
+        buildInvoker.run(tasks, gradleArgs, jvmArgs, null);
+    }
+}

--- a/src/main/java/org/gradle/profiler/RunTasksAction.java
+++ b/src/main/java/org/gradle/profiler/RunTasksAction.java
@@ -10,6 +10,6 @@ public class RunTasksAction implements BuildAction {
 
     @Override
     public void run(BuildInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
-        buildInvoker.run(tasks, gradleArgs, jvmArgs, null);
+        buildInvoker.runTasks(tasks, gradleArgs, jvmArgs);
     }
 }

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -151,7 +151,7 @@ class ScenarioLoader {
                         throw new IllegalArgumentException("Unrecognized key '" + scenarioName + ".bazel." + key + "' defined in scenario file " + scenarioFile);
                     }
                 }
-                List<String> targets = ConfigUtil.strings(executionInstructions, TARGETS, Collections.emptyList());
+                List<String> targets = ConfigUtil.strings(executionInstructions, TARGETS);
                 File outputDir = new File(settings.getOutputDir(), scenarioName + "-bazel");
                 definitions.add(new BazelScenarioDefinition(scenarioName, targets, buildMutatorFactory, warmUpCount, settings.getBuildCount(), outputDir));
             } else if (scenario.hasPath(BUCK) && settings.isBuck()) {
@@ -164,7 +164,7 @@ class ScenarioLoader {
                         throw new IllegalArgumentException("Unrecognized key '" + scenarioName + ".buck." + key + "' defined in scenario file " + scenarioFile);
                     }
                 }
-                List<String> targets = ConfigUtil.strings(executionInstructions, TARGETS, Collections.emptyList());
+                List<String> targets = ConfigUtil.strings(executionInstructions, TARGETS);
                 String type = ConfigUtil.string(executionInstructions, TYPE, null);
                 File outputDir = new File(settings.getOutputDir(), scenarioName + "-buck");
                 definitions.add(new BuckScenarioDefinition(scenarioName, targets, type, buildMutatorFactory, warmUpCount, settings.getBuildCount(), outputDir));
@@ -178,7 +178,7 @@ class ScenarioLoader {
                         throw new IllegalArgumentException("Unrecognized key '" + scenarioName + ".maven." + key + "' defined in scenario file " + scenarioFile);
                     }
                 }
-                List<String> targets = ConfigUtil.strings(executionInstructions, TARGETS, Collections.emptyList());
+                List<String> targets = ConfigUtil.strings(executionInstructions, TARGETS);
                 File outputDir = new File(settings.getOutputDir(), scenarioName + "-maven");
                 definitions.add(new MavenScenarioDefinition(scenarioName, targets, buildMutatorFactory, warmUpCount, settings.getBuildCount(), outputDir));
             } else if (!settings.isBazel() && !settings.isBuck() && !settings.isMaven()) {
@@ -188,9 +188,9 @@ class ScenarioLoader {
                     versions.add(inspector.readConfiguration());
                 }
 
-                List<String> tasks = ConfigUtil.strings(scenario, TASKS, settings.getTargets());
-                List<String> cleanupTasks = ConfigUtil.strings(scenario, CLEANUP_TASKS, Collections.emptyList());
-                List<String> gradleArgs = ConfigUtil.strings(scenario, GRADLE_ARGS, Collections.emptyList());
+                List<String> tasks = ConfigUtil.strings(scenario, TASKS);
+                List<String> cleanupTasks = ConfigUtil.strings(scenario, CLEANUP_TASKS);
+                List<String> gradleArgs = ConfigUtil.strings(scenario, GRADLE_ARGS);
                 Invoker invoker = ConfigUtil.invoker(scenario, RUN_USING, settings.getInvoker());
                 BuildAction buildAction = getBuildAction(scenario, scenarioFile);
                 Map<String, String> systemProperties = ConfigUtil.map(scenario, SYSTEM_PROPERTIES, settings.getSystemProperties());

--- a/src/main/java/org/gradle/profiler/ToolingApiInvoker.java
+++ b/src/main/java/org/gradle/profiler/ToolingApiInvoker.java
@@ -1,8 +1,14 @@
 package org.gradle.profiler;
 
+import org.gradle.tooling.BuildAction;
+import org.gradle.tooling.BuildActionExecuter;
+import org.gradle.tooling.GradleConnectionException;
+import org.gradle.tooling.LongRunningOperation;
 import org.gradle.tooling.ProjectConnection;
 
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 public class ToolingApiInvoker extends BuildInvoker {
     private final ProjectConnection projectConnection;
@@ -11,25 +17,50 @@ public class ToolingApiInvoker extends BuildInvoker {
         this.projectConnection = projectConnection;
     }
 
-    @Override
-    public void run(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, Class<?> toolingModel) {
-        if (toolingModel == null) {
-            run(projectConnection.newBuild(), build -> {
-                build.forTasks(tasks.toArray(new String[0]));
-                build.withArguments(gradleArgs);
-                build.setJvmArguments(jvmArgs);
-                build.run();
-                return null;
-            });
-        } else {
-            run(projectConnection.model(toolingModel), build -> {
-                build.forTasks(tasks.toArray(new String[0]));
-                build.withArguments(gradleArgs);
-                build.setJvmArguments(jvmArgs);
-                build.get();
-                return null;
-            });
+    private static <T extends LongRunningOperation, R> R run(T operation, Function<T, R> function) {
+        operation.setStandardOutput(Logging.detailed());
+        operation.setStandardError(Logging.detailed());
+        try {
+            return function.apply(operation);
+        } catch (GradleConnectionException e) {
+            System.out.println();
+            System.out.println("ERROR: failed to run build. See log file for details.");
+            System.out.println();
+            throw e;
         }
+    }
+
+    @Override
+    public void runTasks(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
+        run(projectConnection.newBuild(), build -> {
+            build.forTasks(tasks.toArray(new String[0]));
+            build.withArguments(gradleArgs);
+            build.setJvmArguments(jvmArgs);
+            build.run();
+            return null;
+        });
+    }
+
+    @Override
+    public void loadToolingModel(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, Class<?> toolingModel) {
+        run(projectConnection.model(toolingModel), build -> {
+            build.forTasks(tasks.toArray(new String[0]));
+            build.withArguments(gradleArgs);
+            build.setJvmArguments(jvmArgs);
+            build.get();
+            return null;
+        });
+    }
+
+    @Override
+    public <T> T runToolingAction(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, BuildAction<T> action, Consumer<BuildActionExecuter<?>> configureAction) {
+        return run(projectConnection.action(action), build -> {
+            build.forTasks(tasks.toArray(new String[0]));
+            build.withArguments(gradleArgs);
+            build.setJvmArguments(jvmArgs);
+            configureAction.accept(build);
+            return build.run();
+        });
     }
 }
 

--- a/src/main/java/org/gradle/profiler/ToolingApiInvoker.java
+++ b/src/main/java/org/gradle/profiler/ToolingApiInvoker.java
@@ -3,23 +3,16 @@ package org.gradle.profiler;
 import org.gradle.tooling.ProjectConnection;
 
 import java.util.List;
-import java.util.function.Consumer;
 
 public class ToolingApiInvoker extends BuildInvoker {
     private final ProjectConnection projectConnection;
 
-    public ToolingApiInvoker(ProjectConnection projectConnection, List<String> jvmArgs, List<String> gradleArgs, PidInstrumentation pidInstrumentation, Consumer<BuildInvocationResult> resultsConsumer) {
-        super(jvmArgs, gradleArgs, pidInstrumentation, resultsConsumer);
+    public ToolingApiInvoker(ProjectConnection projectConnection) {
         this.projectConnection = projectConnection;
     }
 
     @Override
-    protected BuildInvoker copy(List<String> jvmArgs, List<String> gradleArgs, PidInstrumentation pidInstrumentation, Consumer<BuildInvocationResult> resultsConsumer) {
-        return new ToolingApiInvoker(projectConnection, jvmArgs, gradleArgs, pidInstrumentation, resultsConsumer);
-    }
-
-    @Override
-    protected void run(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, Class<?> toolingModel) {
+    public void run(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, Class<?> toolingModel) {
         if (toolingModel == null) {
             run(projectConnection.newBuild(), build -> {
                 build.forTasks(tasks.toArray(new String[0]));

--- a/src/main/java/org/gradle/profiler/mutations/FileChangeMutatorConfigurator.java
+++ b/src/main/java/org/gradle/profiler/mutations/FileChangeMutatorConfigurator.java
@@ -8,7 +8,6 @@ import org.gradle.profiler.ConfigUtil;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
@@ -49,7 +48,7 @@ public class FileChangeMutatorConfigurator implements BuildMutatorConfigurator {
 	}
 
 	private static List<File> sourceFiles(Config config, String scenarioName, File projectDir, String key) {
-		return ConfigUtil.strings(config, key, Collections.emptyList())
+		return ConfigUtil.strings(config, key)
 				.stream()
 				.map(fileName -> openFile(fileName, projectDir, scenarioName))
 				.filter(Objects::nonNull)

--- a/src/main/java/org/gradle/profiler/mutations/GitRevertMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/GitRevertMutator.java
@@ -8,7 +8,6 @@ import org.gradle.profiler.ConfigUtil;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -59,7 +58,7 @@ public class GitRevertMutator extends AbstractGitMutator {
     public static class Configurator implements BuildMutatorConfigurator {
 		@Override
 		public Supplier<BuildMutator> configure(Config scenario, String scenarioName, File projectDir, String key) {
-			List<String> commits = ConfigUtil.strings(scenario, key, Collections.emptyList());
+			List<String> commits = ConfigUtil.strings(scenario, key);
 			if (commits.isEmpty()) {
 				throw new IllegalArgumentException("No commits specified for git-revert");
 			}

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -36,7 +36,22 @@ class ScenarioLoaderTest extends Specification {
         def scenarios = loadScenarios(scenarioFile, settings, Mock(GradleBuildConfigurationReader))
         expect:
         scenarios*.name == ["default"]
-        (scenarios[0] as GradleScenarioDefinition).tasks == ["help"]
+        def scenario = scenarios[0] as GradleScenarioDefinition
+        scenario.tasks == ["help"]
+    }
+
+    def "can load single scenario with no tasks defined"() {
+        def settings = settings()
+        settings.targets.add("default") // don't use the target as the default tasks
+
+        scenarioFile << """
+            default {
+            }
+        """
+        def scenarios = loadScenarios(scenarioFile, settings, Mock(GradleBuildConfigurationReader))
+        expect:
+        def scenario = scenarios[0] as GradleScenarioDefinition
+        scenario.tasks.empty
     }
 
     def "can load tooling model scenarios"() {


### PR DESCRIPTION
This PR adds support for measuring a mock up of the Android Studio sync.

The logic is a copy of the code from the `gradle/gradle` performance tests. At some point it would be good to reuse this logic instead, ideally from the Android Studio source. This PR does not cover that issue.