### PR TITLE
Fix build scan profiler summary

### DIFF
--- a/src/main/java/org/gradle/profiler/buildscan/BuildScanProfiler.java
+++ b/src/main/java/org/gradle/profiler/buildscan/BuildScanProfiler.java
@@ -63,9 +63,9 @@ public class BuildScanProfiler extends Profiler {
                 }
                 nextLineIsBuildScanUrl = false;
             } else {
-                Matcher tasksMatcher = RUNNING_BUILD.matcher(line);
-                if (tasksMatcher.matches()) {
-                    measuredBuildNumber = tasksMatcher.group(1);
+                Matcher buildMatcher = RUNNING_BUILD.matcher(line);
+                if (buildMatcher.matches()) {
+                    measuredBuildNumber = buildMatcher.group(1);
                 } else if (line.equals("Publishing build scan...")) {
                     nextLineIsBuildScanUrl = true;
                 } else {


### PR DESCRIPTION
Fixes two issues with the build scan profiler summary:
- If the project is set up to always publish build scans, the summary will include build scans for initial configuration & warm-ups.
- Every line contains `'UNKNOWN' UNKNOWN [UNKNOWN]` instead of something descriptive, because `BuildScanProfiler.LogParser` searches for [a line in the log output that no longer exists](https://github.com/gradle/gradle-profiler/commit/283be7344548f2b1946bef13f54d70fc4e885872#diff-6ecb6a4c3b8ff1a169ec169add4f33fbR29).

Before (for a project that publishes build scans on every build, with 3 warmups & 5 iterations):

```
* Results written to /Users/philglass/Temp/results/configuration
  - Build scan for 'UNKNOWN' UNKNOWN [UNKNOWN]: https://gradle.com/s/...
  Scenario using Gradle 5.4.1
  - Build scan for 'UNKNOWN' UNKNOWN [UNKNOWN]: https://gradle.com/s/...
  - Build scan for 'UNKNOWN' UNKNOWN [UNKNOWN]: https://gradle.com/s/...
  - Build scan for 'UNKNOWN' UNKNOWN [UNKNOWN]: https://gradle.com/s/...
  - Build scan for 'UNKNOWN' UNKNOWN [UNKNOWN]: https://gradle.com/s/...
  - Build scan for 'UNKNOWN' UNKNOWN [UNKNOWN]: https://gradle.com/s/...
  - Build scan for 'UNKNOWN' UNKNOWN [UNKNOWN]: https://gradle.com/s/...
  - Build scan for 'UNKNOWN' UNKNOWN [UNKNOWN]: https://gradle.com/s/...
  - Build scan for 'UNKNOWN' UNKNOWN [UNKNOWN]: https://gradle.com/s/...
  /Users/philglass/Temp/results/configuration/benchmark.csv
  /Users/philglass/Temp/results/configuration/benchmark.html
```

After:

```
* Results written to /Users/philglass/Temp/results/configuration
  Scenario using Gradle 5.4.1
  - Build scan for measured build #1: https://gradle.com/s/...
  - Build scan for measured build #2: https://gradle.com/s/...
  - Build scan for measured build #3: https://gradle.com/s/...
  - Build scan for measured build #4: https://gradle.com/s/...
  - Build scan for measured build #5: https://gradle.com/s/...
  /Users/philglass/Temp/results/configuration/benchmark.csv
  /Users/philglass/Temp/results/configuration/benchmark.html
```