### PR TITLE
Display simple names for build operations in summary

### DIFF
--- a/src/main/java/org/gradle/profiler/GradleBuildInvocationResult.java
+++ b/src/main/java/org/gradle/profiler/GradleBuildInvocationResult.java
@@ -7,6 +7,8 @@ import javax.annotation.Nullable;
 import java.time.Duration;
 import java.util.Map;
 
+import static org.gradle.profiler.buildops.BuildOperationUtil.getSimpleBuildOperationName;
+
 public class GradleBuildInvocationResult extends BuildInvocationResult {
     private final Duration timeToTaskExecution;
     private final Map<String, Duration> cumulativeBuildOperationTimes;
@@ -55,12 +57,5 @@ public class GradleBuildInvocationResult extends BuildInvocationResult {
 
     public Map<String, Duration> getCumulativeBuildOperationTimes() {
         return cumulativeBuildOperationTimes;
-    }
-
-    private static String getSimpleBuildOperationName(String buildOperationDetailsClass) {
-        int lastDot = buildOperationDetailsClass.lastIndexOf('.');
-        return lastDot == -1
-            ? buildOperationDetailsClass
-            : buildOperationDetailsClass.substring(lastDot + 1);
     }
 }

--- a/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
@@ -130,6 +130,7 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
         if (!measuredBuildOperations.isEmpty()) {
             out.println("  Measured build operations: " + measuredBuildOperations.stream()
                 .map(BuildOperationUtil::getSimpleBuildOperationName)
+                .sorted()
                 .collect(Collectors.joining(", ")));
         }
     }

--- a/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
@@ -1,5 +1,6 @@
 package org.gradle.profiler;
 
+import org.gradle.profiler.buildops.BuildOperationUtil;
 import org.gradle.util.GradleVersion;
 
 import java.io.File;
@@ -8,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 public class GradleScenarioDefinition extends ScenarioDefinition {
 
@@ -126,7 +128,9 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
             out.println("  Jvm args: " + getJvmArgs());
         }
         if (!measuredBuildOperations.isEmpty()) {
-            out.println("  Measured build operations: " + String.join(", ", measuredBuildOperations));
+            out.println("  Measured build operations: " + measuredBuildOperations.stream()
+                .map(BuildOperationUtil::getSimpleBuildOperationName)
+                .collect(Collectors.joining(", ")));
         }
     }
 }

--- a/src/main/java/org/gradle/profiler/buildops/BuildOperationUtil.java
+++ b/src/main/java/org/gradle/profiler/buildops/BuildOperationUtil.java
@@ -1,0 +1,10 @@
+package org.gradle.profiler.buildops;
+
+public class BuildOperationUtil {
+    public static String getSimpleBuildOperationName(String buildOperationDetailsClass) {
+        int lastDot = buildOperationDetailsClass.lastIndexOf('.');
+        return lastDot == -1
+            ? buildOperationDetailsClass
+            : buildOperationDetailsClass.substring(lastDot + 1);
+    }
+}


### PR DESCRIPTION
Display some shorter names to avoid this:

```text
* Scenarios
Scenario: nonAbiChangeWithSnapshottingOps using Gradle 5.7-20190801164842+0000
  Gradle 5.7-20190801164842+0000 (C:\Users\Lorant Pinter\Workspace\gradle\local-install)
  Run using: Tooling API
  Run: run tasks :santa-tracker:assembleDebug
  Cleanup: do nothing
  Gradle args: []
  Measured build operations: org.gradle.api.internal.tasks.execution.ExecuteTaskActionBuildOperationType, org.gradle.internal.execution.steps.CaptureStateBeforeExecutionStep$Operation, org.gradle.internal.execution.steps.SnapshotOutputsStep$Operation, org.gradle.caching.internal.operations.BuildCacheArchivePackBuildOperationType, org.gradle.api.internal.artifacts.transform.DefaultTransformer$FingerprintTransformInputsOperation, org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationType, org.gradle.api.internal.tasks.execution.ExecuteTaskBuildOperationType
  Build changes: ApplyNonAbiChangeToSourceFileMutator(.\tracker\src\main\java\com\google\android\apps\santatracker\tracker\ui\BottomSheetBehavior.java)
  Warm-ups: 4
  Builds: 10
```

And have this instead:

```text
* Scenarios
Scenario: nonAbiChangeWithSnapshottingOps using Gradle 5.7-20190801164842+0000
  Gradle 5.7-20190801164842+0000 (C:\Users\Lorant Pinter\Workspace\gradle\local-install)
  Run using: Tooling API
  Run: run tasks :santa-tracker:assembleDebug
  Cleanup: do nothing
  Gradle args: []
  Measured build operations: BuildCacheArchivePackBuildOperationType, CaptureStateBeforeExecutionStep$Operation, DefaultTransformer$FingerprintTransformInputsOperation, ExecuteTaskActionBuildOperationType, ExecuteTaskBuildOperationType, SnapshotOutputsStep$Operation, SnapshotTaskInputsBuildOperationType
  Build changes: ApplyNonAbiChangeToSourceFileMutator(.\tracker\src\main\java\com\google\android\apps\santatracker\tracker\ui\BottomSheetBehavior.java)
  Warm-ups: 4
  Builds: 10
```