### PR TITLE
Support build variants and source generation avoidance in AS sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,13 @@ Here is an example:
     }
     androidStudioSync {
         # Simulate an Android studio sync
-        android-studio-sync { }
+        android-studio-sync {
+            # Skip source generation on sync
+            skip-source-generation = true // if not specified defaults to "false"
+            # If the above flag is set to "false", the Android studio sync simulation runs "generateDebugSources" tasks by default
+            # This behavior can be overridden in case if the project has different product flavors (e.g. "development", "production", etc.) 
+            build-variant = "developmentDebug" // if not specified defaults to "debug"
+        }
     }
 
 Values are optional and default to the values provided on the command-line or defined in the build.

--- a/src/main/java/org/gradle/profiler/ConfigUtil.java
+++ b/src/main/java/org/gradle/profiler/ConfigUtil.java
@@ -71,4 +71,12 @@ public class ConfigUtil {
 		}
 		return defaults;
 	}
+
+    public static boolean bool(Config config, String key, boolean defaultValue) {
+        if (config.hasPath(key)) {
+            return config.getBoolean(key);
+        } else {
+            return defaultValue;
+        }
+    }
 }

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -69,6 +69,8 @@ class ScenarioLoader {
     private static final String TYPE = "type";
     private static final String MODEL = "model";
     private static final String ANDROID_STUDIO_SYNC = "android-studio-sync";
+    private static final String ANDROID_BUILD_VARIANT = "build-variant";
+    private static final String ANDROID_SKIP_SOURCE_GENERATION = "skip-source-generation";
     private static final String JVM_ARGS = "jvm-args";
 
     private static final List<String> ALL_SCENARIO_KEYS = Arrays.asList(
@@ -390,7 +392,10 @@ class ScenarioLoader {
             return new LoadToolingModelAction(toolingModel, tasks);
         }
         if (sync) {
-            return new AndroidStudioSyncAction();
+            Config androidStudioConfig = scenario.getConfig(ANDROID_STUDIO_SYNC);
+            String buildFlavor = ConfigUtil.string(androidStudioConfig, ANDROID_BUILD_VARIANT, "debug");
+            boolean skipSourceGeneration = ConfigUtil.bool(androidStudioConfig, ANDROID_SKIP_SOURCE_GENERATION, false);
+            return new AndroidStudioSyncAction(buildFlavor, skipSourceGeneration);
         }
         return new RunTasksAction(tasks);
     }

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -245,7 +245,7 @@ class ScenarioLoaderTest extends Specification {
         scenario2.action.tasks == ["help"]
     }
 
-    def "can load single Android studio sync scenario"() {
+    def "can load default Android studio sync scenario"() {
         def settings = settings()
 
         scenarioFile << """
@@ -258,6 +258,28 @@ class ScenarioLoaderTest extends Specification {
         scenarios*.name == ["default"]
         def scenarioDefinition = scenarios[0] as GradleScenarioDefinition
         scenarioDefinition.action instanceof AndroidStudioSyncAction
+        scenarioDefinition.action.skipSourceGeneration == false
+        scenarioDefinition.action.buildFlavor == "debug"
+    }
+
+    def "loads Android studio sync included config"() {
+        def settings = settings()
+
+        scenarioFile << """
+            default {
+                android-studio-sync {
+                    build-variant = "developmentDebug"
+                    skip-source-generation = true
+                }               
+            }
+        """
+        def scenarios = loadScenarios(scenarioFile, settings, Mock(GradleBuildConfigurationReader))
+        expect:
+        scenarios*.name == ["default"]
+        def scenarioDefinition = scenarios[0] as GradleScenarioDefinition
+        scenarioDefinition.action instanceof AndroidStudioSyncAction
+        scenarioDefinition.action.skipSourceGeneration == true
+        scenarioDefinition.action.buildFlavor == "developmentDebug"
     }
 
     def "loads default scenarios only"() {


### PR DESCRIPTION
This PR addresses both #128 and #132. I didn't come up with anything better than adding a new config in the scenario for `android-studio-sync`. Hope this works well for you.