### PR TITLE
Add ability to override jvm arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,8 +222,9 @@ A scenario can define changes that should be applied to the source before each b
 - `clear-build-cache-before`: Deletes the contents of the build cache before the scenario is executed (`SCENARIO`), before cleanup (`CLEANUP`) or before the build is executed (`BUILD`).
 - `clear-transform-cache-before`: Deletes the contents of the transform cache before the scenario is executed (`SCENARIO`), before cleanup (`CLEANUP`) or before the build is executed (`BUILD`).
 - `show-build-cache-size`: Shows the number of files and their size in the build cache before scenario execution, and after each cleanup and build round..
-- `git-checkout`: Checks out a specific for the build step, and a different one for the cleanup step.
+- `git-checkout`: Checks out a specific commit for the build step, and a different one for the cleanup step.
 - `git-revert`: Reverts a given set of commits before the build and resets it afterward.
+- `jvm-args`: Sets or overrides the jvm arguments set by `org.gradle.jvmargs` in gradle.properties.
 
 They can be added to a scenario file like this:
 
@@ -246,6 +247,7 @@ They can be added to a scenario file like this:
             build = "master"
         }
         git-revert = ["efb43a1"]
+        jvm-args = ["-Xmx2500m", "-XX:MaxMetaspaceSize=512m"]
     }
 
 ### Comparing against other build tools

--- a/src/main/java/org/gradle/profiler/AdhocGradleScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/AdhocGradleScenarioDefinition.java
@@ -7,7 +7,7 @@ import java.util.function.Supplier;
 
 public class AdhocGradleScenarioDefinition extends GradleScenarioDefinition {
     public AdhocGradleScenarioDefinition(GradleBuildConfiguration version, GradleBuildInvoker invoker, BuildAction buildAction, Map<String, String> systemProperties, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
-        super("default", invoker, version, buildAction, BuildAction.NO_OP, Collections.emptyList(), systemProperties, buildMutator, warmUpCount, buildCount, outputDir);
+        super("default", invoker, version, buildAction, BuildAction.NO_OP, Collections.emptyList(), systemProperties, buildMutator, warmUpCount, buildCount, outputDir, Collections.emptyList());
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
@@ -17,8 +17,9 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
     private final BuildAction cleanupAction;
     private final List<String> gradleArgs;
     private final Map<String, String> systemProperties;
+    private final List<String> jvmArgs;
 
-    public GradleScenarioDefinition(String name, GradleBuildInvoker invoker, GradleBuildConfiguration buildConfiguration, BuildAction buildAction, BuildAction cleanupAction, List<String> gradleArgs, Map<String, String> systemProperties, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
+    public GradleScenarioDefinition(String name, GradleBuildInvoker invoker, GradleBuildConfiguration buildConfiguration, BuildAction buildAction, BuildAction cleanupAction, List<String> gradleArgs, Map<String, String> systemProperties, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir, List<String> jvmArgs) {
         super(name, buildMutator, warmUpCount, buildCount, outputDir);
         this.invoker = invoker;
         this.buildAction = buildAction;
@@ -26,6 +27,7 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
         this.cleanupAction = cleanupAction;
         this.gradleArgs = gradleArgs;
         this.systemProperties = systemProperties;
+        this.jvmArgs = jvmArgs;
     }
 
     @Override
@@ -72,6 +74,10 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
         return systemProperties;
     }
 
+    public List<String> getJvmArgs() {
+        return jvmArgs;
+    }
+
     @Override
     public void visitProblems(InvocationSettings settings, Consumer<String> reporter) {
         if (getWarmUpCount() < 1) {
@@ -95,6 +101,9 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
             for (Map.Entry<String, String> entry : getSystemProperties().entrySet()) {
                 out.println("    " + entry.getKey() + "=" + entry.getValue());
             }
+        }
+        if (!jvmArgs.isEmpty()) {
+            out.println("  Jvm args: " + getJvmArgs());
         }
     }
 }

--- a/src/main/java/org/gradle/profiler/GradleScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/GradleScenarioInvoker.java
@@ -70,6 +70,8 @@ public class GradleScenarioInvoker extends ScenarioInvoker<GradleScenarioDefinit
             buildConfiguration.printVersionInfo();
 
             List<String> allBuildsJvmArgs = new ArrayList<>(buildConfiguration.getJvmArguments());
+            allBuildsJvmArgs.addAll(scenario.getJvmArgs());
+
             for (Map.Entry<String, String> entry : scenario.getSystemProperties().entrySet()) {
                 allBuildsJvmArgs.add("-D" + entry.getKey() + "=" + entry.getValue());
             }

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -40,9 +40,10 @@ class ScenarioLoader {
     private static final String TYPE = "type";
     private static final String MODEL = "model";
     private static final String ANDROID_STUDIO_SYNC = "android-studio-sync";
+    private static final String JVM_ARGS = "jvm-args";
 
     private static final List<String> ALL_SCENARIO_KEYS = Arrays.asList(
-        VERSIONS, TASKS, CLEANUP_TASKS, GRADLE_ARGS, RUN_USING, SYSTEM_PROPERTIES, WARM_UP_COUNT, APPLY_ABI_CHANGE_TO, APPLY_NON_ABI_CHANGE_TO, APPLY_ANDROID_RESOURCE_CHANGE_TO, APPLY_ANDROID_RESOURCE_VALUE_CHANGE_TO, APPLY_ANDROID_MANIFEST_CHANGE_TO, APPLY_ANDROID_LAYOUT_CHANGE_TO, APPLY_PROPERTY_RESOURCE_CHANGE_TO, APPLY_CPP_SOURCE_CHANGE_TO, APPLY_H_SOURCE_CHANGE_TO, CLEAR_BUILD_CACHE_BEFORE, CLEAR_TRANSFORM_CACHE_BEFORE, SHOW_BUILD_CACHE_SIZE, GIT_CHECKOUT, GIT_REVERT, BAZEL, BUCK, MAVEN, MODEL, ANDROID_STUDIO_SYNC, DAEMON
+        VERSIONS, TASKS, CLEANUP_TASKS, GRADLE_ARGS, RUN_USING, SYSTEM_PROPERTIES, WARM_UP_COUNT, APPLY_ABI_CHANGE_TO, APPLY_NON_ABI_CHANGE_TO, APPLY_ANDROID_RESOURCE_CHANGE_TO, APPLY_ANDROID_RESOURCE_VALUE_CHANGE_TO, APPLY_ANDROID_MANIFEST_CHANGE_TO, APPLY_ANDROID_LAYOUT_CHANGE_TO, APPLY_PROPERTY_RESOURCE_CHANGE_TO, APPLY_CPP_SOURCE_CHANGE_TO, APPLY_H_SOURCE_CHANGE_TO, CLEAR_BUILD_CACHE_BEFORE, CLEAR_TRANSFORM_CACHE_BEFORE, SHOW_BUILD_CACHE_SIZE, GIT_CHECKOUT, GIT_REVERT, BAZEL, BUCK, MAVEN, MODEL, ANDROID_STUDIO_SYNC, DAEMON, JVM_ARGS
     );
     private static final List<String> BAZEL_KEYS = Arrays.asList(TARGETS);
     private static final List<String> BUCK_KEYS = Arrays.asList(TARGETS, TYPE);
@@ -198,10 +199,11 @@ class ScenarioLoader {
                 BuildAction buildAction = getBuildAction(scenario, scenarioFile);
                 BuildAction cleanupAction = getCleanupAction(scenario);
                 Map<String, String> systemProperties = ConfigUtil.map(scenario, SYSTEM_PROPERTIES, settings.getSystemProperties());
+                List<String> jvmArgs = ConfigUtil.strings(scenario, JVM_ARGS);
                 for (GradleBuildConfiguration version : versions) {
                     File outputDir = versions.size() == 1 ? new File(settings.getOutputDir(), scenarioName) : new File(settings.getOutputDir(), scenarioName + "/" + version.getGradleVersion().getVersion());
                     definitions.add(new GradleScenarioDefinition(scenarioName, invoker, version, buildAction, cleanupAction, gradleArgs, systemProperties,
-                        buildMutatorFactory, warmUpCount, buildCount, outputDir));
+                        buildMutatorFactory, warmUpCount, buildCount, outputDir, jvmArgs));
                 }
             }
         }


### PR DESCRIPTION
Adds `jvm-args` to the scenario file to allow for
overriding and testing of different jvm options.