### PR TITLE
Some refactorings to reduce duplication and improve encapsulation

### DIFF
--- a/src/main/java/org/gradle/profiler/AdhocGradleScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/AdhocGradleScenarioDefinition.java
@@ -2,13 +2,12 @@ package org.gradle.profiler;
 
 import java.io.File;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
 public class AdhocGradleScenarioDefinition extends GradleScenarioDefinition {
-    public AdhocGradleScenarioDefinition(GradleBuildConfiguration version, Invoker invoker, BuildAction buildAction, List<String> tasks, Map<String, String> systemProperties, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
-        super("default", invoker, version, buildAction, tasks, Collections.emptyList(), Collections.emptyList(), systemProperties, buildMutator, warmUpCount, buildCount, outputDir);
+    public AdhocGradleScenarioDefinition(GradleBuildConfiguration version, Invoker invoker, BuildAction buildAction, Map<String, String> systemProperties, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
+        super("default", invoker, version, buildAction, BuildAction.NO_OP, Collections.emptyList(), systemProperties, buildMutator, warmUpCount, buildCount, outputDir);
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/AndroidStudioSyncAction.java
+++ b/src/main/java/org/gradle/profiler/AndroidStudioSyncAction.java
@@ -7,29 +7,35 @@ import org.gradle.tooling.model.gradle.BasicGradleProject;
 import org.gradle.tooling.model.gradle.GradleBuild;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 /**
  * A mock-up of Android studio sync.
  */
 public class AndroidStudioSyncAction implements BuildAction {
     @Override
+    public String getShortDisplayName() {
+        return "AS sync";
+    }
+
+    @Override
     public String getDisplayName() {
         return "simulate Android Studio sync";
     }
 
     @Override
-    public void run(GradleInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
+    public boolean isDoesSomething() {
+        return true;
+    }
+
+    @Override
+    public void run(GradleInvoker buildInvoker, List<String> gradleArgs, List<String> jvmArgs) {
         gradleArgs = new ArrayList<>(gradleArgs);
         gradleArgs.add("-Dcom.android.build.gradle.overrideVersionCheck=true");
         gradleArgs.add("-Pandroid.injected.build.model.only=true");
         gradleArgs.add("-Pandroid.injected.build.model.only.versioned=3");
         gradleArgs.add("-Pandroid.builder.sdkDownload=true");
-        tasks = new ArrayList<>(tasks);
-        tasks.add("generateDebugSources");
+        List<String> tasks = Collections.singletonList("generateDebugSources");
         buildInvoker.runToolingAction(tasks, gradleArgs, jvmArgs, new GetModel(), (builder) -> {
             builder.addProgressListener(noOpListener());
         });

--- a/src/main/java/org/gradle/profiler/AndroidStudioSyncAction.java
+++ b/src/main/java/org/gradle/profiler/AndroidStudioSyncAction.java
@@ -22,7 +22,7 @@ public class AndroidStudioSyncAction implements BuildAction {
     }
 
     @Override
-    public void run(BuildInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
+    public void run(GradleInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
         gradleArgs = new ArrayList<>(gradleArgs);
         gradleArgs.add("-Dcom.android.build.gradle.overrideVersionCheck=true");
         gradleArgs.add("-Pandroid.injected.build.model.only=true");

--- a/src/main/java/org/gradle/profiler/BazelScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/BazelScenarioInvoker.java
@@ -1,11 +1,9 @@
 package org.gradle.profiler;
 
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
-import static org.gradle.profiler.Logging.startOperation;
 import static org.gradle.profiler.Phase.MEASURE;
 import static org.gradle.profiler.Phase.WARM_UP;
 
@@ -31,27 +29,11 @@ public class BazelScenarioInvoker extends ScenarioInvoker<BazelScenarioDefinitio
             Consumer<BuildInvocationResult> resultConsumer = benchmarkResults.version(scenario);
             for (int i = 0; i < scenario.getWarmUpCount(); i++) {
                 String displayName = WARM_UP.displayBuildNumber(i + 1);
-                mutator.beforeBuild();
-                tryRun(() -> {
-                    startOperation("Running " + displayName);
-                    Timer timer = new Timer();
-                    new CommandExec().inDir(settings.getProjectDir()).run(commandLine);
-                    Duration executionTime = timer.elapsed();
-                    Main.printExecutionTime(executionTime);
-                    resultConsumer.accept(new BuildInvocationResult(displayName, executionTime, null));
-                }, mutator::afterBuild);
+                runMeasured(displayName, mutator, measureCommandLineExecution(displayName, commandLine, settings.getProjectDir()), resultConsumer);
             }
             for (int i = 0; i < scenario.getBuildCount(); i++) {
                 String displayName = MEASURE.displayBuildNumber(i + 1);
-                mutator.beforeBuild();
-                tryRun(() -> {
-                    startOperation("Running " + displayName);
-                    Timer timer = new Timer();
-                    new CommandExec().inDir(settings.getProjectDir()).run(commandLine);
-                    Duration executionTime = timer.elapsed();
-                    Main.printExecutionTime(executionTime);
-                    resultConsumer.accept(new BuildInvocationResult(displayName, executionTime, null));
-                }, mutator::afterBuild);
+                runMeasured(displayName, mutator, measureCommandLineExecution(displayName, commandLine, settings.getProjectDir()), resultConsumer);
             }
         } finally {
             mutator.afterScenario();

--- a/src/main/java/org/gradle/profiler/BazelScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/BazelScenarioInvoker.java
@@ -1,0 +1,60 @@
+package org.gradle.profiler;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.gradle.profiler.Logging.startOperation;
+import static org.gradle.profiler.Phase.MEASURE;
+import static org.gradle.profiler.Phase.WARM_UP;
+
+public class BazelScenarioInvoker extends ScenarioInvoker<BazelScenarioDefinition> {
+    @Override
+    void run(BazelScenarioDefinition scenario, InvocationSettings settings, BenchmarkResultCollector benchmarkResults) {
+        String bazelHome = System.getenv("BAZEL_HOME");
+        String bazelExe = bazelHome == null ? "bazel" : bazelHome + "/bin/bazel";
+
+        List<String> targets = new ArrayList<>(scenario.getTargets());
+
+        System.out.println();
+        System.out.println("* Bazel targets: " + targets);
+
+        List<String> commandLine = new ArrayList<>();
+        commandLine.add(bazelExe);
+        commandLine.add("build");
+        commandLine.addAll(targets);
+
+        BuildMutator mutator = scenario.getBuildMutator().get();
+        mutator.beforeScenario();
+        try {
+            Consumer<BuildInvocationResult> resultConsumer = benchmarkResults.version(scenario);
+            for (int i = 0; i < scenario.getWarmUpCount(); i++) {
+                String displayName = WARM_UP.displayBuildNumber(i + 1);
+                mutator.beforeBuild();
+                tryRun(() -> {
+                    startOperation("Running " + displayName);
+                    Timer timer = new Timer();
+                    new CommandExec().inDir(settings.getProjectDir()).run(commandLine);
+                    Duration executionTime = timer.elapsed();
+                    Main.printExecutionTime(executionTime);
+                    resultConsumer.accept(new BuildInvocationResult(displayName, executionTime, null));
+                }, mutator::afterBuild);
+            }
+            for (int i = 0; i < scenario.getBuildCount(); i++) {
+                String displayName = MEASURE.displayBuildNumber(i + 1);
+                mutator.beforeBuild();
+                tryRun(() -> {
+                    startOperation("Running " + displayName);
+                    Timer timer = new Timer();
+                    new CommandExec().inDir(settings.getProjectDir()).run(commandLine);
+                    Duration executionTime = timer.elapsed();
+                    Main.printExecutionTime(executionTime);
+                    resultConsumer.accept(new BuildInvocationResult(displayName, executionTime, null));
+                }, mutator::afterBuild);
+            }
+        } finally {
+            mutator.afterScenario();
+        }
+    }
+}

--- a/src/main/java/org/gradle/profiler/BuckScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/BuckScenarioInvoker.java
@@ -1,0 +1,72 @@
+package org.gradle.profiler;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import static org.gradle.profiler.Logging.startOperation;
+import static org.gradle.profiler.Phase.MEASURE;
+import static org.gradle.profiler.Phase.WARM_UP;
+
+public class BuckScenarioInvoker extends ScenarioInvoker<BuckScenarioDefinition> {
+    @Override
+    void run(BuckScenarioDefinition scenario, InvocationSettings settings, BenchmarkResultCollector benchmarkResults) {
+        String buckwExe = settings.getProjectDir() + "/buckw";
+        List<String> targets = new ArrayList<>(scenario.getTargets());
+        if (scenario.getType() != null) {
+            Logging.startOperation("Query targets with type " + scenario.getType());
+            List<String> commandLine = new ArrayList<>();
+            commandLine.add(buckwExe);
+            commandLine.add("targets");
+            if (!scenario.getType().equals("all")) {
+                commandLine.add("--type");
+                commandLine.add(scenario.getType());
+            }
+            String output = new CommandExec().inDir(settings.getProjectDir()).runAndCollectOutput(commandLine);
+            targets.addAll(Arrays.stream(output.split("\\n")).filter(s -> s.matches("//\\w+.*")).collect(Collectors.toList()));
+        }
+
+        System.out.println();
+        System.out.println("* Buck targets: " + targets);
+
+        List<String> commandLine = new ArrayList<>();
+        commandLine.add(buckwExe);
+        commandLine.add("build");
+        commandLine.addAll(targets);
+
+        BuildMutator mutator = scenario.getBuildMutator().get();
+        mutator.beforeScenario();
+        try {
+            Consumer<BuildInvocationResult> resultConsumer = benchmarkResults.version(scenario);
+            for (int i = 0; i < scenario.getWarmUpCount(); i++) {
+                String displayName = WARM_UP.displayBuildNumber(i + 1);
+                mutator.beforeBuild();
+                tryRun(() -> {
+                    startOperation("Running " + displayName);
+                    Timer timer = new Timer();
+                    new CommandExec().inDir(settings.getProjectDir()).run(commandLine);
+                    Duration executionTime = timer.elapsed();
+                    Main.printExecutionTime(executionTime);
+                    resultConsumer.accept(new BuildInvocationResult(displayName, executionTime, null));
+                }, mutator::afterBuild);
+            }
+            for (int i = 0; i < scenario.getBuildCount(); i++) {
+                String displayName = MEASURE.displayBuildNumber(i + 1);
+                mutator.beforeBuild();
+                tryRun(() -> {
+                    startOperation("Running " + displayName);
+                    Timer timer = new Timer();
+                    new CommandExec().inDir(settings.getProjectDir()).run(commandLine);
+                    Duration executionTime = timer.elapsed();
+                    Main.printExecutionTime(executionTime);
+                    resultConsumer.accept(new BuildInvocationResult(displayName, executionTime, null));
+                }, mutator::afterBuild);
+            }
+        } finally {
+            mutator.afterScenario();
+        }
+    }
+}

--- a/src/main/java/org/gradle/profiler/BuildAction.java
+++ b/src/main/java/org/gradle/profiler/BuildAction.java
@@ -3,7 +3,7 @@ package org.gradle.profiler;
 import java.util.List;
 
 /**
- * Runs some particular action against a build.
+ * Runs some particular action against a Gradle build.
  */
 public interface BuildAction {
     /**
@@ -14,5 +14,5 @@ public interface BuildAction {
     /**
      * Runs the measured work of this action.
      */
-    void run(BuildInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs);
+    void run(GradleInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs);
 }

--- a/src/main/java/org/gradle/profiler/BuildAction.java
+++ b/src/main/java/org/gradle/profiler/BuildAction.java
@@ -6,13 +6,41 @@ import java.util.List;
  * Runs some particular action against a Gradle build.
  */
 public interface BuildAction {
+    BuildAction NO_OP = new BuildAction() {
+        @Override
+        public boolean isDoesSomething() {
+            return false;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "do nothing";
+        }
+
+        @Override
+        public String getShortDisplayName() {
+            return "nothing";
+        }
+
+        @Override
+        public void run(GradleInvoker buildInvoker, List<String> gradleArgs, List<String> jvmArgs) {
+        }
+    };
+
+    boolean isDoesSomething();
+
     /**
      * A human consumable display name for this action.
      */
     String getDisplayName();
 
     /**
+     * A human consumable display name for this action.
+     */
+    String getShortDisplayName();
+
+    /**
      * Runs the measured work of this action.
      */
-    void run(GradleInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs);
+    void run(GradleInvoker buildInvoker, List<String> gradleArgs, List<String> jvmArgs);
 }

--- a/src/main/java/org/gradle/profiler/BuildUnderTestInvoker.java
+++ b/src/main/java/org/gradle/profiler/BuildUnderTestInvoker.java
@@ -7,14 +7,14 @@ import java.util.function.Consumer;
 
 import static org.gradle.profiler.Logging.startOperation;
 
-public class BuildActionInvoker {
+public class BuildUnderTestInvoker {
     private final List<String> jvmArgs;
     private final List<String> gradleArgs;
     private final PidInstrumentation pidInstrumentation;
     private final Consumer<BuildInvocationResult> resultsConsumer;
-    private final BuildInvoker buildInvoker;
+    private final GradleInvoker buildInvoker;
 
-    public BuildActionInvoker(List<String> jvmArgs, List<String> gradleArgs, BuildInvoker buildInvoker, PidInstrumentation pidInstrumentation, Consumer<BuildInvocationResult> resultsConsumer) {
+    public BuildUnderTestInvoker(List<String> jvmArgs, List<String> gradleArgs, GradleInvoker buildInvoker, PidInstrumentation pidInstrumentation, Consumer<BuildInvocationResult> resultsConsumer) {
         this.jvmArgs = jvmArgs;
         this.gradleArgs = gradleArgs;
         this.buildInvoker = buildInvoker;
@@ -22,6 +22,9 @@ public class BuildActionInvoker {
         this.resultsConsumer = resultsConsumer;
     }
 
+    /**
+     * Runs a single invocation of a build.
+     */
     public BuildInvocationResult runBuild(Phase phase, int buildNumber, BuildStep buildStep, List<String> tasks, BuildAction buildAction) {
         String displayName = phase.displayBuildNumber(buildNumber);
         startOperation("Running " + displayName + " with " + buildStep.name().toLowerCase() + " tasks " + tasks);
@@ -44,25 +47,25 @@ public class BuildActionInvoker {
         return results;
     }
 
-    public BuildActionInvoker notInstrumented() {
+    public BuildUnderTestInvoker notInstrumented() {
         return copy(jvmArgs, gradleArgs, buildInvocationResult -> { });
     }
 
-    public BuildActionInvoker withJvmArgs(List<String> jvmArgs) {
+    public BuildUnderTestInvoker withJvmArgs(List<String> jvmArgs) {
         if (jvmArgs.equals(this.jvmArgs)) {
             return this;
         }
         return copy(jvmArgs, gradleArgs, resultsConsumer);
     }
 
-    public BuildActionInvoker withGradleArgs(List<String> gradleArgs) {
+    public BuildUnderTestInvoker withGradleArgs(List<String> gradleArgs) {
         if (gradleArgs.equals(this.gradleArgs)) {
             return this;
         }
         return copy(jvmArgs, gradleArgs, resultsConsumer);
     }
 
-    private BuildActionInvoker copy(List<String> jvmArgs, List<String> gradleArgs, Consumer<BuildInvocationResult> resultsConsumer) {
-        return new BuildActionInvoker(jvmArgs, gradleArgs, buildInvoker, pidInstrumentation, resultsConsumer);
+    private BuildUnderTestInvoker copy(List<String> jvmArgs, List<String> gradleArgs, Consumer<BuildInvocationResult> resultsConsumer) {
+        return new BuildUnderTestInvoker(jvmArgs, gradleArgs, buildInvoker, pidInstrumentation, resultsConsumer);
     }
 }

--- a/src/main/java/org/gradle/profiler/BuildUnderTestInvoker.java
+++ b/src/main/java/org/gradle/profiler/BuildUnderTestInvoker.java
@@ -3,23 +3,18 @@ package org.gradle.profiler;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
-
-import static org.gradle.profiler.Logging.startOperation;
 
 public class BuildUnderTestInvoker {
     private final List<String> jvmArgs;
     private final List<String> gradleArgs;
     private final PidInstrumentation pidInstrumentation;
-    private final Consumer<BuildInvocationResult> resultsConsumer;
     private final GradleInvoker buildInvoker;
 
-    public BuildUnderTestInvoker(List<String> jvmArgs, List<String> gradleArgs, GradleInvoker buildInvoker, PidInstrumentation pidInstrumentation, Consumer<BuildInvocationResult> resultsConsumer) {
+    public BuildUnderTestInvoker(List<String> jvmArgs, List<String> gradleArgs, GradleInvoker buildInvoker, PidInstrumentation pidInstrumentation) {
         this.jvmArgs = jvmArgs;
         this.gradleArgs = gradleArgs;
         this.buildInvoker = buildInvoker;
         this.pidInstrumentation = pidInstrumentation;
-        this.resultsConsumer = resultsConsumer;
     }
 
     /**
@@ -27,7 +22,6 @@ public class BuildUnderTestInvoker {
      */
     public BuildInvocationResult runBuild(Phase phase, int buildNumber, BuildStep buildStep, BuildAction buildAction) {
         String displayName = phase.displayBuildNumber(buildNumber);
-        startOperation("Running " + displayName + " with " + buildStep.name().toLowerCase() + " " + buildAction.getDisplayName());
 
         List<String> jvmArgs = new ArrayList<>(this.jvmArgs);
         jvmArgs.add("-Dorg.gradle.profiler.phase=" + phase);
@@ -40,32 +34,25 @@ public class BuildUnderTestInvoker {
 
         String pid = pidInstrumentation.getPidForLastBuild();
         Logging.detailed().println("Used daemon with pid " + pid);
-        Main.printExecutionTime(executionTime);
 
-        BuildInvocationResult results = new BuildInvocationResult(displayName, executionTime, pid);
-        resultsConsumer.accept(results);
-        return results;
-    }
-
-    public BuildUnderTestInvoker notInstrumented() {
-        return copy(jvmArgs, gradleArgs, buildInvocationResult -> { });
+        return new BuildInvocationResult(displayName, executionTime, pid);
     }
 
     public BuildUnderTestInvoker withJvmArgs(List<String> jvmArgs) {
         if (jvmArgs.equals(this.jvmArgs)) {
             return this;
         }
-        return copy(jvmArgs, gradleArgs, resultsConsumer);
+        return copy(jvmArgs, gradleArgs);
     }
 
     public BuildUnderTestInvoker withGradleArgs(List<String> gradleArgs) {
         if (gradleArgs.equals(this.gradleArgs)) {
             return this;
         }
-        return copy(jvmArgs, gradleArgs, resultsConsumer);
+        return copy(jvmArgs, gradleArgs);
     }
 
-    private BuildUnderTestInvoker copy(List<String> jvmArgs, List<String> gradleArgs, Consumer<BuildInvocationResult> resultsConsumer) {
-        return new BuildUnderTestInvoker(jvmArgs, gradleArgs, buildInvoker, pidInstrumentation, resultsConsumer);
+    private BuildUnderTestInvoker copy(List<String> jvmArgs, List<String> gradleArgs) {
+        return new BuildUnderTestInvoker(jvmArgs, gradleArgs, buildInvoker, pidInstrumentation);
     }
 }

--- a/src/main/java/org/gradle/profiler/BuildUnderTestInvoker.java
+++ b/src/main/java/org/gradle/profiler/BuildUnderTestInvoker.java
@@ -25,9 +25,9 @@ public class BuildUnderTestInvoker {
     /**
      * Runs a single invocation of a build.
      */
-    public BuildInvocationResult runBuild(Phase phase, int buildNumber, BuildStep buildStep, List<String> tasks, BuildAction buildAction) {
+    public BuildInvocationResult runBuild(Phase phase, int buildNumber, BuildStep buildStep, BuildAction buildAction) {
         String displayName = phase.displayBuildNumber(buildNumber);
-        startOperation("Running " + displayName + " with " + buildStep.name().toLowerCase() + " tasks " + tasks);
+        startOperation("Running " + displayName + " with " + buildStep.name().toLowerCase() + " " + buildAction.getDisplayName());
 
         List<String> jvmArgs = new ArrayList<>(this.jvmArgs);
         jvmArgs.add("-Dorg.gradle.profiler.phase=" + phase);
@@ -35,7 +35,7 @@ public class BuildUnderTestInvoker {
         jvmArgs.add("-Dorg.gradle.profiler.step=" + buildStep);
 
         Timer timer = new Timer();
-        buildAction.run(buildInvoker, tasks, gradleArgs, jvmArgs);
+        buildAction.run(buildInvoker, gradleArgs, jvmArgs);
         Duration executionTime = timer.elapsed();
 
         String pid = pidInstrumentation.getPidForLastBuild();

--- a/src/main/java/org/gradle/profiler/CliInvoker.java
+++ b/src/main/java/org/gradle/profiler/CliInvoker.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-public class CliInvoker extends BuildInvoker {
+public class CliInvoker extends GradleInvoker {
     private final GradleBuildConfiguration gradleBuildConfiguration;
     private final File javaHome;
     private final File projectDir;

--- a/src/main/java/org/gradle/profiler/GradleInvoker.java
+++ b/src/main/java/org/gradle/profiler/GradleInvoker.java
@@ -6,7 +6,10 @@ import org.gradle.tooling.BuildActionExecuter;
 import java.util.List;
 import java.util.function.Consumer;
 
-public abstract class BuildInvoker {
+/**
+ * Performs operations on a build using Gradle.
+ */
+public abstract class GradleInvoker {
     public abstract void runTasks(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs);
 
     public abstract void loadToolingModel(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs, Class<?> toolingModel);

--- a/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
@@ -5,25 +5,22 @@ import java.io.PrintStream;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 public class GradleScenarioDefinition extends ScenarioDefinition {
 
     private final Invoker invoker;
     private final GradleBuildConfiguration buildConfiguration;
     private final BuildAction buildAction;
-    private final List<String> cleanupTasks;
-    private final List<String> tasks;
+    private final BuildAction cleanupAction;
     private final List<String> gradleArgs;
     private final Map<String, String> systemProperties;
 
-    public GradleScenarioDefinition(String name, Invoker invoker, GradleBuildConfiguration buildConfiguration, BuildAction buildAction, List<String> tasks, List<String> cleanupTasks, List<String> gradleArgs, Map<String, String> systemProperties, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
+    public GradleScenarioDefinition(String name, Invoker invoker, GradleBuildConfiguration buildConfiguration, BuildAction buildAction,  BuildAction cleanupAction, List<String> gradleArgs, Map<String, String> systemProperties, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
         super(name, buildMutator, warmUpCount, buildCount, outputDir);
         this.invoker = invoker;
         this.buildAction = buildAction;
-        this.tasks = tasks;
         this.buildConfiguration = buildConfiguration;
-        this.cleanupTasks = cleanupTasks;
+        this.cleanupAction = cleanupAction;
         this.gradleArgs = gradleArgs;
         this.systemProperties = systemProperties;
     }
@@ -45,7 +42,7 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
 
     @Override
     public String getTasksDisplayName() {
-        return tasks.stream().collect(Collectors.joining(" "));
+        return buildAction.getShortDisplayName();
     }
 
     public List<String> getGradleArgs() {
@@ -56,16 +53,12 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
         return invoker;
     }
 
-    public List<String> getTasks() {
-        return tasks;
-    }
-
     public BuildAction getAction() {
         return buildAction;
     }
 
-    public List<String> getCleanupTasks() {
-        return cleanupTasks;
+    public BuildAction getCleanupAction() {
+        return cleanupAction;
     }
 
     public GradleBuildConfiguration getBuildConfiguration() {
@@ -79,9 +72,9 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
     @Override
     protected void printDetail(PrintStream out) {
         out.println("  " + getBuildConfiguration().getGradleVersion() + " (" + getBuildConfiguration().getGradleHome() + ")");
-        out.println("  Run using: " + getInvoker() + " to " + buildAction.getDisplayName());
-        out.println("  Cleanup Tasks: " + getCleanupTasks());
-        out.println("  Tasks: " + getTasks());
+        out.println("  Run using: " + getInvoker());
+        out.println("  Run: " + getAction().getDisplayName());
+        out.println("  Cleanup: " + getCleanupAction().getDisplayName());
         out.println("  Gradle args: " + getGradleArgs());
         if (!getSystemProperties().isEmpty()) {
             out.println("  System properties:");

--- a/src/main/java/org/gradle/profiler/GradleScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/GradleScenarioInvoker.java
@@ -1,0 +1,207 @@
+package org.gradle.profiler;
+
+import org.apache.commons.io.FileUtils;
+import org.gradle.tooling.GradleConnector;
+import org.gradle.tooling.ProjectConnection;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import static org.gradle.profiler.BuildStep.BUILD;
+import static org.gradle.profiler.BuildStep.CLEANUP;
+import static org.gradle.profiler.Phase.MEASURE;
+import static org.gradle.profiler.Phase.WARM_UP;
+
+public class GradleScenarioInvoker extends ScenarioInvoker<GradleScenarioDefinition> {
+    private final DaemonControl daemonControl;
+    private final PidInstrumentation pidInstrumentation;
+
+    public GradleScenarioInvoker(DaemonControl daemonControl, PidInstrumentation pidInstrumentation) {
+        this.daemonControl = daemonControl;
+        this.pidInstrumentation = pidInstrumentation;
+    }
+
+    @Override
+    public void run(GradleScenarioDefinition scenario, InvocationSettings settings, BenchmarkResultCollector benchmarkResults) throws IOException, InterruptedException {
+        ScenarioSettings scenarioSettings = new ScenarioSettings(settings, scenario);
+        FileUtils.forceMkdir(scenario.getOutputDir());
+        JvmArgsCalculator allBuildsJvmArgsCalculator = settings.getProfiler().newJvmArgsCalculator(scenarioSettings);
+        GradleArgsCalculator allBuildsGradleArgsCalculator = settings.getProfiler().newGradleArgsCalculator(scenarioSettings);
+
+        BuildAction cleanupAction = scenario.getCleanupAction();
+        GradleBuildConfiguration buildConfiguration = scenario.getBuildConfiguration();
+
+        daemonControl.stop(buildConfiguration);
+
+        BuildMutator mutator = scenario.getBuildMutator().get();
+        GradleConnector connector = GradleConnector.newConnector()
+            .useInstallation(buildConfiguration.getGradleHome())
+            .useGradleUserHomeDir(settings.getGradleUserHome().getAbsoluteFile());
+        ProjectConnection projectConnection = connector.forProjectDirectory(settings.getProjectDir()).connect();
+        try {
+            buildConfiguration.printVersionInfo();
+            List<String> allBuildsJvmArgs = new ArrayList<>(buildConfiguration.getJvmArguments());
+            for (Map.Entry<String, String> entry : scenario.getSystemProperties().entrySet()) {
+                allBuildsJvmArgs.add("-D" + entry.getKey() + "=" + entry.getValue());
+            }
+            allBuildsJvmArgs.add("-Dorg.gradle.profiler.scenario=" + scenario.getName());
+            allBuildsJvmArgsCalculator.calculateJvmArgs(allBuildsJvmArgs);
+            logJvmArgs(allBuildsJvmArgs);
+            List<String> allBuildsGradleArgs = new ArrayList<>(pidInstrumentation.getArgs());
+            allBuildsGradleArgs.add("--gradle-user-home");
+            allBuildsGradleArgs.add(settings.getGradleUserHome().getAbsolutePath());
+            for (Map.Entry<String, String> entry : scenario.getSystemProperties().entrySet()) {
+                allBuildsGradleArgs.add("-D" + entry.getKey() + "=" + entry.getValue());
+            }
+            allBuildsGradleArgs.addAll(scenario.getGradleArgs());
+            if (settings.isDryRun()) {
+                allBuildsGradleArgs.add("--dry-run");
+            }
+            allBuildsGradleArgsCalculator.calculateGradleArgs(allBuildsGradleArgs);
+            logGradleArgs(allBuildsGradleArgs);
+
+            Consumer<BuildInvocationResult> resultsCollector = benchmarkResults.version(scenario);
+            GradleInvoker buildInvoker;
+            switch (scenario.getInvoker()) {
+                case NoDaemon:
+                    buildInvoker = new CliInvoker(buildConfiguration, buildConfiguration.getJavaHome(), settings.getProjectDir(), false);
+                    break;
+                case ToolingApi:
+                    buildInvoker = new ToolingApiInvoker(projectConnection);
+                    break;
+                case Cli:
+                    buildInvoker = new CliInvoker(buildConfiguration, buildConfiguration.getJavaHome(), settings.getProjectDir(), true);
+                    break;
+                default:
+                    throw new IllegalArgumentException();
+            }
+            BuildUnderTestInvoker invoker = new BuildUnderTestInvoker(allBuildsJvmArgs, allBuildsGradleArgs, buildInvoker, pidInstrumentation, resultsCollector);
+
+            mutator.beforeScenario();
+
+            BuildInvocationResult results = null;
+            String pid = null;
+
+            for (int i = 1; i <= scenario.getWarmUpCount(); i++) {
+                final int counter = i;
+                beforeBuild(WARM_UP, counter, invoker, cleanupAction, mutator);
+                results = tryRun(() -> invoker.runBuild(WARM_UP, counter, BUILD, scenario.getAction()), mutator::afterBuild);
+                if (pid == null) {
+                    pid = results.getDaemonPid();
+                } else {
+                    checkPid(pid, results.getDaemonPid(), scenario.getInvoker());
+                }
+            }
+
+            ProfilerController control = settings.getProfiler().newController(pid, scenarioSettings);
+
+            List<String> instrumentedBuildJvmArgs = new ArrayList<>(allBuildsJvmArgs);
+            settings.getProfiler().newInstrumentedBuildsJvmArgsCalculator(scenarioSettings).calculateJvmArgs(instrumentedBuildJvmArgs);
+
+            List<String> instrumentedBuildGradleArgs = new ArrayList<>(allBuildsGradleArgs);
+            settings.getProfiler().newInstrumentedBuildsGradleArgsCalculator(scenarioSettings).calculateGradleArgs(instrumentedBuildGradleArgs);
+
+            Logging.detailed().println();
+            Logging.detailed().println("* Using args for instrumented builds:");
+            if (!instrumentedBuildJvmArgs.equals(allBuildsJvmArgs)) {
+                logJvmArgs(instrumentedBuildJvmArgs);
+            }
+            if (!instrumentedBuildGradleArgs.equals(allBuildsGradleArgs)) {
+                logGradleArgs(instrumentedBuildGradleArgs);
+            }
+
+            BuildUnderTestInvoker instrumentedBuildInvoker = invoker.withJvmArgs(instrumentedBuildJvmArgs).withGradleArgs(instrumentedBuildGradleArgs);
+
+            if (settings.isProfile()) {
+                if (pid == null) {
+                    throw new IllegalStateException("Using the --profile option requires at least one warm-up");
+                }
+                Logging.startOperation("Starting profiler for daemon with pid " + pid);
+                control.startSession();
+            }
+            for (int i = 1; i <= scenario.getBuildCount(); i++) {
+                final int counter = i;
+                beforeBuild(MEASURE, counter, invoker, cleanupAction, mutator);
+                results = tryRun(() -> {
+                    if (settings.isProfile() && (counter == 1 || cleanupAction.isDoesSomething())) {
+                        try {
+                            control.startRecording();
+                        } catch (IOException | InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    BuildInvocationResult result = instrumentedBuildInvoker.runBuild(MEASURE, counter, BUILD, scenario.getAction());
+
+                    if (settings.isProfile() && (counter == scenario.getBuildCount() || cleanupAction.isDoesSomething())) {
+                        try {
+                            control.stopRecording();
+                        } catch (IOException | InterruptedException e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    return result;
+                }, mutator::afterBuild);
+            }
+
+            if (settings.isProfile()) {
+                Logging.startOperation("Stopping profiler for daemon with pid " + pid);
+                control.stopSession();
+            }
+            if (settings.isBenchmark()) {
+                benchmarkResults.write();
+            }
+            Objects.requireNonNull(results);
+            checkPid(pid, results.getDaemonPid(), scenario.getInvoker());
+        } finally {
+            mutator.afterScenario();
+            projectConnection.close();
+            daemonControl.stop(buildConfiguration);
+        }
+    }
+
+    private void logGradleArgs(List<String> allBuildsGradleArgs) {
+        Logging.detailed().println("Gradle args:");
+        for (String arg : allBuildsGradleArgs) {
+            Logging.detailed().println("  " + arg);
+        }
+    }
+
+    private void logJvmArgs(List<String> allBuildsJvmArgs) {
+        Logging.detailed().println("JVM args:");
+        for (String jvmArg : allBuildsJvmArgs) {
+            Logging.detailed().println("  " + jvmArg);
+        }
+    }
+
+    private void beforeBuild(Phase phase, int buildNumber, BuildUnderTestInvoker invoker, BuildAction cleanupAction, BuildMutator mutator) {
+        if (cleanupAction.isDoesSomething()) {
+            mutator.beforeCleanup();
+            tryRun(() -> invoker.notInstrumented().runBuild(phase, buildNumber, CLEANUP, cleanupAction), mutator::afterCleanup);
+        }
+        mutator.beforeBuild();
+    }
+
+    private static void checkPid(String expected, String actual, Invoker invoker) {
+        switch (invoker) {
+            case Cli:
+            case ToolingApi:
+                if (!expected.equals(actual)) {
+                    throw new RuntimeException("Multiple Gradle daemons were used.");
+                }
+                break;
+            case NoDaemon:
+                if (expected.equals(actual)) {
+                    throw new RuntimeException("Gradle daemon was used.");
+                }
+                break;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+}

--- a/src/main/java/org/gradle/profiler/LoadToolingModelAction.java
+++ b/src/main/java/org/gradle/profiler/LoadToolingModelAction.java
@@ -15,7 +15,7 @@ public class LoadToolingModelAction implements BuildAction {
     }
 
     @Override
-    public void run(BuildInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
+    public void run(GradleInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
         buildInvoker.loadToolingModel(tasks, gradleArgs, jvmArgs, toolingModel);
     }
 }

--- a/src/main/java/org/gradle/profiler/LoadToolingModelAction.java
+++ b/src/main/java/org/gradle/profiler/LoadToolingModelAction.java
@@ -4,9 +4,21 @@ import java.util.List;
 
 public class LoadToolingModelAction implements BuildAction {
     private final Class<?> toolingModel;
+    private final List<String> tasks;
 
-    public LoadToolingModelAction(Class<?> toolingModel) {
+    public LoadToolingModelAction(Class<?> toolingModel, List<String> tasks) {
         this.toolingModel = toolingModel;
+        this.tasks = tasks;
+    }
+
+    @Override
+    public boolean isDoesSomething() {
+        return true;
+    }
+
+    @Override
+    public String getShortDisplayName() {
+        return "model " + toolingModel.getSimpleName();
     }
 
     @Override
@@ -15,7 +27,7 @@ public class LoadToolingModelAction implements BuildAction {
     }
 
     @Override
-    public void run(GradleInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
+    public void run(GradleInvoker buildInvoker, List<String> gradleArgs, List<String> jvmArgs) {
         buildInvoker.loadToolingModel(tasks, gradleArgs, jvmArgs, toolingModel);
     }
 }

--- a/src/main/java/org/gradle/profiler/Main.java
+++ b/src/main/java/org/gradle/profiler/Main.java
@@ -127,10 +127,6 @@ public class Main {
         }
     }
 
-    public static void printExecutionTime(Duration executionTime) {
-        System.out.println("Execution time " + executionTime.toMillis() + " ms");
-    }
-
     static class ScenarioFailedException extends RuntimeException {
         public ScenarioFailedException(Throwable cause) {
             super(cause);

--- a/src/main/java/org/gradle/profiler/Main.java
+++ b/src/main/java/org/gradle/profiler/Main.java
@@ -154,7 +154,7 @@ public class Main {
             logGradleArgs(allBuildsGradleArgs);
 
             Consumer<BuildInvocationResult> resultsCollector = benchmarkResults.version(scenario);
-            BuildInvoker buildInvoker;
+            GradleInvoker buildInvoker;
             switch (scenario.getInvoker()) {
                 case NoDaemon:
                     buildInvoker = new CliInvoker(buildConfiguration, buildConfiguration.getJavaHome(), settings.getProjectDir(), false);
@@ -168,7 +168,7 @@ public class Main {
                 default:
                     throw new IllegalArgumentException();
             }
-            BuildActionInvoker invoker = new BuildActionInvoker(allBuildsJvmArgs, allBuildsGradleArgs, buildInvoker, pidInstrumentation, resultsCollector);
+            BuildUnderTestInvoker invoker = new BuildUnderTestInvoker(allBuildsJvmArgs, allBuildsGradleArgs, buildInvoker, pidInstrumentation, resultsCollector);
 
             mutator.beforeScenario();
 
@@ -203,7 +203,7 @@ public class Main {
                 logGradleArgs(instrumentedBuildGradleArgs);
             }
 
-            BuildActionInvoker instrumentedBuildInvoker = invoker.withJvmArgs(instrumentedBuildJvmArgs).withGradleArgs(instrumentedBuildGradleArgs);
+            BuildUnderTestInvoker instrumentedBuildInvoker = invoker.withJvmArgs(instrumentedBuildJvmArgs).withGradleArgs(instrumentedBuildGradleArgs);
 
             if (settings.isProfile()) {
                 if (pid == null) {
@@ -438,7 +438,7 @@ public class Main {
         }, after);
     }
 
-    private static void beforeBuild(Phase phase, int buildNumber, BuildActionInvoker invoker, List<String> cleanupTasks, BuildMutator mutator) {
+    private static void beforeBuild(Phase phase, int buildNumber, BuildUnderTestInvoker invoker, List<String> cleanupTasks, BuildMutator mutator) {
         if (!cleanupTasks.isEmpty()) {
             mutator.beforeCleanup();
             tryRun(() -> invoker.notInstrumented().runBuild(phase, buildNumber, CLEANUP, cleanupTasks, new RunTasksAction()), mutator::afterCleanup);

--- a/src/main/java/org/gradle/profiler/MavenScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/MavenScenarioInvoker.java
@@ -1,0 +1,58 @@
+package org.gradle.profiler;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.gradle.profiler.Logging.startOperation;
+import static org.gradle.profiler.Phase.MEASURE;
+import static org.gradle.profiler.Phase.WARM_UP;
+
+public class MavenScenarioInvoker extends ScenarioInvoker<MavenScenarioDefinition> {
+    @Override
+    void run(MavenScenarioDefinition scenario, InvocationSettings settings, BenchmarkResultCollector benchmarkResults) throws IOException, InterruptedException {
+        String mavenHome = System.getenv("MAVEN_HOME");
+        String mvn = mavenHome == null ? "mvn" : mavenHome + "/bin/mvn";
+
+        System.out.println();
+        System.out.println("* Maven targets: " + scenario.getTargets());
+
+        List<String> commandLine = new ArrayList<>();
+        commandLine.add(mvn);
+        commandLine.addAll(scenario.getTargets());
+
+        BuildMutator mutator = scenario.getBuildMutator().get();
+        mutator.beforeScenario();
+        try {
+            Consumer<BuildInvocationResult> resultConsumer = benchmarkResults.version(scenario);
+            for (int i = 0; i < scenario.getWarmUpCount(); i++) {
+                String displayName = WARM_UP.displayBuildNumber(i + 1);
+                mutator.beforeBuild();
+                tryRun(() -> {
+                    startOperation("Running " + displayName);
+                    Timer timer = new Timer();
+                    new CommandExec().inDir(settings.getProjectDir()).run(commandLine);
+                    Duration executionTime = timer.elapsed();
+                    Main.printExecutionTime(executionTime);
+                    resultConsumer.accept(new BuildInvocationResult(displayName, executionTime, null));
+                }, mutator::afterBuild);
+            }
+            for (int i = 0; i < scenario.getBuildCount(); i++) {
+                String displayName = MEASURE.displayBuildNumber(i + 1);
+                mutator.beforeBuild();
+                tryRun(() -> {
+                    startOperation("Running " + displayName);
+                    Timer timer = new Timer();
+                    new CommandExec().inDir(settings.getProjectDir()).run(commandLine);
+                    Duration executionTime = timer.elapsed();
+                    Main.printExecutionTime(executionTime);
+                    resultConsumer.accept(new BuildInvocationResult(displayName, executionTime, null));
+                }, mutator::afterBuild);
+            }
+        } finally {
+            mutator.afterScenario();
+        }
+    }
+}

--- a/src/main/java/org/gradle/profiler/MavenScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/MavenScenarioInvoker.java
@@ -1,18 +1,15 @@
 package org.gradle.profiler;
 
-import java.io.IOException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Consumer;
 
-import static org.gradle.profiler.Logging.startOperation;
 import static org.gradle.profiler.Phase.MEASURE;
 import static org.gradle.profiler.Phase.WARM_UP;
 
 public class MavenScenarioInvoker extends ScenarioInvoker<MavenScenarioDefinition> {
     @Override
-    void run(MavenScenarioDefinition scenario, InvocationSettings settings, BenchmarkResultCollector benchmarkResults) throws IOException, InterruptedException {
+    void run(MavenScenarioDefinition scenario, InvocationSettings settings, BenchmarkResultCollector benchmarkResults) {
         String mavenHome = System.getenv("MAVEN_HOME");
         String mvn = mavenHome == null ? "mvn" : mavenHome + "/bin/mvn";
 
@@ -29,27 +26,11 @@ public class MavenScenarioInvoker extends ScenarioInvoker<MavenScenarioDefinitio
             Consumer<BuildInvocationResult> resultConsumer = benchmarkResults.version(scenario);
             for (int i = 0; i < scenario.getWarmUpCount(); i++) {
                 String displayName = WARM_UP.displayBuildNumber(i + 1);
-                mutator.beforeBuild();
-                tryRun(() -> {
-                    startOperation("Running " + displayName);
-                    Timer timer = new Timer();
-                    new CommandExec().inDir(settings.getProjectDir()).run(commandLine);
-                    Duration executionTime = timer.elapsed();
-                    Main.printExecutionTime(executionTime);
-                    resultConsumer.accept(new BuildInvocationResult(displayName, executionTime, null));
-                }, mutator::afterBuild);
+                runMeasured(displayName, mutator, measureCommandLineExecution(displayName, commandLine, settings.getProjectDir()), resultConsumer);
             }
             for (int i = 0; i < scenario.getBuildCount(); i++) {
                 String displayName = MEASURE.displayBuildNumber(i + 1);
-                mutator.beforeBuild();
-                tryRun(() -> {
-                    startOperation("Running " + displayName);
-                    Timer timer = new Timer();
-                    new CommandExec().inDir(settings.getProjectDir()).run(commandLine);
-                    Duration executionTime = timer.elapsed();
-                    Main.printExecutionTime(executionTime);
-                    resultConsumer.accept(new BuildInvocationResult(displayName, executionTime, null));
-                }, mutator::afterBuild);
+                runMeasured(displayName, mutator, measureCommandLineExecution(displayName, commandLine, settings.getProjectDir()), resultConsumer);
             }
         } finally {
             mutator.afterScenario();

--- a/src/main/java/org/gradle/profiler/RunTasksAction.java
+++ b/src/main/java/org/gradle/profiler/RunTasksAction.java
@@ -9,7 +9,7 @@ public class RunTasksAction implements BuildAction {
     }
 
     @Override
-    public void run(BuildInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
+    public void run(GradleInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
         buildInvoker.runTasks(tasks, gradleArgs, jvmArgs);
     }
 }

--- a/src/main/java/org/gradle/profiler/RunTasksAction.java
+++ b/src/main/java/org/gradle/profiler/RunTasksAction.java
@@ -1,15 +1,38 @@
 package org.gradle.profiler;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class RunTasksAction implements BuildAction {
-    @Override
-    public String getDisplayName() {
-        return "run tasks";
+    private final List<String> tasks;
+
+    public RunTasksAction(List<String> tasks) {
+        this.tasks = tasks;
     }
 
     @Override
-    public void run(GradleInvoker buildInvoker, List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
+    public boolean isDoesSomething() {
+        return true;
+    }
+
+    @Override
+    public String getShortDisplayName() {
+        if (tasks.isEmpty()) {
+            return "default tasks";
+        }
+        return tasks.stream().collect(Collectors.joining(" "));
+    }
+
+    @Override
+    public String getDisplayName() {
+        if (tasks.isEmpty()) {
+            return "run default tasks";
+        }
+        return "run tasks " + getShortDisplayName();
+    }
+
+    @Override
+    public void run(GradleInvoker buildInvoker, List<String> gradleArgs, List<String> jvmArgs) {
         buildInvoker.runTasks(tasks, gradleArgs, jvmArgs);
     }
 }

--- a/src/main/java/org/gradle/profiler/ScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/ScenarioInvoker.java
@@ -1,0 +1,31 @@
+package org.gradle.profiler;
+
+import java.io.IOException;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public abstract class ScenarioInvoker<T extends ScenarioDefinition> {
+    abstract void run(T scenario, InvocationSettings settings, BenchmarkResultCollector benchmarkResults) throws IOException, InterruptedException;
+
+    <T> T tryRun(Supplier<T> action, Consumer<Throwable> after) {
+        Throwable error = null;
+        try {
+            return action.get();
+        } catch (RuntimeException | Error ex) {
+            error = ex;
+            throw ex;
+        } catch (Throwable ex) {
+            error = ex;
+            throw new RuntimeException(ex);
+        } finally {
+            after.accept(error);
+        }
+    }
+
+    void tryRun(Runnable action, Consumer<Throwable> after) {
+        tryRun(() -> {
+            action.run();
+            return null;
+        }, after);
+    }
+}

--- a/src/main/java/org/gradle/profiler/ScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/ScenarioInvoker.java
@@ -1,13 +1,58 @@
 package org.gradle.profiler;
 
+import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import static org.gradle.profiler.Logging.startOperation;
 
 public abstract class ScenarioInvoker<T extends ScenarioDefinition> {
     abstract void run(T scenario, InvocationSettings settings, BenchmarkResultCollector benchmarkResults) throws IOException, InterruptedException;
 
-    <T> T tryRun(Supplier<T> action, Consumer<Throwable> after) {
+    /**
+     * Runs a single measured build and collects the result.
+     */
+    BuildInvocationResult runMeasured(String displayName, BuildMutator mutator, Supplier<? extends BuildInvocationResult> action, Consumer<? super BuildInvocationResult> consumer) {
+        startOperation("Running " + displayName);
+        mutator.beforeBuild();
+        BuildInvocationResult result = tryRun(() -> {
+            BuildInvocationResult result1 = action.get();
+            printExecutionTime(result1.getExecutionTime());
+            return result1;
+        }, mutator::afterBuild);
+        consumer.accept(result);
+        return result;
+    }
+
+    private static void printExecutionTime(Duration executionTime) {
+        System.out.println("Execution time " + executionTime.toMillis() + " ms");
+    }
+
+    /**
+     * Runs a single clean-up build.
+     */
+    void runCleanup(String displayName, BuildMutator mutator, Runnable action) {
+        startOperation("Running cleanup for " + displayName);
+        mutator.beforeCleanup();
+        tryRun(() -> action.run(), mutator::afterCleanup);
+    }
+
+    /**
+     * Returns a {@link Supplier} that returns the result of the given command.
+     */
+    Supplier<BuildInvocationResult> measureCommandLineExecution(String displayName, List<String> commandLine, File workingDir) {
+        return () -> {
+            Timer timer = new Timer();
+            new CommandExec().inDir(workingDir).run(commandLine);
+            Duration executionTime = timer.elapsed();
+            return new BuildInvocationResult(displayName, executionTime, null);
+        };
+    }
+
+    private <T> T tryRun(Supplier<T> action, Consumer<Throwable> after) {
         Throwable error = null;
         try {
             return action.get();
@@ -22,7 +67,7 @@ public abstract class ScenarioInvoker<T extends ScenarioDefinition> {
         }
     }
 
-    void tryRun(Runnable action, Consumer<Throwable> after) {
+    private void tryRun(Runnable action, Consumer<Throwable> after) {
         tryRun(() -> {
             action.run();
             return null;

--- a/src/main/java/org/gradle/profiler/ToolingApiInvoker.java
+++ b/src/main/java/org/gradle/profiler/ToolingApiInvoker.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class ToolingApiInvoker extends BuildInvoker {
+public class ToolingApiInvoker extends GradleInvoker {
     private final ProjectConnection projectConnection;
 
     public ToolingApiInvoker(ProjectConnection projectConnection) {

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -37,7 +37,8 @@ class ScenarioLoaderTest extends Specification {
         expect:
         scenarios*.name == ["default"]
         def scenario = scenarios[0] as GradleScenarioDefinition
-        scenario.tasks == ["help"]
+        scenario.action.tasks == ["help"]
+        scenario.cleanupAction == BuildAction.NO_OP
     }
 
     def "can load single scenario with no tasks defined"() {
@@ -51,7 +52,7 @@ class ScenarioLoaderTest extends Specification {
         def scenarios = loadScenarios(scenarioFile, settings, Mock(GradleBuildConfigurationReader))
         expect:
         def scenario = scenarios[0] as GradleScenarioDefinition
-        scenario.tasks.empty
+        scenario.action.tasks.empty
     }
 
     def "can load tooling model scenarios"() {
@@ -72,11 +73,11 @@ class ScenarioLoaderTest extends Specification {
         def scenario1 = scenarios[0] as GradleScenarioDefinition
         scenario1.action instanceof LoadToolingModelAction
         scenario1.action.toolingModel == IdeaProject
-        scenario1.tasks == []
+        scenario1.action.tasks == []
         def scenario2 = scenarios[1] as GradleScenarioDefinition
         scenario2.action instanceof LoadToolingModelAction
         scenario2.action.toolingModel == IdeaProject
-        scenario2.tasks == ["help"]
+        scenario2.action.tasks == ["help"]
     }
 
     def "can load single Android studio sync scenario"() {
@@ -115,8 +116,8 @@ class ScenarioLoaderTest extends Specification {
         def scenarios = loadScenarios(scenarioFile, settings, Mock(GradleBuildConfigurationReader))
         expect:
         scenarios*.name == ["alma", "bela"]
-        (scenarios[0] as GradleScenarioDefinition).tasks == ["alma"]
-        (scenarios[1] as GradleScenarioDefinition).tasks == ["bela"]
+        (scenarios[0] as GradleScenarioDefinition).action.tasks == ["alma"]
+        (scenarios[1] as GradleScenarioDefinition).action.tasks == ["bela"]
     }
 
     def "loads included config"() {
@@ -140,7 +141,7 @@ class ScenarioLoaderTest extends Specification {
         def scenarios = loadScenarios(scenarioFile, settings, Mock(GradleBuildConfigurationReader))
         expect:
         scenarios*.name == ["alma"]
-        (scenarios[0] as GradleScenarioDefinition).tasks == ["alma"]
+        (scenarios[0] as GradleScenarioDefinition).action.tasks == ["alma"]
     }
 
     def "can load Bazel scenario"() {


### PR DESCRIPTION
This PR contains some refactorings to improve structure and partially address duplication across the integrations with the various build tools:

- Push the tasks to run for a Gradle scenario into the `BuildAction` implementations, so that all Gradle scenarios are modelled consistently regardless of what kind of Gradle invocation is being measured (running tasks, building a model, an "Android Studio sync", etc).
- Split out the build tool specific code from the giant `Main` class into separate implementations of a shared abstraction. This could be further improved to reduce duplication and make the Gradle integration less different to the other build tool integrations.
- Some renames.