### PR TITLE
Add git-commit to Profiler Scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ A scenario can define changes that should be applied to the source before each b
 - `show-build-cache-size`: Shows the number of files and their size in the build cache before scenario execution, and after each cleanup and build round..
 - `git-checkout`: Checks out a specific commit for the build step, and a different one for the cleanup step.
 - `git-revert`: Reverts a given set of commits before the build and resets it afterward.
+- `git-commit`: Checks out a commit and runs the profiler on that commit.
 - `jvm-args`: Sets or overrides the jvm arguments set by `org.gradle.jvmargs` in gradle.properties.
 
 They can be added to a scenario file like this:
@@ -247,6 +248,7 @@ They can be added to a scenario file like this:
             build = "master"
         }
         git-revert = ["efb43a1"]
+        git-commit = "efb43a1"
         jvm-args = ["-Xmx2500m", "-XX:MaxMetaspaceSize=512m"]
     }
 

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -36,6 +36,7 @@ class ScenarioLoader {
     private static final String SHOW_BUILD_CACHE_SIZE = "show-build-cache-size";
     private static final String GIT_CHECKOUT = "git-checkout";
     private static final String GIT_REVERT = "git-revert";
+    private static final String GIT_COMMIT = "git-commit";
     private static final String TARGETS = "targets";
     private static final String TYPE = "type";
     private static final String MODEL = "model";
@@ -43,7 +44,7 @@ class ScenarioLoader {
     private static final String JVM_ARGS = "jvm-args";
 
     private static final List<String> ALL_SCENARIO_KEYS = Arrays.asList(
-        VERSIONS, TASKS, CLEANUP_TASKS, GRADLE_ARGS, RUN_USING, SYSTEM_PROPERTIES, WARM_UP_COUNT, APPLY_ABI_CHANGE_TO, APPLY_NON_ABI_CHANGE_TO, APPLY_ANDROID_RESOURCE_CHANGE_TO, APPLY_ANDROID_RESOURCE_VALUE_CHANGE_TO, APPLY_ANDROID_MANIFEST_CHANGE_TO, APPLY_ANDROID_LAYOUT_CHANGE_TO, APPLY_PROPERTY_RESOURCE_CHANGE_TO, APPLY_CPP_SOURCE_CHANGE_TO, APPLY_H_SOURCE_CHANGE_TO, CLEAR_BUILD_CACHE_BEFORE, CLEAR_TRANSFORM_CACHE_BEFORE, SHOW_BUILD_CACHE_SIZE, GIT_CHECKOUT, GIT_REVERT, BAZEL, BUCK, MAVEN, MODEL, ANDROID_STUDIO_SYNC, DAEMON, JVM_ARGS
+        VERSIONS, TASKS, CLEANUP_TASKS, GRADLE_ARGS, RUN_USING, SYSTEM_PROPERTIES, WARM_UP_COUNT, APPLY_ABI_CHANGE_TO, APPLY_NON_ABI_CHANGE_TO, APPLY_ANDROID_RESOURCE_CHANGE_TO, APPLY_ANDROID_RESOURCE_VALUE_CHANGE_TO, APPLY_ANDROID_MANIFEST_CHANGE_TO, APPLY_ANDROID_LAYOUT_CHANGE_TO, APPLY_PROPERTY_RESOURCE_CHANGE_TO, APPLY_CPP_SOURCE_CHANGE_TO, APPLY_H_SOURCE_CHANGE_TO, CLEAR_BUILD_CACHE_BEFORE, CLEAR_TRANSFORM_CACHE_BEFORE, SHOW_BUILD_CACHE_SIZE, GIT_CHECKOUT, GIT_REVERT, BAZEL, BUCK, MAVEN, MODEL, ANDROID_STUDIO_SYNC, DAEMON, VERSIONS, TASKS, CLEANUP_TASKS, GRADLE_ARGS, RUN_USING, SYSTEM_PROPERTIES, WARM_UP_COUNT, APPLY_ABI_CHANGE_TO, APPLY_NON_ABI_CHANGE_TO, APPLY_ANDROID_RESOURCE_CHANGE_TO, APPLY_ANDROID_RESOURCE_VALUE_CHANGE_TO, APPLY_ANDROID_MANIFEST_CHANGE_TO, APPLY_ANDROID_LAYOUT_CHANGE_TO, APPLY_PROPERTY_RESOURCE_CHANGE_TO, APPLY_CPP_SOURCE_CHANGE_TO, APPLY_H_SOURCE_CHANGE_TO, CLEAR_BUILD_CACHE_BEFORE, CLEAR_TRANSFORM_CACHE_BEFORE, SHOW_BUILD_CACHE_SIZE, GIT_CHECKOUT, GIT_REVERT, BAZEL, BUCK, MAVEN, MODEL, ANDROID_STUDIO_SYNC, DAEMON, GIT_COMMIT, JVM_ARGS
     );
     private static final List<String> BAZEL_KEYS = Arrays.asList(TARGETS);
     private static final List<String> BUCK_KEYS = Arrays.asList(TARGETS, TYPE);
@@ -138,6 +139,7 @@ class ScenarioLoader {
             maybeAddMutator(scenario, scenarioName, settings.getProjectDir(), SHOW_BUILD_CACHE_SIZE, new ShowBuildCacheSizeMutator.Configurator(settings.getGradleUserHome()), mutators);
             maybeAddMutator(scenario, scenarioName, settings.getProjectDir(), GIT_CHECKOUT, new GitCheckoutMutator.Configurator(), mutators);
             maybeAddMutator(scenario, scenarioName, settings.getProjectDir(), GIT_REVERT, new GitRevertMutator.Configurator(), mutators);
+            maybeAddMutator(scenario, scenarioName, settings.getProjectDir(), GIT_COMMIT, new GitCommitMutator.Configurator(), mutators);
 
             BuildMutatorFactory buildMutatorFactory = new BuildMutatorFactory(mutators);
 

--- a/src/main/java/org/gradle/profiler/mutations/GitCommitMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/GitCommitMutator.java
@@ -1,0 +1,51 @@
+package org.gradle.profiler.mutations;
+
+import com.typesafe.config.Config;
+import org.gradle.profiler.BuildMutator;
+import org.gradle.profiler.CommandExec;
+import org.gradle.profiler.ConfigUtil;
+
+import java.io.File;
+import java.util.function.Supplier;
+
+public class GitCommitMutator extends AbstractGitMutator {
+
+	private final String commit;
+
+	private String originalBranch;
+
+	public GitCommitMutator(File projectDir, String commit) {
+		super(projectDir);
+		this.commit = commit;
+	}
+
+	@Override
+	public void beforeScenario() {
+        System.out.println("> Checking out commit " + commit);
+        originalBranch = new CommandExec().inDir(projectDir).runAndCollectOutput("git", "rev-parse", "--abbrev-ref", "HEAD").trim();
+        try {
+            new CommandExec().inDir(projectDir).run("git", "checkout", commit, "--quiet");
+        } catch (RuntimeException e) {
+            throw new UnsupportedOperationException("Cannot checkout " + commit + " there are unsaved changes. Please commit or stash these changes and try again");
+        }
+	}
+
+	@Override
+    public void afterScenario() {
+        new CommandExec().inDir(projectDir).run("git", "checkout", originalBranch, "--quiet");
+        resetGit();
+    }
+
+    public static class Configurator implements BuildMutatorConfigurator {
+		@Override
+		public Supplier<BuildMutator> configure(Config scenario, String scenarioName, File projectDir, String key) {
+			String commit = ConfigUtil.string(scenario, key);
+			return () -> new GitCommitMutator(projectDir, commit);
+		}
+	}
+
+	@Override
+	public String toString() {
+		return getClass().getSimpleName() + "(" + commit + ")";
+	}
+}

--- a/src/test/groovy/org/gradle/profiler/mutations/GitCommitMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/GitCommitMutatorTest.groovy
@@ -1,0 +1,42 @@
+package org.gradle.profiler.mutations
+
+import org.gradle.profiler.CommandExec
+import org.gradle.profiler.TestGitRepo
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class GitCommitMutatorTest extends Specification {
+    @Rule TemporaryFolder tempDir = new TemporaryFolder()
+
+    def "should fail when unsaved changes"() {
+        given:
+        def repo = new TestGitRepo(tempDir.newFolder())
+        def mutator = new GitCommitMutator(repo.directory, repo.modifiedCommit)
+
+        when:
+        mutator.beforeScenario()
+
+        then:
+        thrown(UnsupportedOperationException)
+    }
+
+    def "check out target commit"() {
+        given:
+        def repo = new TestGitRepo(tempDir.newFolder())
+        def mutator = new GitCommitMutator(repo.directory, repo.modifiedCommit)
+        new CommandExec().inDir(repo.directory).run("git", "reset", "--hard", "HEAD")
+
+        when:
+        mutator.beforeScenario()
+
+        then:
+        repo.atModifiedCommit()
+
+        and:
+        mutator.afterScenario()
+
+        then:
+        repo.atFinalCommit()
+    }
+}


### PR DESCRIPTION
Adds ability to checkout a previous commit, run the profiler
against that commit, and then reverts back to the original checked
out branch.

Signed-off-by: Andrew Reitz <aj.reitz@gmail.com>