### PR TITLE
Fix build scan configuration for build scan plugin v2.0+

### DIFF
--- a/src/main/java/org/gradle/profiler/buildscan/BuildScanInitScript.java
+++ b/src/main/java/org/gradle/profiler/buildscan/BuildScanInitScript.java
@@ -43,8 +43,8 @@ public class BuildScanInitScript extends GeneratedInitScript {
         writer.write("rootProject { prj ->\n");
         writer.write("    apply plugin: initscript.classLoader.loadClass(\"com.gradle.scan.plugin.BuildScanPlugin\")\n");
         writer.write("    buildScan {\n");
-        writer.write("        licenseAgreementUrl = 'https://gradle.com/terms-of-service'\n");
-        writer.write("        licenseAgree = 'yes'\n");
+        writer.write("        termsOfServiceUrl = 'https://gradle.com/terms-of-service'\n");
+        writer.write("        termsOfServiceAgree = 'yes'\n");
         writer.write("    }\n");
         writer.write("}\n");
     }

--- a/src/main/java/org/gradle/profiler/buildscan/BuildScanInitScript.java
+++ b/src/main/java/org/gradle/profiler/buildscan/BuildScanInitScript.java
@@ -43,8 +43,13 @@ public class BuildScanInitScript extends GeneratedInitScript {
         writer.write("rootProject { prj ->\n");
         writer.write("    apply plugin: initscript.classLoader.loadClass(\"com.gradle.scan.plugin.BuildScanPlugin\")\n");
         writer.write("    buildScan {\n");
-        writer.write("        termsOfServiceUrl = 'https://gradle.com/terms-of-service'\n");
-        writer.write("        termsOfServiceAgree = 'yes'\n");
+        if (version.startsWith("0.") || version.startsWith("1.")) {
+            writer.write("        licenseAgreementUrl = 'https://gradle.com/terms-of-service'\n");
+            writer.write("        licenseAgree = 'yes'\n");
+        } else {
+            writer.write("        termsOfServiceUrl = 'https://gradle.com/terms-of-service'\n");
+            writer.write("        termsOfServiceAgree = 'yes'\n");
+        }
         writer.write("    }\n");
         writer.write("}\n");
     }

--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -340,6 +340,23 @@ println "<daemon: " + gradle.services.get(org.gradle.internal.environment.Gradle
         assertBuildScanPublished(BuildScanProfiler.defaultBuildScanVersion(GradleVersion.version(minimalSupportedGradleVersion)))
     }
 
+    def "profiles build using Build Scans with latest supported Gradle version"() {
+        given:
+        buildFile.text = """
+apply plugin: BasePlugin
+println "<gradle-version: " + gradle.gradleVersion + ">"
+"""
+
+        when:
+        new Main().
+                run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion, "--profile", "buildscan",
+                        "assemble")
+
+        then:
+        logFile.grep("<gradle-version: $latestSupportedGradleVersion>").size() == 4
+        assertBuildScanPublished(BuildScanProfiler.defaultBuildScanVersion(GradleVersion.version(latestSupportedGradleVersion)))
+    }
+
     def "uses build scan version used by the build if present"() {
         given:
         buildFile.text = """


### PR DESCRIPTION
build scan plugin v2 removed 'licenseAgreementUrl' in favor of
'termsOfServiceUrl'.

This probably breaks build scan integration for early plugin versions, however.