### PR TITLE
Update tooling API version to 5.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ configurations {
 }
 
 dependencies {
-    implementation 'org.gradle:gradle-tooling-api:5.0'
+    implementation 'org.gradle:gradle-tooling-api:5.2.1'
     implementation 'com.google.code.findbugs:annotations:3.0.1'
     implementation 'com.google.guava:guava:21.0'
     implementation 'net.sf.jopt-simple:jopt-simple:5.0.2'

--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -14,7 +14,7 @@ import spock.lang.Unroll
 class ProfilerIntegrationTest extends Specification {
 
     @Shared
-    List<String> supportedGradleVersions = ["3.3", "3.4.1", "3.5", "4.0", "4.1", "4.2.1", "4.7", "5.1"]
+    List<String> supportedGradleVersions = ["3.3", "3.4.1", "3.5", "4.0", "4.1", "4.2.1", "4.7", "5.2.1"]
     @Shared
     String minimalSupportedGradleVersion = supportedGradleVersions.first()
     @Shared


### PR DESCRIPTION
So Gradle versions containing branch names can be parsed. The Gradle version scheme has been made more lenient in Gradle 5.1: https://github.com/gradle/gradle/commit/5c327a8e5ee023ae75e2424922d615c0f22e48f4#diff-ace955bf837be41415dd459eb9b3815eR37