### PR TITLE
Fix NPE when cleaning transform or build cache when files with matching names are present in the caches directory

### DIFF
--- a/src/main/java/org/gradle/profiler/mutations/AbstractCleanupMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/AbstractCleanupMutator.java
@@ -1,10 +1,13 @@
 package org.gradle.profiler.mutations;
 
 import com.typesafe.config.Config;
+import org.apache.commons.io.FileUtils;
 import org.gradle.profiler.BuildMutator;
 import org.gradle.profiler.ConfigUtil;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.function.Supplier;
 
 public abstract class AbstractCleanupMutator implements BuildMutator {
@@ -49,12 +52,26 @@ public abstract class AbstractCleanupMutator implements BuildMutator {
                 throw new IllegalStateException("Cannot find cache directories in " + gradleUserHome);
             }
             for (File cacheDir : cacheDirs) {
-                cleanupCacheDir(cacheDir);
+                if (cacheDir.isDirectory()) {
+                    cleanupCacheDir(cacheDir);
+                }
             }
         }
     }
 
     protected abstract void cleanupCacheDir(File cacheDir);
+
+    protected static void delete(File f) {
+        try {
+            if (f.isFile()) {
+                Files.delete(f.toPath());
+            } else {
+                FileUtils.deleteDirectory(f);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Could not delete " + f, e);
+        }
+    }
 
     public static abstract class Configurator implements BuildMutatorConfigurator {
         private final File gradleUserHome;

--- a/src/main/java/org/gradle/profiler/mutations/ClearArtifactTransformCacheMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ClearArtifactTransformCacheMutator.java
@@ -1,6 +1,5 @@
 package org.gradle.profiler.mutations;
 
-import org.apache.commons.io.FileUtils;
 import org.gradle.profiler.BuildMutator;
 
 import java.io.File;
@@ -21,7 +20,7 @@ public class ClearArtifactTransformCacheMutator extends AbstractCleanupMutator {
             cacheDir,
             (dir, name) -> name.startsWith("files-")
         ).flatMap(file -> filesAsStream(file, (dir, name) -> !name.endsWith(".lock")))
-            .forEach(FileUtils::deleteQuietly);
+            .forEach(AbstractCleanupMutator::delete);
     }
 
     private Stream<File> filesAsStream(File dir, FilenameFilter filter) {

--- a/src/main/java/org/gradle/profiler/mutations/ClearBuildCacheMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ClearBuildCacheMutator.java
@@ -1,6 +1,5 @@
 package org.gradle.profiler.mutations;
 
-import org.apache.commons.io.FileUtils;
 import org.gradle.profiler.BuildMutator;
 
 import java.io.File;
@@ -15,7 +14,7 @@ public class ClearBuildCacheMutator extends AbstractCleanupMutator {
 
     @Override
     protected void cleanupCacheDir(File cacheDir) {
-        Arrays.stream(Objects.requireNonNull(cacheDir.listFiles((file) -> file.getName().length() == 32))).forEach(FileUtils::deleteQuietly);
+        Arrays.stream(Objects.requireNonNull(cacheDir.listFiles((file) -> file.getName().length() == 32))).forEach(AbstractCleanupMutator::delete);
     }
 
     public static class Configurator extends AbstractCleanupMutator.Configurator {

--- a/src/test/groovy/org/gradle/profiler/mutations/ClearArtifactTransformCacheMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ClearArtifactTransformCacheMutatorTest.groovy
@@ -1,0 +1,35 @@
+package org.gradle.profiler.mutations
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+
+class ClearArtifactTransformCacheMutatorTest extends Specification {
+    @Rule
+    TemporaryFolder tmpDir = new TemporaryFolder()
+
+    def "removes directories with transforms prefix"() {
+        def userHome = tmpDir.newFolder()
+        def cachesDir = new File(userHome, "caches")
+        cachesDir.mkdirs()
+        def file = new File(cachesDir, "transforms-1")
+        file.text = "a file"
+        def dir = new File(cachesDir, "transforms-2/files-1/thing")
+        dir.mkdirs()
+        def ignored1 = new File(cachesDir, "keep-me/files-1/thing")
+        ignored1.mkdirs()
+        def ignored2 = new File(cachesDir, "transforms/files-1/thing")
+        ignored2.mkdirs()
+
+        when:
+        def mutator = new ClearArtifactTransformCacheMutator(userHome, AbstractCleanupMutator.CleanupSchedule.BUILD)
+        mutator.beforeBuild()
+
+        then:
+        file.file
+        !dir.exists()
+        ignored1.directory
+        ignored2.directory
+    }
+}


### PR DESCRIPTION
Also don't silently ignore failures to delete these directories, as leaving these files behind can affect the results.