### PR TITLE
Only publish the root project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,31 +85,14 @@ publishing {
     }
 }
 
-subprojects {
-    apply(plugin = "maven-publish")
-    pluginManager.withPlugin("java") {
-        publishing {
-            publications {
-                register<MavenPublication>("mavenJava") {
-                    from(components["java"])
-                }
-            }
-        }
-    }
-}
-
-allprojects {
-    pluginManager.withPlugin("maven-publish") {
-        publishing {
-            repositories {
-                maven {
-                    name = "GradleBuildInternal"
-                    url = gradleInternalRepositoryUrl()
-                    credentials {
-                        username = project.findProperty("artifactoryUsername") as String?
-                        password = project.findProperty("artifactoryPassword") as String?
-                    }
-                }
+publishing {
+    repositories {
+        maven {
+            name = "GradleBuildInternal"
+            url = gradleInternalRepositoryUrl()
+            credentials {
+                username = project.findProperty("artifactoryUsername") as String?
+                password = project.findProperty("artifactoryPassword") as String?
             }
         }
     }


### PR DESCRIPTION
The chrome-trace subproject did contain already a publication added
by the `java-gradle-plugin`. Adding a second publication caused
everything to be published twice which caused a build failure when
releasing.

Since the subprojects are not meant to be consumed, we shouldn't publish them at all.