### PR TITLE
Add mutation support for Android Layout files

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ A scenario can define changes that should be applied to the source before each b
 - `apply-android-resource-change-to`: Add a string resource to an Android resource file. Each iteration adds a new resource and removes the resource added by the previous iteration.
 - `apply-android-resource-value-change-to`: Change a string resource in an Android resource file.
 - `apply-android-manifest-change-to`: Add a permission to an Android manifest file.
+- `apply-android-layout-change-to`: Add a hidden view with id to an Android layout file. Supports traditional layouts as well as Databinding layouts with a ViewGroup as the root element.
 - `clear-build-cache-before`: Deletes the contents of the build cache before the scenario is executed (`SCENARIO`), before cleanup (`CLEANUP`) or before the build is executed (`BUILD`).
 - `clear-transform-cache-before`: Deletes the contents of the transform cache before the scenario is executed (`SCENARIO`), before cleanup (`CLEANUP`) or before the build is executed (`BUILD`).
 - `show-build-cache-size`: Shows the number of files and their size in the build cache before scenario execution, and after each cleanup and build round..

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
     runtimeOnly 'org.slf4j:slf4j-simple:1.7.10'
     testCompile 'org.codehaus.groovy:groovy:2.4.7'
-    testCompile 'org.spockframework:spock-core:1.0-groovy-2.4'
+    testCompile 'org.spockframework:spock-core:1.1-groovy-2.4'
     testRuntime 'cglib:cglib:3.2.6'
     testRuntime 'org.objenesis:objenesis:2.6'
 }

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -25,6 +25,7 @@ class ScenarioLoader {
     private static final String APPLY_NON_ABI_CHANGE_TO = "apply-non-abi-change-to";
     private static final String APPLY_ANDROID_RESOURCE_CHANGE_TO = "apply-android-resource-change-to";
     private static final String APPLY_ANDROID_RESOURCE_VALUE_CHANGE_TO = "apply-android-resource-value-change-to";
+    private static final String APPLY_ANDROID_LAYOUT_CHANGE_TO = "apply-android-layout-change-to";
     private static final String APPLY_PROPERTY_RESOURCE_CHANGE_TO = "apply-property-resource-change-to";
     private static final String APPLY_ANDROID_MANIFEST_CHANGE_TO = "apply-android-manifest-change-to";
     private static final String APPLY_CPP_SOURCE_CHANGE_TO = "apply-cpp-change-to";
@@ -40,7 +41,7 @@ class ScenarioLoader {
     private static final String ANDROID_STUDIO_SYNC = "android-studio-sync";
 
     private static final List<String> ALL_SCENARIO_KEYS = Arrays.asList(
-        VERSIONS, TASKS, CLEANUP_TASKS, GRADLE_ARGS, RUN_USING, SYSTEM_PROPERTIES, WARM_UP_COUNT, APPLY_ABI_CHANGE_TO, APPLY_NON_ABI_CHANGE_TO, APPLY_ANDROID_RESOURCE_CHANGE_TO, APPLY_ANDROID_RESOURCE_VALUE_CHANGE_TO, APPLY_ANDROID_MANIFEST_CHANGE_TO, APPLY_PROPERTY_RESOURCE_CHANGE_TO, APPLY_CPP_SOURCE_CHANGE_TO, APPLY_H_SOURCE_CHANGE_TO, CLEAR_BUILD_CACHE_BEFORE, CLEAR_TRANSFORM_CACHE_BEFORE, SHOW_BUILD_CACHE_SIZE, GIT_CHECKOUT, GIT_REVERT, BAZEL, BUCK, MAVEN, MODEL, ANDROID_STUDIO_SYNC
+        VERSIONS, TASKS, CLEANUP_TASKS, GRADLE_ARGS, RUN_USING, SYSTEM_PROPERTIES, WARM_UP_COUNT, APPLY_ABI_CHANGE_TO, APPLY_NON_ABI_CHANGE_TO, APPLY_ANDROID_RESOURCE_CHANGE_TO, APPLY_ANDROID_RESOURCE_VALUE_CHANGE_TO, APPLY_ANDROID_MANIFEST_CHANGE_TO, APPLY_ANDROID_LAYOUT_CHANGE_TO, APPLY_PROPERTY_RESOURCE_CHANGE_TO, APPLY_CPP_SOURCE_CHANGE_TO, APPLY_H_SOURCE_CHANGE_TO, CLEAR_BUILD_CACHE_BEFORE, CLEAR_TRANSFORM_CACHE_BEFORE, SHOW_BUILD_CACHE_SIZE, GIT_CHECKOUT, GIT_REVERT, BAZEL, BUCK, MAVEN, MODEL, ANDROID_STUDIO_SYNC
     );
     private static final List<String> BAZEL_KEYS = Arrays.asList(TARGETS);
     private static final List<String> BUCK_KEYS = Arrays.asList(TARGETS, TYPE);
@@ -108,6 +109,7 @@ class ScenarioLoader {
             maybeAddMutator(scenario, scenarioName, settings.getProjectDir(), APPLY_NON_ABI_CHANGE_TO, ApplyNonAbiChangeToSourceFileMutator.class, mutators);
             maybeAddMutator(scenario, scenarioName, settings.getProjectDir(), APPLY_ANDROID_RESOURCE_CHANGE_TO, ApplyChangeToAndroidResourceFileMutator.class, mutators);
             maybeAddMutator(scenario, scenarioName, settings.getProjectDir(), APPLY_ANDROID_RESOURCE_VALUE_CHANGE_TO, ApplyValueChangeToAndroidResourceFileMutator.class, mutators);
+            maybeAddMutator(scenario, scenarioName, settings.getProjectDir(), APPLY_ANDROID_LAYOUT_CHANGE_TO, ApplyChangeToAndroidLayoutFileMutator.class, mutators);
             maybeAddMutator(scenario, scenarioName, settings.getProjectDir(), APPLY_ANDROID_MANIFEST_CHANGE_TO, ApplyChangeToAndroidManifestFileMutator.class, mutators);
             maybeAddMutator(scenario, scenarioName, settings.getProjectDir(), APPLY_PROPERTY_RESOURCE_CHANGE_TO, ApplyChangeToPropertyResourceFileMutator.class, mutators);
             maybeAddMutator(scenario, scenarioName, settings.getProjectDir(), APPLY_CPP_SOURCE_CHANGE_TO, ApplyChangeToNativeSourceFileMutator.class, mutators);

--- a/src/main/java/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutator.java
@@ -2,6 +2,14 @@ package org.gradle.profiler.mutations;
 
 import java.io.File;
 
+/**
+ * This class applies a mutation to an Android layout file by adding an extra, hidden view at the bottom of the layout.
+ * It supports both DataBinding layouts and traditional Android layouts.
+ *
+ * Note: This mutator does not support layouts with a single view in them - it requires a valid ViewGroup to contain the
+ * new view. Attempting to mutate a layout that does not have a ViewGroup as its root element will result in an
+ * invalid layout file.
+ */
 public class ApplyChangeToAndroidLayoutFileMutator extends AbstractFileChangeMutator {
     public ApplyChangeToAndroidLayoutFileMutator(File sourceFile) {
         super(sourceFile);

--- a/src/main/java/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutator.java
@@ -1,0 +1,52 @@
+package org.gradle.profiler.mutations;
+
+import java.io.File;
+
+public class ApplyChangeToAndroidLayoutFileMutator extends AbstractFileChangeMutator {
+    public ApplyChangeToAndroidLayoutFileMutator(File sourceFile) {
+        super(sourceFile);
+    }
+
+    @Override
+    protected void applyChangeTo(StringBuilder text) {
+        // We need to handle both databinding layouts, which end with </layout>, and non, which can end with any layout item closing tag
+        // Handle DataBinding first
+        int insertPos = text.lastIndexOf("</layout>");
+        if (insertPos < 0) {
+            // handle not databinding
+            applyChangeToNonDataBindingLayout(text);
+        } else {
+            applyChangeToDataBindingLayout(text, insertPos);
+        }
+    }
+
+    private void applyChangeToDataBindingLayout(StringBuilder text, int tagEndPosition) {
+        // Find the closing tag before the </layout>, which will be the closing of the top-level layout item we want to add to
+        String substring = text.substring(0, tagEndPosition);
+        int insertPos = substring.lastIndexOf("</");
+        if (insertPos < 0) {
+            throw new IllegalArgumentException("Cannot parse android layout file " + sourceFile + " to apply changes position " + insertPos);
+        }
+
+        text.insert(insertPos, generateUniqueViewItem());
+    }
+
+    private void applyChangeToNonDataBindingLayout(StringBuilder text) {
+        // For non-databinding layouts, we can just append right before the last item ends, which will be some form of a layout item
+        int insertPos = text.lastIndexOf("</");
+        if (insertPos < 0) {
+            throw new IllegalArgumentException("Cannot parse android layout file " + sourceFile + " to apply changes");
+        }
+
+        text.insert(insertPos, generateUniqueViewItem());
+    }
+
+    private String generateUniqueViewItem() {
+        return "<View \n" +
+               "    android:id=\"@+id/view" + getUniqueText() + "\"\n" +
+               "    android:visibility=\"gone\"\n" +
+               "    android:layout_width=\"5dp\"\n" +
+               "    android:layout_height=\"5dp\"/>\n" +
+               "\n";
+    }
+}

--- a/src/main/java/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutator.java
@@ -4,7 +4,7 @@ import java.io.File;
 
 /**
  * This class applies a mutation to an Android layout file by adding an extra, hidden view at the bottom of the layout.
- * It supports both DataBinding layouts and traditional Android layouts.
+ * It supports both DataBinding layouts (wrapped in <layout></layout> tags) and traditional Android layouts.
  *
  * Note: This mutator does not support layouts with a single view in them - it requires a valid ViewGroup to contain the
  * new view. Attempting to mutate a layout that does not have a ViewGroup as its root element will result in an
@@ -17,11 +17,8 @@ public class ApplyChangeToAndroidLayoutFileMutator extends AbstractFileChangeMut
 
     @Override
     protected void applyChangeTo(StringBuilder text) {
-        // We need to handle both databinding layouts, which end with </layout>, and non, which can end with any layout item closing tag
-        // Handle DataBinding first
         int insertPos = text.lastIndexOf("</layout>");
         if (insertPos < 0) {
-            // handle not databinding
             applyChangeToNonDataBindingLayout(text);
         } else {
             applyChangeToDataBindingLayout(text, insertPos);
@@ -29,7 +26,6 @@ public class ApplyChangeToAndroidLayoutFileMutator extends AbstractFileChangeMut
     }
 
     private void applyChangeToDataBindingLayout(StringBuilder text, int tagEndPosition) {
-        // Find the closing tag before the </layout>, which will be the closing of the top-level layout item we want to add to
         String substring = text.substring(0, tagEndPosition);
         int insertPos = substring.lastIndexOf("</");
         if (insertPos < 0) {
@@ -40,7 +36,6 @@ public class ApplyChangeToAndroidLayoutFileMutator extends AbstractFileChangeMut
     }
 
     private void applyChangeToNonDataBindingLayout(StringBuilder text) {
-        // For non-databinding layouts, we can just append right before the last item ends, which will be some form of a layout item
         int insertPos = text.lastIndexOf("</");
         if (insertPos < 0) {
             throw new IllegalArgumentException("Cannot parse android layout file " + sourceFile + " to apply changes");

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutatorTest.groovy
@@ -1,0 +1,127 @@
+package org.gradle.profiler.mutations
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class ApplyChangeToAndroidLayoutFileMutatorTest extends Specification {
+    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+
+    def "adds new view at bottom of top level layout"() {
+        def sourceFile = tmpDir.newFile("strings.xml")
+        sourceFile.text = "<LinearLayout></LinearLayout>"
+        def mutator = new ApplyChangeToAndroidLayoutFileMutator(sourceFile)
+        mutator.timestamp = 1234
+
+        when:
+        mutator.beforeBuild()
+
+        then:
+        sourceFile.text == """\
+        <LinearLayout><View 
+            android:id="@+id/view_1234_1"
+            android:visibility="gone"
+            android:layout_width="5dp"
+            android:layout_height="5dp"/>
+
+        </LinearLayout>""".stripIndent()
+
+        when:
+        mutator.beforeBuild()
+
+        then:
+        sourceFile.text == """\
+        <LinearLayout><View 
+            android:id="@+id/view_1234_2"
+            android:visibility="gone"
+            android:layout_width="5dp"
+            android:layout_height="5dp"/>
+
+        </LinearLayout>""".stripIndent()
+
+        when:
+        mutator.beforeBuild()
+
+        then:
+        sourceFile.text == """\
+        <LinearLayout><View 
+            android:id="@+id/view_1234_3"
+            android:visibility="gone"
+            android:layout_width="5dp"
+            android:layout_height="5dp"/>
+
+        </LinearLayout>""".stripIndent()
+    }
+
+
+    def "adds new view at bottom of top level db layout"() {
+        def sourceFile = tmpDir.newFile("strings.xml")
+        sourceFile.text = '<layout><LinearLayout></LinearLayout></layout>'
+        def mutator = new ApplyChangeToAndroidLayoutFileMutator(sourceFile)
+        mutator.timestamp = 1234
+
+        when:
+        mutator.beforeBuild()
+
+        then:
+        sourceFile.text == """\
+        <layout><LinearLayout><View 
+            android:id="@+id/view_1234_1"
+            android:visibility="gone"
+            android:layout_width="5dp"
+            android:layout_height="5dp"/>
+
+        </LinearLayout></layout>""".stripIndent()
+
+        when:
+        mutator.beforeBuild()
+
+        then:
+        sourceFile.text == """\
+        <layout><LinearLayout><View 
+            android:id="@+id/view_1234_2"
+            android:visibility="gone"
+            android:layout_width="5dp"
+            android:layout_height="5dp"/>
+
+        </LinearLayout></layout>""".stripIndent()
+
+        when:
+        mutator.beforeBuild()
+
+        then:
+        sourceFile.text == """\
+        <layout><LinearLayout><View 
+            android:id="@+id/view_1234_3"
+            android:visibility="gone"
+            android:layout_width="5dp"
+            android:layout_height="5dp"/>
+
+        </LinearLayout></layout>""".stripIndent()
+    }
+
+    def "reverts changes when nothing has been applied"() {
+        def sourceFile = tmpDir.newFile("strings.xml")
+        sourceFile.text = "<LinearLayout></LinearLayout>"
+        def mutator = new ApplyChangeToAndroidLayoutFileMutator(sourceFile)
+
+        when:
+        mutator.afterScenario()
+
+        then:
+        sourceFile.text == "<LinearLayout></LinearLayout>"
+    }
+
+    def "reverts changes when changes have been applied"() {
+        def sourceFile = tmpDir.newFile("strings.xml")
+        sourceFile.text = "<LinearLayout></LinearLayout>"
+        def mutator = new ApplyChangeToAndroidLayoutFileMutator(sourceFile)
+
+        when:
+        mutator.beforeBuild()
+        mutator.afterScenario()
+
+        then:
+        sourceFile.text == "<LinearLayout></LinearLayout>"
+    }
+}


### PR DESCRIPTION
Changes to Android layout files are a common situation to profile, especially when using Android Data binding, which
will trigger its own compiler. This PR adds support for this form of mutations to the profiler. It supports mutating
both normal layout files and data binding layouts, which have a special format.

This is done by inserting a non-visible view into the bottom of the layout with a random ID. The ID is important
as it guanartees that the API of the data binding model for this layout will also change.

The one thing not supported currently is mutating a layout file with a single element inside it, as in that case there
is nowhere for a fake element to be inserted. Likely the solution to this is to make the fake element a wrapper layout,
but I don't see much use for that use case right now, so I left it out.