### PR TITLE
Fix failure on Windows when file paths have spaces in them

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,43 @@
+* text eol=lf
+
+#
+# The above will handle all files NOT found below
+# https://help.github.com/articles/dealing-with-line-endings/
+# https://github.com/Danimoth/gitattributes
+
+# These are explicitly windows files and should use crlf
+*.bat           text eol=crlf
+
+# These files are text and should be normalized (Convert crlf => lf)
+*.bash          text eol=lf
+*.css           text diff=css
+*.htm           text diff=html
+*.html          text diff=html
+*.java          text diff=java
+*.sh            text eol=lf
+
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.a             binary
+*.lib           binary
+*.icns          binary
+*.png           binary
+*.jpg           binary
+*.jpeg          binary
+*.gif           binary
+*.ico           binary
+*.mov           binary
+*.mp4           binary
+*.mp3           binary
+*.flv           binary
+*.fla           binary
+*.swf           binary
+*.gz            binary
+*.zip           binary
+*.jar           binary
+*.tar           binary
+*.tar.gz        binary
+*.7z            binary
+*.ttf           binary
+*.pyc           binary

--- a/src/main/java/org/gradle/profiler/GradleBuildConfiguration.java
+++ b/src/main/java/org/gradle/profiler/GradleBuildConfiguration.java
@@ -60,10 +60,9 @@ public class GradleBuildConfiguration {
     }
 
     public void addGradleCommand(List<String> commandLine) {
-        if (OperatingSystem.isWindows()) {
-            commandLine.add("cmd.exe");
-            commandLine.add("/C");
-        }
-        commandLine.add(new File(gradleHome, "bin/gradle").getAbsolutePath());
+        String gradleScriptName = OperatingSystem.isWindows()
+            ? "gradle.bat"
+            : "gradle";
+        commandLine.add(new File(gradleHome, "bin/" + gradleScriptName).getAbsolutePath());
     }
 }

--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -1048,7 +1048,7 @@ println "User home: \$gradle.gradleUserHomeDir"
         logFile.find("User home: " + new File("gradle-user-home").absolutePath)
     }
 
-    def "Can specify user home"() {
+    def "can specify user home"() {
         given:
         buildFile.text = """
 apply plugin: 'base'
@@ -1057,10 +1057,10 @@ println "User home: \$gradle.gradleUserHomeDir"
 
         when:
         new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", minimalSupportedGradleVersion,
-            "--benchmark", "--gradle-user-home", "foobar", "help")
+            "--benchmark", "--gradle-user-home", "home with spaces", "help")
 
         then:
-        logFile.find("User home: " + new File("foobar").absolutePath)
+        logFile.find("User home: " + new File("home with spaces").absolutePath)
     }
 
     @Requires({ !OperatingSystem.windows })


### PR DESCRIPTION
We don't need to run Gradle using cmd.exe. Doing so messes up the escaping of spaces in the file names passed to it as parameters and results in the following type of failure:

```text
* Stopping daemons
java.lang.RuntimeException: Could not run command cmd.exe /C C:\Users\Lorant Pinter\Workspace\gradle\local-install\bin\gradle --stop --gradle-user-home C:\Users\Lorant Pinter\Workspace\gradle\snapshotting-performance\santa-tracker-android\gradle-user-home
Output:
======
'C:\Users\Lorant' is not recognized as an internal or external command,
operable program or batch file.
======
        at org.gradle.profiler.CommandExec$RunHandle.waitForSuccess(CommandExec.java:178)
        at org.gradle.profiler.CommandExec.run(CommandExec.java:68)
        at org.gradle.profiler.CommandExec.run(CommandExec.java:34)
        at org.gradle.profiler.CommandExec.run(CommandExec.java:29)
        at org.gradle.profiler.GradleBuildConfiguration.runGradle(GradleBuildConfiguration.java:59)
```

Instead we can invoke `gradle.bat` directly that has none of this problem.