### PR TITLE
Warmup count from commandline should override scenario

### DIFF
--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -322,11 +322,11 @@ class ScenarioLoader {
         if (settings.isDryRun()) {
             return 1;
         }
-        if (providedValue != null) {
-            return providedValue;
-        }
         if (settings.getWarmUpCount() != null) {
             return settings.getWarmUpCount();
+        }
+        if (providedValue != null) {
+            return providedValue;
         }
         if (settings.isBenchmark()) {
             return invoker.benchmarkWarmUps();

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -157,6 +157,7 @@ class ScenarioLoaderTest extends Specification {
             default {
                 run-using = tooling-api
                 daemon = warm
+                warm-ups = 5
             }
         """
         def benchmarkScenarios = loadScenarios(scenarioFile, benchmarkSettings, Mock(GradleBuildConfigurationReader))


### PR DESCRIPTION
The warmup count on the command line should override the warmup count
from the scenario file.