### PR TITLE
Fail at the configuration stage when trying to profile or benchmark without warm-ups

### DIFF
--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -89,6 +89,10 @@ class ScenarioLoader {
         if (versions.isEmpty()) {
             versions.add(gradleBuildConfigurationReader.readConfiguration());
         }
+        if(settings.getWarmUpCount()<1) {
+            throw new IllegalArgumentException("You can not skip warm-ups when profiling or benchmarking. Use --no-daemon if you want to profile or benchmark JVM startup");
+        }
+
         for (GradleBuildConfiguration version : versions) {
             File outputDir = versions.size() == 1 ? settings.getOutputDir() : new File(settings.getOutputDir(), version.getGradleVersion().getVersion());
             scenarios.add(new AdhocGradleScenarioDefinition(version, settings.getInvoker(), settings.getTargets(), settings.getSystemProperties(), new BuildMutatorFactory(Collections.emptyList()), settings.getWarmUpCount(), settings.getBuildCount(), outputDir));
@@ -181,6 +185,10 @@ class ScenarioLoader {
                 File outputDir = new File(settings.getOutputDir(), scenarioName + "-maven");
                 definitions.add(new MavenScenarioDefinition(scenarioName, targets, buildMutatorFactory, warmUpCount, settings.getBuildCount(), outputDir));
             } else if (!settings.isBazel() && !settings.isBuck() && !settings.isMaven()) {
+                if(warmUpCount<1) {
+                    throw new IllegalArgumentException("You can not skip warm-ups when profiling or benchmarking scenario "+scenarioName+". Use --no-daemon if you want to profile or benchmark JVM startup");
+                }
+
                 List<GradleBuildConfiguration> versions = ConfigUtil.strings(scenario, VERSIONS, settings.getVersions()).stream().map(inspector::readConfiguration).collect(
                     Collectors.toList());
                 if (versions.isEmpty()) {

--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -112,6 +112,56 @@ help {
         output.contains("Unknown scenario 'asmbl' requested. Available scenarios are: assemble, help")
     }
 
+    def "complains when profiling and skipping warm-up builds"() {
+        given:
+        buildFile.text = """
+apply plugin: BasePlugin
+println "<gradle-version: " + gradle.gradleVersion + ">"
+println "<tasks: " + gradle.startParameter.taskNames + ">"
+"""
+
+        when:
+        new Main().
+            run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", minimalSupportedGradleVersion, "--profile", "jfr",
+                "--warmups", "0", "--iterations", "2", "assemble")
+
+        then:
+        thrown(IllegalArgumentException)
+
+        and:
+        output.contains("You can not skip warm-ups when profiling or benchmarking. Use --no-daemon if you want to profile or benchmark JVM startup")
+    }
+
+    def "complains when benchmarking scenario and skipping warm-up builds"() {
+        given:
+        def scenarioFile = file("benchmark.conf")
+        scenarioFile.text = """
+assemble {
+    tasks = assemble
+}
+help {
+    tasks = help
+    warm-ups = 0
+}
+"""
+        buildFile.text = """
+apply plugin: BasePlugin
+println "<gradle-version: " + gradle.gradleVersion + ">"
+println "<tasks: " + gradle.startParameter.taskNames + ">"
+"""
+
+        when:
+        new Main().
+            run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", minimalSupportedGradleVersion, "--benchmark",
+                "--iterations", "2", "--scenario-file", scenarioFile.absolutePath)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        and:
+        output.contains("You can not skip warm-ups when profiling or benchmarking scenario help. Use --no-daemon if you want to profile or benchmark JVM startup")
+    }
+
     def "reports build failures"() {
         given:
         buildFile.text = """
@@ -220,7 +270,6 @@ println "<tasks: " + gradle.startParameter.taskNames + ">"
         def profileFile = new File(outputDir, "${minimalSupportedGradleVersion}.jfr")
         profileFile.exists()
     }
-
 
     @Requires({ YourKit.findYourKitHome() })
     def "profiles build using YourKit to produce CPU tracing snapshot"() {


### PR DESCRIPTION
Fail at the configuration stage when trying to profile or benchmark without warm-ups

Issue #43 

**EDIT:** Previously was ~~Allow skipping warm-ups when profiling.~~