### PR TITLE
Make unique text used by file mutators actually unique

### DIFF
--- a/src/main/java/org/gradle/profiler/BazelScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/BazelScenarioInvoker.java
@@ -22,19 +22,21 @@ public class BazelScenarioInvoker extends ScenarioInvoker<BazelScenarioDefinitio
         commandLine.add("build");
         commandLine.addAll(targets);
 
+        ScenarioContext scenarioContext = ScenarioContext.from(settings, scenario);
+
         BuildMutator mutator = scenario.getBuildMutator().get();
-        mutator.beforeScenario();
+        mutator.beforeScenario(scenarioContext);
         try {
-            for (int i = 0; i < scenario.getWarmUpCount(); i++) {
-                String displayName = WARM_UP.displayBuildNumber(i + 1);
-                runMeasured(displayName, mutator, measureCommandLineExecution(displayName, commandLine, settings.getProjectDir()), resultConsumer);
+            for (int iteration = 1; iteration <= scenario.getWarmUpCount(); iteration++) {
+                BuildContext buildContext = scenarioContext.withBuild(WARM_UP, iteration);
+                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir()), resultConsumer);
             }
-            for (int i = 0; i < scenario.getBuildCount(); i++) {
-                String displayName = MEASURE.displayBuildNumber(i + 1);
-                runMeasured(displayName, mutator, measureCommandLineExecution(displayName, commandLine, settings.getProjectDir()), resultConsumer);
+            for (int iteration = 1; iteration <= scenario.getBuildCount(); iteration++) {
+                BuildContext buildContext = scenarioContext.withBuild(MEASURE, iteration);
+                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir()), resultConsumer);
             }
         } finally {
-            mutator.afterScenario();
+            mutator.afterScenario(scenarioContext);
         }
     }
 }

--- a/src/main/java/org/gradle/profiler/BuckScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/BuckScenarioInvoker.java
@@ -37,18 +37,20 @@ public class BuckScenarioInvoker extends ScenarioInvoker<BuckScenarioDefinition,
         commandLine.addAll(targets);
 
         BuildMutator mutator = scenario.getBuildMutator().get();
-        mutator.beforeScenario();
+        ScenarioContext scenarioContext = ScenarioContext.from(settings, scenario);
+
+        mutator.beforeScenario(scenarioContext);
         try {
-            for (int i = 0; i < scenario.getWarmUpCount(); i++) {
-                String displayName = WARM_UP.displayBuildNumber(i + 1);
-                runMeasured(displayName, mutator, measureCommandLineExecution(displayName, commandLine, settings.getProjectDir()), resultConsumer);
+            for (int iteration = 1; iteration <= scenario.getWarmUpCount(); iteration++) {
+                BuildContext buildContext = scenarioContext.withBuild(WARM_UP, iteration);
+                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir()), resultConsumer);
             }
-            for (int i = 0; i < scenario.getBuildCount(); i++) {
-                String displayName = MEASURE.displayBuildNumber(i + 1);
-                runMeasured(displayName, mutator, measureCommandLineExecution(displayName, commandLine, settings.getProjectDir()), resultConsumer);
+            for (int iteration = 1; iteration <= scenario.getBuildCount(); iteration++) {
+                BuildContext buildContext = scenarioContext.withBuild(MEASURE, iteration);
+                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir()), resultConsumer);
             }
         } finally {
-            mutator.afterScenario();
+            mutator.afterScenario(scenarioContext);
         }
     }
 }

--- a/src/main/java/org/gradle/profiler/BuildContext.java
+++ b/src/main/java/org/gradle/profiler/BuildContext.java
@@ -1,0 +1,30 @@
+package org.gradle.profiler;
+
+import java.util.UUID;
+
+public class BuildContext extends ScenarioContext {
+    private final Phase phase;
+    private final int iteration;
+
+    protected BuildContext(UUID invocationId, String scenarioName, Phase phase, int iteration) {
+        super(invocationId, scenarioName);
+        this.phase = phase;
+        this.iteration = iteration;
+    }
+
+    public String getUniqueBuildId() {
+        return String.format("%s-%s-%d", getUniqueScenarioId(), phase.name(), iteration);
+    }
+
+    public Phase getPhase() {
+        return phase;
+    }
+
+    public int getIteration() {
+        return iteration;
+    }
+
+    public String getDisplayName() {
+        return phase.displayBuildNumber(iteration);
+    }
+}

--- a/src/main/java/org/gradle/profiler/BuildContext.java
+++ b/src/main/java/org/gradle/profiler/BuildContext.java
@@ -13,7 +13,7 @@ public class BuildContext extends ScenarioContext {
     }
 
     public String getUniqueBuildId() {
-        return String.format("%s-%s-%d", getUniqueScenarioId(), phase.name(), iteration);
+        return String.format("%s_%s_%d", getUniqueScenarioId(), phase.name(), iteration);
     }
 
     public Phase getPhase() {

--- a/src/main/java/org/gradle/profiler/BuildMutator.java
+++ b/src/main/java/org/gradle/profiler/BuildMutator.java
@@ -4,32 +4,32 @@ public interface BuildMutator {
     /**
      * Runs before the first iteration of the scenario.
      */
-    default void beforeScenario() {};
+    default void beforeScenario(ScenarioContext context) {}
 
     /**
      * Runs before each iteration if cleanup tasks are declared.
      */
-    default void beforeCleanup() {};
+    default void beforeCleanup(BuildContext context) {}
 
     /**
      * Runs after each iteration of cleanup has finished.
      */
-    default void afterCleanup(Throwable error) {};
+    default void afterCleanup(BuildContext context, Throwable error) {}
 
     /**
      * Runs before starting an iteration of the build, after any potential cleanup has finished.
      */
-    default void beforeBuild() {};
+    default void beforeBuild(BuildContext context) {}
 
     /**
      * Runs after each iteration of the build has finished.
      */
-    default void afterBuild(Throwable error) {};
+    default void afterBuild(BuildContext context, Throwable error) {}
 
     /**
      * Runs after the last iteration of the scenario has finished.
      */
-    default void afterScenario() {};
+    default void afterScenario(ScenarioContext context) {}
 
     BuildMutator NOOP = new BuildMutator() {
         @Override
@@ -37,4 +37,5 @@ public interface BuildMutator {
             return "none";
         }
     };
+
 }

--- a/src/main/java/org/gradle/profiler/BuildMutator.java
+++ b/src/main/java/org/gradle/profiler/BuildMutator.java
@@ -37,5 +37,4 @@ public interface BuildMutator {
             return "none";
         }
     };
-
 }

--- a/src/main/java/org/gradle/profiler/BuildUnderTestInvoker.java
+++ b/src/main/java/org/gradle/profiler/BuildUnderTestInvoker.java
@@ -30,12 +30,12 @@ public class BuildUnderTestInvoker {
     /**
      * Runs a single invocation of a Gradle build.
      */
-    public GradleBuildInvocationResult runBuild(Phase phase, int buildNumber, BuildStep buildStep, BuildAction buildAction) {
-        String displayName = phase.displayBuildNumber(buildNumber);
+    public GradleBuildInvocationResult runBuild(BuildContext buildContext, BuildStep buildStep, BuildAction buildAction) {
+        String displayName = buildContext.getDisplayName();
 
         List<String> jvmArgs = new ArrayList<>(this.jvmArgs);
-        jvmArgs.add("-Dorg.gradle.profiler.phase=" + phase);
-        jvmArgs.add("-Dorg.gradle.profiler.number=" + buildNumber);
+        jvmArgs.add("-Dorg.gradle.profiler.phase=" + buildContext.getPhase());
+        jvmArgs.add("-Dorg.gradle.profiler.number=" + buildContext.getIteration());
         jvmArgs.add("-Dorg.gradle.profiler.step=" + buildStep);
 
         Timer timer = new Timer();

--- a/src/main/java/org/gradle/profiler/CompositeBuildMutator.java
+++ b/src/main/java/org/gradle/profiler/CompositeBuildMutator.java
@@ -11,44 +11,44 @@ public class CompositeBuildMutator implements BuildMutator {
 	}
 
 	@Override
-	public void beforeScenario() {
+	public void beforeScenario(ScenarioContext context) {
 		for (BuildMutator mutator : mutators) {
-			mutator.beforeScenario();
+			mutator.beforeScenario(context);
 		}
 	}
 
 	@Override
-	public void beforeCleanup() {
+	public void beforeCleanup(BuildContext context) {
 		for (BuildMutator mutator : mutators) {
-			mutator.beforeCleanup();
+			mutator.beforeCleanup(context);
 		}
 	}
 
 	@Override
-	public void afterCleanup(Throwable error) {
+	public void afterCleanup(BuildContext context, Throwable error) {
 		for (BuildMutator mutator : mutators) {
-			mutator.afterCleanup(error);
+			mutator.afterCleanup(context, error);
 		}
 	}
 
 	@Override
-	public void beforeBuild() {
+	public void beforeBuild(BuildContext context) {
 		for (BuildMutator mutator : mutators) {
-			mutator.beforeBuild();
+			mutator.beforeBuild(context);
 		}
 	}
 
 	@Override
-	public void afterBuild(Throwable error) {
+	public void afterBuild(BuildContext context, Throwable error) {
 		for (BuildMutator mutator : mutators) {
-			mutator.afterBuild(error);
+			mutator.afterBuild(context, error);
 		}
 	}
 
 	@Override
-	public void afterScenario() {
+	public void afterScenario(ScenarioContext context) {
 		for (BuildMutator mutator : mutators) {
-			mutator.afterScenario();
+			mutator.afterScenario(context);
 		}
 	}
 

--- a/src/main/java/org/gradle/profiler/InvocationSettings.java
+++ b/src/main/java/org/gradle/profiler/InvocationSettings.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.PrintStream;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class InvocationSettings {
     private final File projectDir;
@@ -21,6 +22,7 @@ public class InvocationSettings {
     private final Integer iterations;
     private final boolean measureConfigTime;
     private final List<String> measuredBuildOperations;
+    private final UUID invocationId = UUID.randomUUID();
 
     public InvocationSettings(
         File projectDir,
@@ -131,6 +133,10 @@ public class InvocationSettings {
 
     public List<String> getMeasuredBuildOperations() {
         return measuredBuildOperations;
+    }
+
+    public UUID getInvocationId() {
+        return invocationId;
     }
 
     public void printTo(PrintStream out) {

--- a/src/main/java/org/gradle/profiler/MavenScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/MavenScenarioInvoker.java
@@ -19,19 +19,21 @@ public class MavenScenarioInvoker extends ScenarioInvoker<MavenScenarioDefinitio
         commandLine.add(mvn);
         commandLine.addAll(scenario.getTargets());
 
+        ScenarioContext scenarioContext = ScenarioContext.from(settings, scenario);
+
         BuildMutator mutator = scenario.getBuildMutator().get();
-        mutator.beforeScenario();
+        mutator.beforeScenario(scenarioContext);
         try {
-            for (int i = 0; i < scenario.getWarmUpCount(); i++) {
-                String displayName = WARM_UP.displayBuildNumber(i + 1);
-                runMeasured(displayName, mutator, measureCommandLineExecution(displayName, commandLine, settings.getProjectDir()), resultConsumer);
+            for (int iteration = 1; iteration <= scenario.getWarmUpCount(); iteration++) {
+                BuildContext buildContext = scenarioContext.withBuild(WARM_UP, iteration);
+                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir()), resultConsumer);
             }
-            for (int i = 0; i < scenario.getBuildCount(); i++) {
-                String displayName = MEASURE.displayBuildNumber(i + 1);
-                runMeasured(displayName, mutator, measureCommandLineExecution(displayName, commandLine, settings.getProjectDir()), resultConsumer);
+            for (int iteration = 1; iteration <= scenario.getBuildCount(); iteration++) {
+                BuildContext buildContext = scenarioContext.withBuild(MEASURE, iteration);
+                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir()), resultConsumer);
             }
         } finally {
-            mutator.afterScenario();
+            mutator.afterScenario(scenarioContext);
         }
     }
 }

--- a/src/main/java/org/gradle/profiler/ScenarioContext.java
+++ b/src/main/java/org/gradle/profiler/ScenarioContext.java
@@ -16,7 +16,7 @@ public class ScenarioContext {
     }
 
     public String getUniqueScenarioId() {
-        return String.format("%s-%s", invocationId, scenarioName);
+        return String.format("_%s_%s", invocationId.toString().replaceAll("-", "_"), scenarioName);
     }
 
     public BuildContext withBuild(Phase phase, int count) {

--- a/src/main/java/org/gradle/profiler/ScenarioContext.java
+++ b/src/main/java/org/gradle/profiler/ScenarioContext.java
@@ -1,0 +1,25 @@
+package org.gradle.profiler;
+
+import java.util.UUID;
+
+public class ScenarioContext {
+    private final UUID invocationId;
+    private final String scenarioName;
+
+    public static ScenarioContext from(InvocationSettings invocationSettings, ScenarioDefinition scenarioDefinition) {
+        return new ScenarioContext(invocationSettings.getInvocationId(), scenarioDefinition.getName());
+    };
+
+    protected ScenarioContext(UUID invocationId, String scenarioName) {
+        this.invocationId = invocationId;
+        this.scenarioName = scenarioName;
+    }
+
+    public String getUniqueScenarioId() {
+        return String.format("%s-%s", invocationId, scenarioName);
+    }
+
+    public BuildContext withBuild(Phase phase, int count) {
+        return new BuildContext(invocationId, scenarioName, phase, count);
+    }
+}

--- a/src/main/java/org/gradle/profiler/ScenarioContext.java
+++ b/src/main/java/org/gradle/profiler/ScenarioContext.java
@@ -1,5 +1,7 @@
 package org.gradle.profiler;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.util.UUID;
 
 public class ScenarioContext {
@@ -10,7 +12,8 @@ public class ScenarioContext {
         return new ScenarioContext(invocationSettings.getInvocationId(), scenarioDefinition.getName());
     };
 
-    protected ScenarioContext(UUID invocationId, String scenarioName) {
+    @VisibleForTesting
+    public ScenarioContext(UUID invocationId, String scenarioName) {
         this.invocationId = invocationId;
         this.scenarioName = scenarioName;
     }

--- a/src/main/java/org/gradle/profiler/ScenarioContext.java
+++ b/src/main/java/org/gradle/profiler/ScenarioContext.java
@@ -1,7 +1,9 @@
 package org.gradle.profiler;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.hash.Hashing;
 
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 public class ScenarioContext {
@@ -19,10 +21,23 @@ public class ScenarioContext {
     }
 
     public String getUniqueScenarioId() {
-        return String.format("_%s_%s", invocationId.toString().replaceAll("-", "_"), scenarioName);
+        return String.format("_%s_%s", invocationId.toString().replaceAll("-", "_"), mangleName(scenarioName));
     }
 
     public BuildContext withBuild(Phase phase, int count) {
         return new BuildContext(invocationId, scenarioName, phase, count);
+    }
+
+    /**
+     * This is to ensure that the scenario ID is a valid Java identifier part, and it is also (reasonably) unique.
+     */
+    private static String mangleName(String scenarioName) {
+        StringBuilder name = new StringBuilder();
+        for (char ch :scenarioName.toCharArray()){
+            name.append(Character.isJavaIdentifierPart(ch) ? ch : '_');
+        }
+        name.append('_');
+        name.append(Hashing.murmur3_32().hashString(scenarioName, StandardCharsets.UTF_8));
+        return name.toString();
     }
 }

--- a/src/main/java/org/gradle/profiler/mutations/AbstractCleanupMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/AbstractCleanupMutator.java
@@ -2,8 +2,10 @@ package org.gradle.profiler.mutations;
 
 import com.typesafe.config.Config;
 import org.apache.commons.io.FileUtils;
+import org.gradle.profiler.BuildContext;
 import org.gradle.profiler.BuildMutator;
 import org.gradle.profiler.ConfigUtil;
+import org.gradle.profiler.ScenarioContext;
 
 import java.io.File;
 import java.io.IOException;
@@ -23,21 +25,21 @@ public abstract class AbstractCleanupMutator implements BuildMutator {
     }
 
     @Override
-    public void beforeBuild() {
+    public void beforeBuild(BuildContext context) {
         if (schedule == CleanupSchedule.BUILD) {
             doCleanup();
         }
     }
 
     @Override
-    public void beforeScenario() {
+    public void beforeScenario(ScenarioContext context) {
         if (schedule == CleanupSchedule.SCENARIO) {
             doCleanup();
         }
     }
 
     @Override
-    public void beforeCleanup() {
+    public void beforeCleanup(BuildContext context) {
         if (schedule == CleanupSchedule.CLEANUP) {
             doCleanup();
         }

--- a/src/main/java/org/gradle/profiler/mutations/AbstractDelegateFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/AbstractDelegateFileMutator.java
@@ -16,8 +16,8 @@ public abstract class AbstractDelegateFileMutator extends AbstractFileChangeMuta
     protected abstract AbstractFileChangeMutator getFileChangeMutator(File sourceFile);
 
     @Override
-    protected void applyChangeTo(StringBuilder text) {
-        fileChangeMutator.applyChangeTo(text);
+    protected void applyChangeTo(BuildContext context, StringBuilder text) {
+        fileChangeMutator.applyChangeTo(context, text);
     }
 
     @Override
@@ -48,10 +48,5 @@ public abstract class AbstractDelegateFileMutator extends AbstractFileChangeMuta
     @Override
     public void afterScenario(ScenarioContext context) {
         fileChangeMutator.afterScenario(context);
-    }
-
-    @Override
-    protected void setTimestamp(long timestamp) {
-        fileChangeMutator.setTimestamp(timestamp);
     }
 }

--- a/src/main/java/org/gradle/profiler/mutations/AbstractDelegateFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/AbstractDelegateFileMutator.java
@@ -1,5 +1,8 @@
 package org.gradle.profiler.mutations;
 
+import org.gradle.profiler.BuildContext;
+import org.gradle.profiler.ScenarioContext;
+
 import java.io.File;
 
 public abstract class AbstractDelegateFileMutator extends AbstractFileChangeMutator {
@@ -18,33 +21,33 @@ public abstract class AbstractDelegateFileMutator extends AbstractFileChangeMuta
     }
 
     @Override
-    public void beforeScenario() {
-        fileChangeMutator.beforeScenario();
+    public void beforeScenario(ScenarioContext context) {
+        fileChangeMutator.beforeScenario(context);
     }
 
     @Override
-    public void beforeCleanup() {
-        fileChangeMutator.beforeCleanup();
+    public void beforeCleanup(BuildContext context) {
+        fileChangeMutator.beforeCleanup(context);
     }
 
     @Override
-    public void afterCleanup(Throwable error) {
-        fileChangeMutator.afterCleanup(error);
+    public void afterCleanup(BuildContext context, Throwable error) {
+        fileChangeMutator.afterCleanup(context, error);
     }
 
     @Override
-    public void beforeBuild() {
-        fileChangeMutator.beforeBuild();
+    public void beforeBuild(BuildContext context) {
+        fileChangeMutator.beforeBuild(context);
     }
 
     @Override
-    public void afterBuild(Throwable error) {
-        fileChangeMutator.afterBuild(error);
+    public void afterBuild(BuildContext context, Throwable error) {
+        fileChangeMutator.afterBuild(context, error);
     }
 
     @Override
-    public void afterScenario() {
-        fileChangeMutator.afterScenario();
+    public void afterScenario(ScenarioContext context) {
+        fileChangeMutator.afterScenario(context);
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/mutations/AbstractFileChangeMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/AbstractFileChangeMutator.java
@@ -1,6 +1,8 @@
 package org.gradle.profiler.mutations;
 
+import org.gradle.profiler.BuildContext;
 import org.gradle.profiler.BuildMutator;
+import org.gradle.profiler.ScenarioContext;
 
 import java.io.File;
 import java.io.IOException;
@@ -35,7 +37,7 @@ public abstract class AbstractFileChangeMutator implements BuildMutator {
     }
 
     @Override
-    public void beforeBuild() {
+    public void beforeBuild(BuildContext context) {
         counter++;
         StringBuilder modifiedText = new StringBuilder(originalText);
         applyChangeTo(modifiedText);
@@ -57,7 +59,7 @@ public abstract class AbstractFileChangeMutator implements BuildMutator {
     }
 
     @Override
-    public void afterScenario() {
+    public void afterScenario(ScenarioContext context) {
         if (counter > 0) {
             revert();
             counter = 0;

--- a/src/main/java/org/gradle/profiler/mutations/AbstractJavaSourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/AbstractJavaSourceFileMutator.java
@@ -2,6 +2,7 @@ package org.gradle.profiler.mutations;
 
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import org.gradle.profiler.BuildContext;
 
 import java.io.File;
 
@@ -14,11 +15,11 @@ public abstract class AbstractJavaSourceFileMutator extends AbstractFileChangeMu
     }
 
     @Override
-    protected void applyChangeTo(StringBuilder text) {
+    protected void applyChangeTo(BuildContext context, StringBuilder text) {
         CompilationUnit compilationUnit = JavaParser.parse(text.toString());
-        applyChangeTo(compilationUnit);
+        applyChangeTo(context, compilationUnit);
         text.replace(0, text.length(), compilationUnit.toString());
     }
 
-    protected abstract void applyChangeTo(CompilationUnit compilationUnit);
+    protected abstract void applyChangeTo(BuildContext context, CompilationUnit compilationUnit);
 }

--- a/src/main/java/org/gradle/profiler/mutations/ApplyAbiChangeToJavaSourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyAbiChangeToJavaSourceFileMutator.java
@@ -6,6 +6,7 @@ import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.expr.MethodCallExpr;
+import org.gradle.profiler.BuildContext;
 
 import java.io.File;
 import java.util.List;
@@ -16,7 +17,7 @@ public class ApplyAbiChangeToJavaSourceFileMutator extends AbstractJavaSourceFil
     }
 
     @Override
-    protected void applyChangeTo(CompilationUnit compilationUnit) {
+    protected void applyChangeTo(BuildContext context, CompilationUnit compilationUnit) {
         NodeList<TypeDeclaration<?>> types = compilationUnit.getTypes();
         if (types.isEmpty()) {
             throw new IllegalArgumentException("No types to change in " + sourceFile);
@@ -27,7 +28,7 @@ public class ApplyAbiChangeToJavaSourceFileMutator extends AbstractJavaSourceFil
             throw new IllegalArgumentException("No methods to change in " + sourceFile);
         }
 
-        String newMethodName = "_m" + getUniqueText();
+        String newMethodName = "_m" + context.getUniqueBuildId();
         MethodDeclaration existingMethod = methods.get(0);
         existingMethod.getBody().get().addStatement(0, new MethodCallExpr(null, newMethodName));
 

--- a/src/main/java/org/gradle/profiler/mutations/ApplyAbiChangeToKotlinSourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyAbiChangeToKotlinSourceFileMutator.java
@@ -1,5 +1,7 @@
 package org.gradle.profiler.mutations;
 
+import org.gradle.profiler.BuildContext;
+
 import java.io.File;
 
 public class ApplyAbiChangeToKotlinSourceFileMutator extends AbstractKotlinSourceFileMutator {
@@ -9,9 +11,9 @@ public class ApplyAbiChangeToKotlinSourceFileMutator extends AbstractKotlinSourc
     }
 
     @Override
-    protected void applyChangeTo(StringBuilder text) {
+    protected void applyChangeTo(BuildContext context, StringBuilder text) {
         text.append("fun _m")
-                .append(getUniqueText())
+                .append(context.getUniqueBuildId())
                 .append("() {}");
     }
 }

--- a/src/main/java/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutator.java
@@ -1,5 +1,7 @@
 package org.gradle.profiler.mutations;
 
+import org.gradle.profiler.BuildContext;
+
 import java.io.File;
 
 /**
@@ -16,37 +18,37 @@ public class ApplyChangeToAndroidLayoutFileMutator extends AbstractFileChangeMut
     }
 
     @Override
-    protected void applyChangeTo(StringBuilder text) {
+    protected void applyChangeTo(BuildContext context, StringBuilder text) {
         int insertPos = text.lastIndexOf("</layout>");
         if (insertPos < 0) {
-            applyChangeToNonDataBindingLayout(text);
+            applyChangeToNonDataBindingLayout(context, text);
         } else {
-            applyChangeToDataBindingLayout(text, insertPos);
+            applyChangeToDataBindingLayout(context, text, insertPos);
         }
     }
 
-    private void applyChangeToDataBindingLayout(StringBuilder text, int tagEndPosition) {
+    private void applyChangeToDataBindingLayout(BuildContext context, StringBuilder text, int tagEndPosition) {
         String substring = text.substring(0, tagEndPosition);
         int insertPos = substring.lastIndexOf("</");
         if (insertPos < 0) {
             throw new IllegalArgumentException("Cannot parse android layout file " + sourceFile + " to apply changes position " + insertPos);
         }
 
-        text.insert(insertPos, generateUniqueViewItem());
+        text.insert(insertPos, generateUniqueViewItem(context));
     }
 
-    private void applyChangeToNonDataBindingLayout(StringBuilder text) {
+    private void applyChangeToNonDataBindingLayout(BuildContext context, StringBuilder text) {
         int insertPos = text.lastIndexOf("</");
         if (insertPos < 0) {
             throw new IllegalArgumentException("Cannot parse android layout file " + sourceFile + " to apply changes");
         }
 
-        text.insert(insertPos, generateUniqueViewItem());
+        text.insert(insertPos, generateUniqueViewItem(context));
     }
 
-    private String generateUniqueViewItem() {
+    private String generateUniqueViewItem(BuildContext context) {
         return "<View \n" +
-               "    android:id=\"@+id/view" + getUniqueText() + "\"\n" +
+               "    android:id=\"@+id/view" + context.getUniqueBuildId() + "\"\n" +
                "    android:visibility=\"gone\"\n" +
                "    android:layout_width=\"5dp\"\n" +
                "    android:layout_height=\"5dp\"/>\n" +

--- a/src/main/java/org/gradle/profiler/mutations/ApplyChangeToAndroidManifestFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyChangeToAndroidManifestFileMutator.java
@@ -1,5 +1,7 @@
 package org.gradle.profiler.mutations;
 
+import org.gradle.profiler.BuildContext;
+
 import java.io.File;
 
 public class ApplyChangeToAndroidManifestFileMutator extends AbstractFileChangeMutator {
@@ -8,11 +10,11 @@ public class ApplyChangeToAndroidManifestFileMutator extends AbstractFileChangeM
     }
 
     @Override
-    protected void applyChangeTo(StringBuilder text) {
+    protected void applyChangeTo(BuildContext context, StringBuilder text) {
         int insertPos = text.lastIndexOf("</manifest>");
         if (insertPos < 0) {
             throw new IllegalArgumentException("Cannot parse android manifest file " + sourceFile + " to apply changes");
         }
-        text.insert(insertPos, "<!-- " + getUniqueText() + " --><permission android:name=\"com.acme.SOME_PERMISSION\"/>");
+        text.insert(insertPos, "<!-- " + context.getUniqueBuildId() + " --><permission android:name=\"com.acme.SOME_PERMISSION\"/>");
     }
 }

--- a/src/main/java/org/gradle/profiler/mutations/ApplyChangeToAndroidResourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyChangeToAndroidResourceFileMutator.java
@@ -1,5 +1,7 @@
 package org.gradle.profiler.mutations;
 
+import org.gradle.profiler.BuildContext;
+
 import java.io.File;
 
 public class ApplyChangeToAndroidResourceFileMutator extends AbstractFileChangeMutator {
@@ -8,11 +10,11 @@ public class ApplyChangeToAndroidResourceFileMutator extends AbstractFileChangeM
     }
 
     @Override
-    protected void applyChangeTo(StringBuilder text) {
+    protected void applyChangeTo(BuildContext context, StringBuilder text) {
         int insertPos = text.lastIndexOf("</resources>");
         if (insertPos < 0) {
             throw new IllegalArgumentException("Cannot parse source file " + sourceFile + " to apply changes");
         }
-        text.insert(insertPos, "<string name=\"new_resource\">" + getUniqueText() + "</string>");
+        text.insert(insertPos, "<string name=\"new_resource\">" + context.getUniqueBuildId() + "</string>");
     }
 }

--- a/src/main/java/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutator.java
@@ -1,9 +1,10 @@
 package org.gradle.profiler.mutations;
 
+import org.gradle.profiler.BuildContext;
+
 import java.io.File;
 
 public class ApplyChangeToNativeSourceFileMutator extends AbstractFileChangeMutator {
-    private static long classCreationTime = System.currentTimeMillis();
 
     public ApplyChangeToNativeSourceFileMutator(File file) {
         super(file);
@@ -13,29 +14,29 @@ public class ApplyChangeToNativeSourceFileMutator extends AbstractFileChangeMuta
     }
 
     @Override
-    protected void applyChangeTo(StringBuilder text) {
+    protected void applyChangeTo(BuildContext context, StringBuilder text) {
         int insertPos;
         if (sourceFile.getName().endsWith(".cpp")) {
             insertPos = text.length();
-            applyChangeAt(text, insertPos);
+            applyChangeAt(context, text, insertPos);
         } else {
             insertPos = text.lastIndexOf("#endif");
             if (insertPos < 0) {
                 throw new IllegalArgumentException("Cannot parse header file " + sourceFile + " to apply changes");
             }
-            applyHeaderChangeAt(text, insertPos);
+            applyHeaderChangeAt(context, text, insertPos);
         }
     }
 
-    protected String getSharedUniqueText() {
-        return "_" + String.valueOf(classCreationTime) + "_" + counter;
+    protected String getFieldName(BuildContext context) {
+        return "_m" + context.getUniqueBuildId();
     }
 
-    protected void applyChangeAt(StringBuilder text, int insertPos) {
-        text.insert(insertPos, "\nint _m" + getSharedUniqueText() + " () { }");
+    private void applyChangeAt(BuildContext context, StringBuilder text, int insertPos) {
+        text.insert(insertPos, "\nint " + getFieldName(context) + " () { }");
     }
 
-    protected void applyHeaderChangeAt(StringBuilder text, int insertPos) {
-        text.insert(insertPos, "int _m" + getSharedUniqueText() + "();\n");
+    private void applyHeaderChangeAt(BuildContext context, StringBuilder text, int insertPos) {
+        text.insert(insertPos, "int " + getFieldName(context) + "();\n");
     }
 }

--- a/src/main/java/org/gradle/profiler/mutations/ApplyChangeToPropertyResourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyChangeToPropertyResourceFileMutator.java
@@ -1,5 +1,7 @@
 package org.gradle.profiler.mutations;
 
+import org.gradle.profiler.BuildContext;
+
 import java.io.File;
 
 public class ApplyChangeToPropertyResourceFileMutator extends AbstractFileChangeMutator {
@@ -8,7 +10,7 @@ public class ApplyChangeToPropertyResourceFileMutator extends AbstractFileChange
     }
 
     @Override
-    protected void applyChangeTo(StringBuilder text) {
-        text.append("\norg.acme.some=").append(getUniqueText()).append("\n");
+    protected void applyChangeTo(BuildContext context, StringBuilder text) {
+        text.append("\norg.acme.some=").append(context.getUniqueBuildId()).append("\n");
     }
 }

--- a/src/main/java/org/gradle/profiler/mutations/ApplyNonAbiChangeToJavaSourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyNonAbiChangeToJavaSourceFileMutator.java
@@ -5,6 +5,7 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
+import org.gradle.profiler.BuildContext;
 
 import java.io.File;
 import java.util.List;
@@ -15,9 +16,10 @@ public class ApplyNonAbiChangeToJavaSourceFileMutator extends AbstractJavaSource
     }
 
     @Override
-    protected void applyChangeTo(CompilationUnit compilationUnit) {
+    protected void applyChangeTo(BuildContext context, CompilationUnit compilationUnit) {
         MethodDeclaration existingMethod = getExistingMethod(compilationUnit);
-        existingMethod.getBody().get().addStatement(0, JavaParser.parseStatement("System.out.println(\"" + getUniqueText() + "\");"));
+        existingMethod.getBody()
+            .ifPresent(body -> body.addStatement(0, JavaParser.parseStatement("System.out.println(\"" + context.getUniqueBuildId() + "\");")));
     }
 
     private MethodDeclaration getExistingMethod(CompilationUnit compilationUnit) {

--- a/src/main/java/org/gradle/profiler/mutations/ApplyNonAbiChangeToJavaSourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyNonAbiChangeToJavaSourceFileMutator.java
@@ -19,7 +19,8 @@ public class ApplyNonAbiChangeToJavaSourceFileMutator extends AbstractJavaSource
     protected void applyChangeTo(BuildContext context, CompilationUnit compilationUnit) {
         MethodDeclaration existingMethod = getExistingMethod(compilationUnit);
         existingMethod.getBody()
-            .ifPresent(body -> body.addStatement(0, JavaParser.parseStatement("System.out.println(\"" + context.getUniqueBuildId() + "\");")));
+            .orElseThrow(() -> new RuntimeException("Method body not found"))
+            .addStatement(0, JavaParser.parseStatement("System.out.println(\"" + context.getUniqueBuildId() + "\");"));
     }
 
     private MethodDeclaration getExistingMethod(CompilationUnit compilationUnit) {

--- a/src/main/java/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutator.java
@@ -1,5 +1,7 @@
 package org.gradle.profiler.mutations;
 
+import org.gradle.profiler.BuildContext;
+
 import java.io.File;
 
 public class ApplyNonAbiChangeToKotlinSourceFileMutator extends AbstractKotlinSourceFileMutator {
@@ -9,9 +11,9 @@ public class ApplyNonAbiChangeToKotlinSourceFileMutator extends AbstractKotlinSo
     }
 
     @Override
-    protected void applyChangeTo(StringBuilder text) {
+    protected void applyChangeTo(BuildContext context, StringBuilder text) {
         text.append("private fun _m")
-                .append(getUniqueText())
+                .append(context.getUniqueBuildId())
                 .append("() {}");
     }
 }

--- a/src/main/java/org/gradle/profiler/mutations/ApplyValueChangeToAndroidResourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyValueChangeToAndroidResourceFileMutator.java
@@ -1,5 +1,7 @@
 package org.gradle.profiler.mutations;
 
+import org.gradle.profiler.BuildContext;
+
 import java.io.File;
 
 public class ApplyValueChangeToAndroidResourceFileMutator extends AbstractFileChangeMutator {
@@ -8,11 +10,11 @@ public class ApplyValueChangeToAndroidResourceFileMutator extends AbstractFileCh
     }
 
     @Override
-    protected void applyChangeTo(StringBuilder text) {
+    protected void applyChangeTo(BuildContext context, StringBuilder text) {
         int insertPos = text.lastIndexOf("</string>");
         if (insertPos < 0) {
             throw new IllegalArgumentException("Cannot parse source file " + sourceFile + " to apply changes");
         }
-        text.insert(insertPos, getUniqueText());
+        text.insert(insertPos, context.getUniqueBuildId());
     }
 }

--- a/src/main/java/org/gradle/profiler/mutations/ClearGradleUserHomeMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ClearGradleUserHomeMutator.java
@@ -1,6 +1,7 @@
 package org.gradle.profiler.mutations;
 
 import org.apache.commons.io.FileUtils;
+import org.gradle.profiler.BuildContext;
 import org.gradle.profiler.BuildMutator;
 
 import java.io.File;
@@ -16,7 +17,7 @@ public class ClearGradleUserHomeMutator extends AbstractBuildMutator {
     }
 
     @Override
-    public void beforeBuild() {
+    public void beforeBuild(BuildContext context) {
         System.out.println(String.format("> Cleaning Gradle user home: %s", gradleUserHome.getAbsolutePath()));
         if (!gradleUserHome.exists()) {
             throw new IllegalArgumentException(String.format(

--- a/src/main/java/org/gradle/profiler/mutations/ClearProjectCacheMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ClearProjectCacheMutator.java
@@ -1,6 +1,7 @@
 package org.gradle.profiler.mutations;
 
 import org.apache.commons.io.FileUtils;
+import org.gradle.profiler.BuildContext;
 import org.gradle.profiler.BuildMutator;
 
 import java.io.File;
@@ -15,7 +16,7 @@ public class ClearProjectCacheMutator extends AbstractBuildMutator {
     }
 
     @Override
-    public void afterBuild(Throwable error) {
+    public void afterBuild(BuildContext context, Throwable error) {
         deleteGradleCache("project", projectDir);
         File buildSrc = new File(projectDir, "buildSrc");
         if (buildSrc.exists()) {

--- a/src/main/java/org/gradle/profiler/mutations/GitCheckoutMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/GitCheckoutMutator.java
@@ -1,9 +1,11 @@
 package org.gradle.profiler.mutations;
 
 import com.typesafe.config.Config;
+import org.gradle.profiler.BuildContext;
 import org.gradle.profiler.BuildMutator;
 import org.gradle.profiler.CommandExec;
 import org.gradle.profiler.ConfigUtil;
+import org.gradle.profiler.ScenarioContext;
 
 import java.io.File;
 import java.util.function.Supplier;
@@ -21,27 +23,27 @@ public class GitCheckoutMutator extends AbstractGitMutator {
 	}
 
 	@Override
-	public void beforeScenario() {
+	public void beforeScenario(ScenarioContext context) {
 		resetGit();
 		original = getCurrentCommit();
 	}
 
 	@Override
-	public void beforeCleanup() {
+	public void beforeCleanup(BuildContext context) {
 		if (cleanup != null) {
 			checkout(cleanup);
 		}
 	}
 
 	@Override
-	public void beforeBuild() {
+	public void beforeBuild(BuildContext context) {
 		if (build != null) {
 			checkout(build);
 		}
 	}
 
 	@Override
-	public void afterBuild(Throwable error) {
+	public void afterBuild(BuildContext context, Throwable error) {
 		if (error == null) {
 			checkout(original);
 		} else {

--- a/src/main/java/org/gradle/profiler/mutations/GitRevertMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/GitRevertMutator.java
@@ -1,9 +1,11 @@
 package org.gradle.profiler.mutations;
 
 import com.typesafe.config.Config;
+import org.gradle.profiler.BuildContext;
 import org.gradle.profiler.BuildMutator;
 import org.gradle.profiler.CommandExec;
 import org.gradle.profiler.ConfigUtil;
+import org.gradle.profiler.ScenarioContext;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -22,17 +24,17 @@ public class GitRevertMutator extends AbstractGitMutator {
 	}
 
 	@Override
-	public void beforeScenario() {
+	public void beforeScenario(ScenarioContext context) {
 		resetGit();
 	}
 
 	@Override
-	public void beforeBuild() {
+	public void beforeBuild(BuildContext context) {
         revertCommits();
 	}
 
 	@Override
-	public void afterBuild(Throwable error) {
+	public void afterBuild(BuildContext context, Throwable error) {
 		if (error == null) {
 			abortRevert();
 			resetGit();

--- a/src/main/java/org/gradle/profiler/mutations/ShowBuildCacheSizeMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ShowBuildCacheSizeMutator.java
@@ -1,6 +1,8 @@
 package org.gradle.profiler.mutations;
 
+import org.gradle.profiler.BuildContext;
 import org.gradle.profiler.BuildMutator;
+import org.gradle.profiler.ScenarioContext;
 
 import java.io.File;
 import java.text.MessageFormat;
@@ -14,17 +16,17 @@ public class ShowBuildCacheSizeMutator extends AbstractBuildMutator {
 	}
 
 	@Override
-	public void beforeScenario() {
+	public void beforeScenario(ScenarioContext context) {
 		showCacheSize();
 	}
 
 	@Override
-	public void afterCleanup(Throwable error) {
+	public void afterCleanup(BuildContext context, Throwable error) {
 		showCacheSize();
 	}
 
 	@Override
-	public void afterBuild(Throwable error) {
+	public void afterBuild(BuildContext context, Throwable error) {
 		showCacheSize();
 	}
 

--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -925,8 +925,8 @@ classes {
         then:
         // Probe version, 6 warm up, 10 builds
         logFile.find("<src-length: ${srcFile.length()}>").size() == 1
-        logFile.find("<src-length: ${srcFile.length() + (OperatingSystem.windows ? 174 : 165)}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
-        logFile.find("<src-length: ${srcFile.length() + (OperatingSystem.windows ? 176 : 167)}>").size() == 1 /* MEASURE #10 */
+        logFile.find("<src-length: ${srcFile.length() + (OperatingSystem.windows ? 210 : 201)}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
+        logFile.find("<src-length: ${srcFile.length() + (OperatingSystem.windows ? 212 : 203)}>").size() == 1 /* MEASURE #10 */
         srcFile.text == originalText
     }
 
@@ -960,8 +960,8 @@ classes {
         then:
         // Probe version, 6 warm up, 10 builds
         logFile.find("<src-length: ${srcFile.length()}>").size() == 1
-        logFile.find("<src-length: ${srcFile.length() + 92}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
-        logFile.find("<src-length: ${srcFile.length() + 93}>").size() == 1 /* MEASURE #10 */
+        logFile.find("<src-length: ${srcFile.length() + 110}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
+        logFile.find("<src-length: ${srcFile.length() + 111}>").size() == 1 /* MEASURE #10 */
         srcFile.text == originalText
     }
 
@@ -995,8 +995,8 @@ classes {
         then:
         // Probe version, 6 warm up, 10 builds
         logFile.find("<src-length: ${srcFile.length()}>").size() == 1
-        logFile.find("<src-length: ${srcFile.length() + 55}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
-        logFile.find("<src-length: ${srcFile.length() + 56}>").size() == 1 /* MEASURE #10 */
+        logFile.find("<src-length: ${srcFile.length() + 73}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
+        logFile.find("<src-length: ${srcFile.length() + 74}>").size() == 1 /* MEASURE #10 */
         srcFile.text == originalText
     }
 

--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -925,8 +925,8 @@ classes {
         then:
         // Probe version, 6 warm up, 10 builds
         logFile.find("<src-length: ${srcFile.length()}>").size() == 1
-        logFile.find("<src-length: ${srcFile.length() + (OperatingSystem.windows ? 96 : 87)}>").size() == 9
-        logFile.find("<src-length: ${srcFile.length() + (OperatingSystem.windows ? 98 : 89)}>").size() == 7
+        logFile.find("<src-length: ${srcFile.length() + (OperatingSystem.windows ? 174 : 165)}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
+        logFile.find("<src-length: ${srcFile.length() + (OperatingSystem.windows ? 176 : 167)}>").size() == 1 /* MEASURE #10 */
         srcFile.text == originalText
     }
 
@@ -960,8 +960,8 @@ classes {
         then:
         // Probe version, 6 warm up, 10 builds
         logFile.find("<src-length: ${srcFile.length()}>").size() == 1
-        logFile.find("<src-length: ${srcFile.length() + 53}>").size() == 9
-        logFile.find("<src-length: ${srcFile.length() + 54}>").size() == 7
+        logFile.find("<src-length: ${srcFile.length() + 92}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
+        logFile.find("<src-length: ${srcFile.length() + 93}>").size() == 1 /* MEASURE #10 */
         srcFile.text == originalText
     }
 
@@ -995,8 +995,8 @@ classes {
         then:
         // Probe version, 6 warm up, 10 builds
         logFile.find("<src-length: ${srcFile.length()}>").size() == 1
-        logFile.find("<src-length: ${srcFile.length() + 16}>").size() == 9
-        logFile.find("<src-length: ${srcFile.length() + 17}>").size() == 7
+        logFile.find("<src-length: ${srcFile.length() + 55}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
+        logFile.find("<src-length: ${srcFile.length() + 56}>").size() == 1 /* MEASURE #10 */
         srcFile.text == originalText
     }
 

--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -925,8 +925,8 @@ classes {
         then:
         // Probe version, 6 warm up, 10 builds
         logFile.find("<src-length: ${srcFile.length()}>").size() == 1
-        logFile.find("<src-length: ${srcFile.length() + (OperatingSystem.windows ? 210 : 201)}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
-        logFile.find("<src-length: ${srcFile.length() + (OperatingSystem.windows ? 212 : 203)}>").size() == 1 /* MEASURE #10 */
+        logFile.find("<src-length: ${srcFile.length() + (OperatingSystem.windows ? 192 : 183)}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
+        logFile.find("<src-length: ${srcFile.length() + (OperatingSystem.windows ? 194 : 185)}>").size() == 1 /* MEASURE #10 */
         srcFile.text == originalText
     }
 
@@ -960,8 +960,8 @@ classes {
         then:
         // Probe version, 6 warm up, 10 builds
         logFile.find("<src-length: ${srcFile.length()}>").size() == 1
-        logFile.find("<src-length: ${srcFile.length() + 110}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
-        logFile.find("<src-length: ${srcFile.length() + 111}>").size() == 1 /* MEASURE #10 */
+        logFile.find("<src-length: ${srcFile.length() + 101}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
+        logFile.find("<src-length: ${srcFile.length() + 102}>").size() == 1 /* MEASURE #10 */
         srcFile.text == originalText
     }
 
@@ -995,8 +995,8 @@ classes {
         then:
         // Probe version, 6 warm up, 10 builds
         logFile.find("<src-length: ${srcFile.length()}>").size() == 1
-        logFile.find("<src-length: ${srcFile.length() + 73}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
-        logFile.find("<src-length: ${srcFile.length() + 74}>").size() == 1 /* MEASURE #10 */
+        logFile.find("<src-length: ${srcFile.length() + 64}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
+        logFile.find("<src-length: ${srcFile.length() + 65}>").size() == 1 /* MEASURE #10 */
         srcFile.text == originalText
     }
 

--- a/src/test/groovy/org/gradle/profiler/mutations/AbstractMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/AbstractMutatorTest.groovy
@@ -1,6 +1,6 @@
 package org.gradle.profiler.mutations
 
-import org.gradle.profiler.BuildContext
+import org.gradle.profiler.Phase
 import org.gradle.profiler.ScenarioContext
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -8,6 +8,6 @@ import spock.lang.Specification
 
 abstract class AbstractMutatorTest extends Specification {
     @Rule TemporaryFolder tmpDir = new TemporaryFolder()
-    def scenarioContext = Mock(ScenarioContext)
-    def buildContext = Mock(BuildContext)
+    def scenarioContext = new ScenarioContext(UUID.fromString("276d92f3-16ac-4064-9a18-5f1dfd67992f"), "testScenario")
+    def buildContext = scenarioContext.withBuild(Phase.MEASURE, 7)
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/AbstractMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/AbstractMutatorTest.groovy
@@ -1,0 +1,13 @@
+package org.gradle.profiler.mutations
+
+import org.gradle.profiler.BuildContext
+import org.gradle.profiler.ScenarioContext
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+abstract class AbstractMutatorTest extends Specification {
+    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+    def scenarioContext = Mock(ScenarioContext)
+    def buildContext = Mock(BuildContext)
+}

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToJavaSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToJavaSourceFileMutatorTest.groovy
@@ -1,6 +1,5 @@
 package org.gradle.profiler.mutations
 
-
 import static com.github.javaparser.JavaParser.parse
 
 class ApplyAbiChangeToJavaSourceFileMutatorTest extends AbstractMutatorTest {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToJavaSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToJavaSourceFileMutatorTest.groovy
@@ -9,25 +9,14 @@ class ApplyAbiChangeToJavaSourceFileMutatorTest extends AbstractMutatorTest {
         def sourceFile = tmpDir.newFile("Thing.java")
         sourceFile.text = "class Thing { public void existingMethod() { }}"
         def mutator = new ApplyAbiChangeToJavaSourceFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)
 
         then:
-        parse(sourceFile) == parse("class Thing { public void existingMethod() { _m_1234_1();}public static void _m_1234_1() { }}")
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        parse(sourceFile) == parse("class Thing { public void existingMethod() { _m_1234_2();}public static void _m_1234_2() { }}")
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        parse(sourceFile) == parse("class Thing { public void existingMethod() { _m_1234_3();}public static void _m_1234_3() { }}")
+        parse(sourceFile) == parse("class Thing { public void existingMethod() { _mUNIQUE_ID();}public static void _mUNIQUE_ID() { }}")
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToJavaSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToJavaSourceFileMutatorTest.groovy
@@ -1,13 +1,9 @@
 package org.gradle.profiler.mutations
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
 
 import static com.github.javaparser.JavaParser.parse
 
-class ApplyAbiChangeToJavaSourceFileMutatorTest extends Specification {
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+class ApplyAbiChangeToJavaSourceFileMutatorTest extends AbstractMutatorTest {
 
     def "adds and replaces public method at end of source file"() {
         def sourceFile = tmpDir.newFile("Thing.java")
@@ -16,19 +12,19 @@ class ApplyAbiChangeToJavaSourceFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         parse(sourceFile) == parse("class Thing { public void existingMethod() { _m_1234_1();}public static void _m_1234_1() { }}")
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         parse(sourceFile) == parse("class Thing { public void existingMethod() { _m_1234_2();}public static void _m_1234_2() { }}")
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         parse(sourceFile) == parse("class Thing { public void existingMethod() { _m_1234_3();}public static void _m_1234_3() { }}")
@@ -40,13 +36,13 @@ class ApplyAbiChangeToJavaSourceFileMutatorTest extends Specification {
         def mutator = new ApplyAbiChangeToJavaSourceFileMutator(sourceFile)
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "class Thing { public void existingMethod() { }}"
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "class Thing { public void existingMethod() { }}"
@@ -58,14 +54,14 @@ class ApplyAbiChangeToJavaSourceFileMutatorTest extends Specification {
         def mutator = new ApplyAbiChangeToJavaSourceFileMutator(sourceFile)
 
         when:
-        mutator.beforeBuild()
-        mutator.afterScenario()
+        mutator.beforeBuild(buildContext)
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "class Thing { public void existingMethod() { }}"
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "class Thing { public void existingMethod() { }}"

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToJavaSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToJavaSourceFileMutatorTest.groovy
@@ -13,7 +13,7 @@ class ApplyAbiChangeToJavaSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        parse(sourceFile) == parse("class Thing { public void existingMethod() { _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7();}public static void _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7() { }}")
+        parse(sourceFile) == parse("class Thing { public void existingMethod() { _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7();}public static void _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7() { }}")
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToJavaSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToJavaSourceFileMutatorTest.groovy
@@ -14,9 +14,7 @@ class ApplyAbiChangeToJavaSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        parse(sourceFile) == parse("class Thing { public void existingMethod() { _mUNIQUE_ID();}public static void _mUNIQUE_ID() { }}")
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        parse(sourceFile) == parse("class Thing { public void existingMethod() { _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7();}public static void _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7() { }}")
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToKotlinSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToKotlinSourceFileMutatorTest.groovy
@@ -11,9 +11,7 @@ class ApplyAbiChangeToKotlinSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}fun _mUNIQUE_ID() {}"
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        sourceFile.text == "class Thing { fun existingMethod() { }}fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7() {}"
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToKotlinSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToKotlinSourceFileMutatorTest.groovy
@@ -11,7 +11,7 @@ class ApplyAbiChangeToKotlinSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7() {}"
+        sourceFile.text == "class Thing { fun existingMethod() { }}fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7() {}"
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToKotlinSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToKotlinSourceFileMutatorTest.groovy
@@ -6,25 +6,14 @@ class ApplyAbiChangeToKotlinSourceFileMutatorTest extends AbstractMutatorTest {
         def sourceFile = tmpDir.newFile("Thing.kt")
         sourceFile.text = "class Thing { fun existingMethod() { }}"
         def mutator = new ApplyAbiChangeToKotlinSourceFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}fun _m_1234_1() {}"
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}fun _m_1234_2() {}"
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}fun _m_1234_3() {}"
+        sourceFile.text == "class Thing { fun existingMethod() { }}fun _mUNIQUE_ID() {}"
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToKotlinSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToKotlinSourceFileMutatorTest.groovy
@@ -1,11 +1,6 @@
 package org.gradle.profiler.mutations
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
-
-class ApplyAbiChangeToKotlinSourceFileMutatorTest extends Specification {
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+class ApplyAbiChangeToKotlinSourceFileMutatorTest extends AbstractMutatorTest {
 
     def "adds and replaces public method at end of source file"() {
         def sourceFile = tmpDir.newFile("Thing.kt")
@@ -14,19 +9,19 @@ class ApplyAbiChangeToKotlinSourceFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}fun _m_1234_1() {}"
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}fun _m_1234_2() {}"
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}fun _m_1234_3() {}"
@@ -38,13 +33,13 @@ class ApplyAbiChangeToKotlinSourceFileMutatorTest extends Specification {
         def mutator = new ApplyAbiChangeToKotlinSourceFileMutator(sourceFile)
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}"
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}"
@@ -56,14 +51,14 @@ class ApplyAbiChangeToKotlinSourceFileMutatorTest extends Specification {
         def mutator = new ApplyAbiChangeToKotlinSourceFileMutator(sourceFile)
 
         when:
-        mutator.beforeBuild()
-        mutator.afterScenario()
+        mutator.beforeBuild(buildContext)
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}"
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}"

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToSourceFileMutatorTest.groovy
@@ -9,26 +9,27 @@ class ApplyAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {
         def sourceFile = tmpDir.newFile("Thing.kt")
         sourceFile.text = "class Thing { fun existingMethod() { }}"
         def mutator = new ApplyAbiChangeToSourceFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}fun _m_1234_1() {}"
+        sourceFile.text == "class Thing { fun existingMethod() { }}fun _mUNIQUE_ID() {}"
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
     def "adds and replaces public method at end of Java source file"() {
         def sourceFile = tmpDir.newFile("Thing.java")
         sourceFile.text = "class Thing { public void existingMethod() { }}"
         def mutator = new ApplyAbiChangeToSourceFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)
 
         then:
-        parse(sourceFile) == parse("class Thing { public void existingMethod() { _m_1234_1();}public static void _m_1234_1() { }}")
+        parse(sourceFile) == parse("class Thing { public void existingMethod() { _mUNIQUE_ID();}public static void _mUNIQUE_ID() { }}")
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
-
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToSourceFileMutatorTest.groovy
@@ -13,7 +13,7 @@ class ApplyAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7() {}"
+        sourceFile.text == "class Thing { fun existingMethod() { }}fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7() {}"
     }
 
     def "adds and replaces public method at end of Java source file"() {
@@ -25,6 +25,6 @@ class ApplyAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        parse(sourceFile) == parse("class Thing { public void existingMethod() { _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7();}public static void _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7() { }}")
+        parse(sourceFile) == parse("class Thing { public void existingMethod() { _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7();}public static void _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7() { }}")
     }
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToSourceFileMutatorTest.groovy
@@ -1,6 +1,5 @@
 package org.gradle.profiler.mutations
 
-
 import static com.github.javaparser.JavaParser.parse
 
 class ApplyAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToSourceFileMutatorTest.groovy
@@ -14,9 +14,7 @@ class ApplyAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}fun _mUNIQUE_ID() {}"
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        sourceFile.text == "class Thing { fun existingMethod() { }}fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7() {}"
     }
 
     def "adds and replaces public method at end of Java source file"() {
@@ -28,8 +26,6 @@ class ApplyAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        parse(sourceFile) == parse("class Thing { public void existingMethod() { _mUNIQUE_ID();}public static void _mUNIQUE_ID() { }}")
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        parse(sourceFile) == parse("class Thing { public void existingMethod() { _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7();}public static void _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7() { }}")
     }
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToSourceFileMutatorTest.groovy
@@ -1,18 +1,9 @@
 package org.gradle.profiler.mutations
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
 
 import static com.github.javaparser.JavaParser.parse
-import static com.github.javaparser.JavaParser.parse
-import static com.github.javaparser.JavaParser.parse
-import static com.github.javaparser.JavaParser.parse
-import static com.github.javaparser.JavaParser.parse
-import static com.github.javaparser.JavaParser.parse
 
-class ApplyAbiChangeToSourceFileMutatorTest extends Specification {
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+class ApplyAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {
 
     def "adds and replaces public method at end of Kotlin source file"() {
         def sourceFile = tmpDir.newFile("Thing.kt")
@@ -21,7 +12,7 @@ class ApplyAbiChangeToSourceFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}fun _m_1234_1() {}"
@@ -34,7 +25,7 @@ class ApplyAbiChangeToSourceFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         parse(sourceFile) == parse("class Thing { public void existingMethod() { _m_1234_1();}public static void _m_1234_1() { }}")

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutatorTest.groovy
@@ -6,7 +6,6 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends AbstractMutatorTest {
         def sourceFile = tmpDir.newFile("strings.xml")
         sourceFile.text = "<LinearLayout></LinearLayout>"
         def mutator = new ApplyChangeToAndroidLayoutFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)
@@ -14,38 +13,14 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends AbstractMutatorTest {
         then:
         sourceFile.text == """\
         <LinearLayout><View 
-            android:id="@+id/view_1234_1"
+            android:id="@+id/viewUNIQUE_ID"
             android:visibility="gone"
             android:layout_width="5dp"
             android:layout_height="5dp"/>
 
         </LinearLayout>""".stripIndent()
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == """\
-        <LinearLayout><View 
-            android:id="@+id/view_1234_2"
-            android:visibility="gone"
-            android:layout_width="5dp"
-            android:layout_height="5dp"/>
-
-        </LinearLayout>""".stripIndent()
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == """\
-        <LinearLayout><View 
-            android:id="@+id/view_1234_3"
-            android:visibility="gone"
-            android:layout_width="5dp"
-            android:layout_height="5dp"/>
-
-        </LinearLayout>""".stripIndent()
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
 
@@ -53,7 +28,6 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends AbstractMutatorTest {
         def sourceFile = tmpDir.newFile("strings.xml")
         sourceFile.text = '<layout><LinearLayout></LinearLayout></layout>'
         def mutator = new ApplyChangeToAndroidLayoutFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)
@@ -61,38 +35,14 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends AbstractMutatorTest {
         then:
         sourceFile.text == """\
         <layout><LinearLayout><View 
-            android:id="@+id/view_1234_1"
+            android:id="@+id/viewUNIQUE_ID"
             android:visibility="gone"
             android:layout_width="5dp"
             android:layout_height="5dp"/>
 
         </LinearLayout></layout>""".stripIndent()
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == """\
-        <layout><LinearLayout><View 
-            android:id="@+id/view_1234_2"
-            android:visibility="gone"
-            android:layout_width="5dp"
-            android:layout_height="5dp"/>
-
-        </LinearLayout></layout>""".stripIndent()
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == """\
-        <layout><LinearLayout><View 
-            android:id="@+id/view_1234_3"
-            android:visibility="gone"
-            android:layout_width="5dp"
-            android:layout_height="5dp"/>
-
-        </LinearLayout></layout>""".stripIndent()
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutatorTest.groovy
@@ -13,14 +13,12 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends AbstractMutatorTest {
         then:
         sourceFile.text == """\
         <LinearLayout><View 
-            android:id="@+id/viewUNIQUE_ID"
+            android:id="@+id/view_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7"
             android:visibility="gone"
             android:layout_width="5dp"
             android:layout_height="5dp"/>
 
         </LinearLayout>""".stripIndent()
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
     }
 
 
@@ -35,14 +33,12 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends AbstractMutatorTest {
         then:
         sourceFile.text == """\
         <layout><LinearLayout><View 
-            android:id="@+id/viewUNIQUE_ID"
+            android:id="@+id/view_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7"
             android:visibility="gone"
             android:layout_width="5dp"
             android:layout_height="5dp"/>
 
         </LinearLayout></layout>""".stripIndent()
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutatorTest.groovy
@@ -1,11 +1,6 @@
 package org.gradle.profiler.mutations
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
-
-class ApplyChangeToAndroidLayoutFileMutatorTest extends Specification {
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+class ApplyChangeToAndroidLayoutFileMutatorTest extends AbstractMutatorTest {
 
     def "adds new view at bottom of top level layout"() {
         def sourceFile = tmpDir.newFile("strings.xml")
@@ -14,7 +9,7 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == """\
@@ -27,7 +22,7 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends Specification {
         </LinearLayout>""".stripIndent()
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == """\
@@ -40,7 +35,7 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends Specification {
         </LinearLayout>""".stripIndent()
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == """\
@@ -61,7 +56,7 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == """\
@@ -74,7 +69,7 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends Specification {
         </LinearLayout></layout>""".stripIndent()
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == """\
@@ -87,7 +82,7 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends Specification {
         </LinearLayout></layout>""".stripIndent()
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == """\
@@ -106,7 +101,7 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends Specification {
         def mutator = new ApplyChangeToAndroidLayoutFileMutator(sourceFile)
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "<LinearLayout></LinearLayout>"
@@ -118,8 +113,8 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends Specification {
         def mutator = new ApplyChangeToAndroidLayoutFileMutator(sourceFile)
 
         when:
-        mutator.beforeBuild()
-        mutator.afterScenario()
+        mutator.beforeBuild(buildContext)
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "<LinearLayout></LinearLayout>"

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidLayoutFileMutatorTest.groovy
@@ -13,7 +13,7 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends AbstractMutatorTest {
         then:
         sourceFile.text == """\
         <LinearLayout><View 
-            android:id="@+id/view_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7"
+            android:id="@+id/view_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7"
             android:visibility="gone"
             android:layout_width="5dp"
             android:layout_height="5dp"/>
@@ -33,7 +33,7 @@ class ApplyChangeToAndroidLayoutFileMutatorTest extends AbstractMutatorTest {
         then:
         sourceFile.text == """\
         <layout><LinearLayout><View 
-            android:id="@+id/view_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7"
+            android:id="@+id/view_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7"
             android:visibility="gone"
             android:layout_width="5dp"
             android:layout_height="5dp"/>

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidManifestFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidManifestFileMutatorTest.groovy
@@ -11,9 +11,7 @@ class ApplyChangeToAndroidManifestFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == '<manifest><!-- UNIQUE_ID --><permission android:name="com.acme.SOME_PERMISSION"/></manifest>'
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        sourceFile.text == '<manifest><!-- _276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7 --><permission android:name="com.acme.SOME_PERMISSION"/></manifest>'
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidManifestFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidManifestFileMutatorTest.groovy
@@ -6,25 +6,14 @@ class ApplyChangeToAndroidManifestFileMutatorTest extends AbstractMutatorTest {
         def sourceFile = tmpDir.newFile("AndroidManifest.xml")
         sourceFile.text = "<manifest></manifest>"
         def mutator = new ApplyChangeToAndroidManifestFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == '<manifest><!-- _1234_1 --><permission android:name="com.acme.SOME_PERMISSION"/></manifest>'
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == '<manifest><!-- _1234_2 --><permission android:name="com.acme.SOME_PERMISSION"/></manifest>'
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == '<manifest><!-- _1234_3 --><permission android:name="com.acme.SOME_PERMISSION"/></manifest>'
+        sourceFile.text == '<manifest><!-- UNIQUE_ID --><permission android:name="com.acme.SOME_PERMISSION"/></manifest>'
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidManifestFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidManifestFileMutatorTest.groovy
@@ -11,7 +11,7 @@ class ApplyChangeToAndroidManifestFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == '<manifest><!-- _276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7 --><permission android:name="com.acme.SOME_PERMISSION"/></manifest>'
+        sourceFile.text == '<manifest><!-- _276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7 --><permission android:name="com.acme.SOME_PERMISSION"/></manifest>'
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidManifestFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidManifestFileMutatorTest.groovy
@@ -1,12 +1,6 @@
 package org.gradle.profiler.mutations
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
-
-class ApplyChangeToAndroidManifestFileMutatorTest extends Specification {
-    @Rule
-    TemporaryFolder tmpDir = new TemporaryFolder()
+class ApplyChangeToAndroidManifestFileMutatorTest extends AbstractMutatorTest {
 
     def "adds fake permission to end of android manifest file"() {
         def sourceFile = tmpDir.newFile("AndroidManifest.xml")
@@ -15,19 +9,19 @@ class ApplyChangeToAndroidManifestFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == '<manifest><!-- _1234_1 --><permission android:name="com.acme.SOME_PERMISSION"/></manifest>'
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == '<manifest><!-- _1234_2 --><permission android:name="com.acme.SOME_PERMISSION"/></manifest>'
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == '<manifest><!-- _1234_3 --><permission android:name="com.acme.SOME_PERMISSION"/></manifest>'
@@ -39,7 +33,7 @@ class ApplyChangeToAndroidManifestFileMutatorTest extends Specification {
         def mutator = new ApplyChangeToAndroidManifestFileMutator(sourceFile)
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "<manifest></manifest>"
@@ -51,8 +45,8 @@ class ApplyChangeToAndroidManifestFileMutatorTest extends Specification {
         def mutator = new ApplyChangeToAndroidManifestFileMutator(sourceFile)
 
         when:
-        mutator.beforeBuild()
-        mutator.afterScenario()
+        mutator.beforeBuild(buildContext)
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "<manifest></manifest>"

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidResourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidResourceFileMutatorTest.groovy
@@ -11,7 +11,7 @@ class ApplyChangeToAndroidResourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == '<resources><string name="new_resource">_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7</string></resources>'
+        sourceFile.text == '<resources><string name="new_resource">_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7</string></resources>'
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidResourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidResourceFileMutatorTest.groovy
@@ -6,25 +6,14 @@ class ApplyChangeToAndroidResourceFileMutatorTest extends AbstractMutatorTest {
         def sourceFile = tmpDir.newFile("strings.xml")
         sourceFile.text = "<resources></resources>"
         def mutator = new ApplyChangeToAndroidResourceFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == '<resources><string name="new_resource">_1234_1</string></resources>'
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == '<resources><string name="new_resource">_1234_2</string></resources>'
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == '<resources><string name="new_resource">_1234_3</string></resources>'
+        sourceFile.text == '<resources><string name="new_resource">UNIQUE_ID</string></resources>'
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidResourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidResourceFileMutatorTest.groovy
@@ -11,9 +11,7 @@ class ApplyChangeToAndroidResourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == '<resources><string name="new_resource">UNIQUE_ID</string></resources>'
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        sourceFile.text == '<resources><string name="new_resource">_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7</string></resources>'
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidResourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidResourceFileMutatorTest.groovy
@@ -1,11 +1,6 @@
 package org.gradle.profiler.mutations
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
-
-class ApplyChangeToAndroidResourceFileMutatorTest extends Specification {
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+class ApplyChangeToAndroidResourceFileMutatorTest extends AbstractMutatorTest {
 
     def "adds string resource to end of source file"() {
         def sourceFile = tmpDir.newFile("strings.xml")
@@ -14,19 +9,19 @@ class ApplyChangeToAndroidResourceFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == '<resources><string name="new_resource">_1234_1</string></resources>'
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == '<resources><string name="new_resource">_1234_2</string></resources>'
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == '<resources><string name="new_resource">_1234_3</string></resources>'
@@ -38,7 +33,7 @@ class ApplyChangeToAndroidResourceFileMutatorTest extends Specification {
         def mutator = new ApplyChangeToAndroidResourceFileMutator(sourceFile)
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "<resources></resources>"
@@ -50,8 +45,8 @@ class ApplyChangeToAndroidResourceFileMutatorTest extends Specification {
         def mutator = new ApplyChangeToAndroidResourceFileMutator(sourceFile)
 
         when:
-        mutator.beforeBuild()
-        mutator.afterScenario()
+        mutator.beforeBuild(buildContext)
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "<resources></resources>"

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutatorTest.groovy
@@ -1,11 +1,6 @@
 package org.gradle.profiler.mutations
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
-
-class ApplyChangeToNativeSourceFileMutatorTest extends Specification {
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
 
     def "adds and replaces method to end of cpp source file"() {
         def sourceFile = tmpDir.newFile("Thing.cpp")
@@ -14,19 +9,19 @@ class ApplyChangeToNativeSourceFileMutatorTest extends Specification {
         ApplyChangeToNativeSourceFileMutator.classCreationTime = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == " \nint _m_1234_1 () { }"
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == " \nint _m_1234_2 () { }"
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == " \nint _m_1234_3 () { }"
@@ -40,19 +35,19 @@ class ApplyChangeToNativeSourceFileMutatorTest extends Specification {
         ApplyChangeToNativeSourceFileMutator.classCreationTime = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == "#ifndef ABC\n\nint _m_1234_1();\n#endif"
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == "#ifndef ABC\n\nint _m_1234_2();\n#endif"
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == "#ifndef ABC\n\nint _m_1234_3();\n#endif"
@@ -70,16 +65,16 @@ class ApplyChangeToNativeSourceFileMutatorTest extends Specification {
         ApplyChangeToNativeSourceFileMutator.classCreationTime = 1234
 
         when:
-        mutatorCPP.beforeBuild()
-        mutatorH.beforeBuild()
+        mutatorCPP.beforeBuild(buildContext)
+        mutatorH.beforeBuild(buildContext)
 
         then:
         sourceFileCPP.text == " \nint _m_1234_1 () { }"
         sourceFileH.text == "#ifndef ABC\n\nint _m_1234_1();\n#endif"
 
         when:
-        mutatorCPP.beforeBuild()
-        mutatorH.beforeBuild()
+        mutatorCPP.beforeBuild(buildContext)
+        mutatorH.beforeBuild(buildContext)
 
         then:
         sourceFileCPP.text == " \nint _m_1234_2 () { }"

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutatorTest.groovy
@@ -6,25 +6,14 @@ class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
         def sourceFile = tmpDir.newFile("Thing.cpp")
         sourceFile.text = " "
         def mutator = new ApplyChangeToNativeSourceFileMutator(sourceFile)
-        ApplyChangeToNativeSourceFileMutator.classCreationTime = 1234
 
         when:
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == " \nint _m_1234_1 () { }"
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == " \nint _m_1234_2 () { }"
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == " \nint _m_1234_3 () { }"
+        sourceFile.text == " \nint _mUNIQUE_ID () { }"
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
     def "adds and replaces method to end of h source file"() {
@@ -32,25 +21,14 @@ class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
         sourceFile.text = "#ifndef ABC\n\n#endif"
 
         def mutator = new ApplyChangeToNativeSourceFileMutator(sourceFile)
-        ApplyChangeToNativeSourceFileMutator.classCreationTime = 1234
 
         when:
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "#ifndef ABC\n\nint _m_1234_1();\n#endif"
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == "#ifndef ABC\n\nint _m_1234_2();\n#endif"
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == "#ifndef ABC\n\nint _m_1234_3();\n#endif"
+        sourceFile.text == "#ifndef ABC\n\nint _mUNIQUE_ID();\n#endif"
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
     def "uses same name for method in CPP and H files"() {
@@ -62,23 +40,20 @@ class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
         def mutatorCPP = new ApplyChangeToNativeSourceFileMutator(sourceFileCPP)
         def mutatorH = new ApplyChangeToNativeSourceFileMutator(sourceFileH)
 
-        ApplyChangeToNativeSourceFileMutator.classCreationTime = 1234
-
         when:
         mutatorCPP.beforeBuild(buildContext)
+
+        then:
+        sourceFileCPP.text == " \nint _mUNIQUE_ID () { }"
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+
+        when:
         mutatorH.beforeBuild(buildContext)
 
         then:
-        sourceFileCPP.text == " \nint _m_1234_1 () { }"
-        sourceFileH.text == "#ifndef ABC\n\nint _m_1234_1();\n#endif"
-
-        when:
-        mutatorCPP.beforeBuild(buildContext)
-        mutatorH.beforeBuild(buildContext)
-
-        then:
-        sourceFileCPP.text == " \nint _m_1234_2 () { }"
-        sourceFileH.text == "#ifndef ABC\n\nint _m_1234_2();\n#endif"
+        sourceFileH.text == "#ifndef ABC\n\nint _mUNIQUE_ID();\n#endif"
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutatorTest.groovy
@@ -11,7 +11,7 @@ class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == " \nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7 () { }"
+        sourceFile.text == " \nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7 () { }"
     }
 
     def "adds and replaces method to end of h source file"() {
@@ -24,7 +24,7 @@ class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "#ifndef ABC\n\nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7();\n#endif"
+        sourceFile.text == "#ifndef ABC\n\nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7();\n#endif"
     }
 
     def "uses same name for method in CPP and H files"() {
@@ -40,13 +40,13 @@ class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
         mutatorCPP.beforeBuild(buildContext)
 
         then:
-        sourceFileCPP.text == " \nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7 () { }"
+        sourceFileCPP.text == " \nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7 () { }"
 
         when:
         mutatorH.beforeBuild(buildContext)
 
         then:
-        sourceFileH.text == "#ifndef ABC\n\nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7();\n#endif"
+        sourceFileH.text == "#ifndef ABC\n\nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7();\n#endif"
     }
 
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutatorTest.groovy
@@ -11,9 +11,7 @@ class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == " \nint _mUNIQUE_ID () { }"
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        sourceFile.text == " \nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7 () { }"
     }
 
     def "adds and replaces method to end of h source file"() {
@@ -26,9 +24,7 @@ class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "#ifndef ABC\n\nint _mUNIQUE_ID();\n#endif"
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        sourceFile.text == "#ifndef ABC\n\nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7();\n#endif"
     }
 
     def "uses same name for method in CPP and H files"() {
@@ -44,16 +40,13 @@ class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
         mutatorCPP.beforeBuild(buildContext)
 
         then:
-        sourceFileCPP.text == " \nint _mUNIQUE_ID () { }"
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        sourceFileCPP.text == " \nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7 () { }"
 
         when:
         mutatorH.beforeBuild(buildContext)
 
         then:
-        sourceFileH.text == "#ifndef ABC\n\nint _mUNIQUE_ID();\n#endif"
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        sourceFileH.text == "#ifndef ABC\n\nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7();\n#endif"
     }
 
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToPropertyResourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToPropertyResourceFileMutatorTest.groovy
@@ -12,9 +12,7 @@ class ApplyChangeToPropertyResourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == 'org.foo=bar\norg.acme.some=UNIQUE_ID\n'
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        sourceFile.text == 'org.foo=bar\norg.acme.some=_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7\n'
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToPropertyResourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToPropertyResourceFileMutatorTest.groovy
@@ -12,7 +12,7 @@ class ApplyChangeToPropertyResourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == 'org.foo=bar\norg.acme.some=_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7\n'
+        sourceFile.text == 'org.foo=bar\norg.acme.some=_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7\n'
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToPropertyResourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToPropertyResourceFileMutatorTest.groovy
@@ -7,25 +7,14 @@ class ApplyChangeToPropertyResourceFileMutatorTest extends AbstractMutatorTest {
         def sourceFile = tmpDir.newFile("test.properties")
         sourceFile.text = ORIGINAL_CONTENTS
         def mutator = new ApplyChangeToPropertyResourceFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == 'org.foo=bar\norg.acme.some=_1234_1\n'
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == 'org.foo=bar\norg.acme.some=_1234_2\n'
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == 'org.foo=bar\norg.acme.some=_1234_3\n'
+        sourceFile.text == 'org.foo=bar\norg.acme.some=UNIQUE_ID\n'
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToPropertyResourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToPropertyResourceFileMutatorTest.groovy
@@ -1,12 +1,7 @@
 package org.gradle.profiler.mutations
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
-
-class ApplyChangeToPropertyResourceFileMutatorTest extends Specification {
+class ApplyChangeToPropertyResourceFileMutatorTest extends AbstractMutatorTest {
     public static final String ORIGINAL_CONTENTS = "org.foo=bar"
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
 
     def "adds and removes property to end of source file"() {
         def sourceFile = tmpDir.newFile("test.properties")
@@ -15,19 +10,19 @@ class ApplyChangeToPropertyResourceFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == 'org.foo=bar\norg.acme.some=_1234_1\n'
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == 'org.foo=bar\norg.acme.some=_1234_2\n'
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == 'org.foo=bar\norg.acme.some=_1234_3\n'
@@ -39,7 +34,7 @@ class ApplyChangeToPropertyResourceFileMutatorTest extends Specification {
         def mutator = new ApplyChangeToPropertyResourceFileMutator(sourceFile)
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == ORIGINAL_CONTENTS
@@ -51,8 +46,8 @@ class ApplyChangeToPropertyResourceFileMutatorTest extends Specification {
         def mutator = new ApplyChangeToPropertyResourceFileMutator(sourceFile)
 
         when:
-        mutator.beforeBuild()
-        mutator.afterScenario()
+        mutator.beforeBuild(buildContext)
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == ORIGINAL_CONTENTS

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToJavaSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToJavaSourceFileMutatorTest.groovy
@@ -9,32 +9,20 @@ class ApplyNonAbiChangeToJavaSourceFileMutatorTest extends AbstractMutatorTest {
         def sourceFile = tmpDir.newFile("Thing.java")
         sourceFile.text = "class Thing { public void existingMethod() { }}"
         def mutator = new ApplyNonAbiChangeToJavaSourceFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)
 
         then:
-        parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("_1234_1");}}')
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("_1234_2");}}')
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("_1234_3");}}')
+        parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("UNIQUE_ID");}}')
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
     def "does not work with Java files that do not contain a method"() {
         def sourceFile = tmpDir.newFile("Thing.java")
         sourceFile.text = "class Thing { }"
         def mutator = new ApplyNonAbiChangeToJavaSourceFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToJavaSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToJavaSourceFileMutatorTest.groovy
@@ -13,7 +13,7 @@ class ApplyNonAbiChangeToJavaSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7");}}')
+        parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7");}}')
     }
 
     def "does not work with Java files that do not contain a method"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToJavaSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToJavaSourceFileMutatorTest.groovy
@@ -1,13 +1,9 @@
 package org.gradle.profiler.mutations
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
 
 import static com.github.javaparser.JavaParser.parse
 
-class ApplyNonAbiChangeToJavaSourceFileMutatorTest extends Specification {
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+class ApplyNonAbiChangeToJavaSourceFileMutatorTest extends AbstractMutatorTest {
 
     def "changes the first method in the source file"() {
         def sourceFile = tmpDir.newFile("Thing.java")
@@ -16,19 +12,19 @@ class ApplyNonAbiChangeToJavaSourceFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("_1234_1");}}')
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("_1234_2");}}')
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("_1234_3");}}')
@@ -41,7 +37,7 @@ class ApplyNonAbiChangeToJavaSourceFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         IllegalArgumentException t = thrown()

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToJavaSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToJavaSourceFileMutatorTest.groovy
@@ -14,9 +14,7 @@ class ApplyNonAbiChangeToJavaSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("UNIQUE_ID");}}')
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7");}}')
     }
 
     def "does not work with Java files that do not contain a method"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToJavaSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToJavaSourceFileMutatorTest.groovy
@@ -1,6 +1,5 @@
 package org.gradle.profiler.mutations
 
-
 import static com.github.javaparser.JavaParser.parse
 
 class ApplyNonAbiChangeToJavaSourceFileMutatorTest extends AbstractMutatorTest {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutatorTest.groovy
@@ -11,7 +11,7 @@ class ApplyNonAbiChangeToKotlinSourceFileMutatorTest extends AbstractMutatorTest
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7() {}"
+        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7() {}"
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutatorTest.groovy
@@ -11,9 +11,7 @@ class ApplyNonAbiChangeToKotlinSourceFileMutatorTest extends AbstractMutatorTest
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _mUNIQUE_ID() {}"
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7() {}"
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutatorTest.groovy
@@ -6,25 +6,14 @@ class ApplyNonAbiChangeToKotlinSourceFileMutatorTest extends AbstractMutatorTest
         def sourceFile = tmpDir.newFile("Thing.kt")
         sourceFile.text = "class Thing { fun existingMethod() { }}"
         def mutator = new ApplyNonAbiChangeToKotlinSourceFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_1234_1() {}"
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_1234_2() {}"
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_1234_3() {}"
+        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _mUNIQUE_ID() {}"
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutatorTest.groovy
@@ -1,11 +1,6 @@
 package org.gradle.profiler.mutations
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
-
-class ApplyNonAbiChangeToKotlinSourceFileMutatorTest extends Specification {
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+class ApplyNonAbiChangeToKotlinSourceFileMutatorTest extends AbstractMutatorTest {
 
     def "adds and replaces public method at end of source file"() {
         def sourceFile = tmpDir.newFile("Thing.kt")
@@ -14,19 +9,19 @@ class ApplyNonAbiChangeToKotlinSourceFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_1234_1() {}"
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_1234_2() {}"
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_1234_3() {}"
@@ -38,13 +33,13 @@ class ApplyNonAbiChangeToKotlinSourceFileMutatorTest extends Specification {
         def mutator = new ApplyNonAbiChangeToKotlinSourceFileMutator(sourceFile)
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}"
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}"
@@ -56,14 +51,14 @@ class ApplyNonAbiChangeToKotlinSourceFileMutatorTest extends Specification {
         def mutator = new ApplyNonAbiChangeToKotlinSourceFileMutator(sourceFile)
 
         when:
-        mutator.beforeBuild()
-        mutator.afterScenario()
+        mutator.beforeBuild(buildContext)
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}"
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}"

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToSourceFileMutatorTest.groovy
@@ -1,13 +1,9 @@
 package org.gradle.profiler.mutations
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
 
 import static com.github.javaparser.JavaParser.parse
 
-class ApplyNonAbiChangeToSourceFileMutatorTest extends Specification {
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+class ApplyNonAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {
 
     def "adds and replaces public method at end of Kotlin source file"() {
         def sourceFile = tmpDir.newFile("Thing.kt")
@@ -16,7 +12,7 @@ class ApplyNonAbiChangeToSourceFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_1234_1() {}"
@@ -29,10 +25,9 @@ class ApplyNonAbiChangeToSourceFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("_1234_1");}}')
     }
-
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToSourceFileMutatorTest.groovy
@@ -13,7 +13,7 @@ class ApplyNonAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7() {}"
+        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7() {}"
     }
 
     def "adds and replaces public method at end of Java source file"() {
@@ -25,6 +25,6 @@ class ApplyNonAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7");}}')
+        parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7");}}')
     }
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToSourceFileMutatorTest.groovy
@@ -1,6 +1,5 @@
 package org.gradle.profiler.mutations
 
-
 import static com.github.javaparser.JavaParser.parse
 
 class ApplyNonAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToSourceFileMutatorTest.groovy
@@ -9,25 +9,27 @@ class ApplyNonAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {
         def sourceFile = tmpDir.newFile("Thing.kt")
         sourceFile.text = "class Thing { fun existingMethod() { }}"
         def mutator = new ApplyNonAbiChangeToSourceFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_1234_1() {}"
+        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _mUNIQUE_ID() {}"
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
     def "adds and replaces public method at end of Java source file"() {
         def sourceFile = tmpDir.newFile("Thing.java")
         sourceFile.text = "class Thing { public void existingMethod() { }}"
         def mutator = new ApplyNonAbiChangeToSourceFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)
 
         then:
-        parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("_1234_1");}}')
+        parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("UNIQUE_ID");}}')
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToSourceFileMutatorTest.groovy
@@ -14,9 +14,7 @@ class ApplyNonAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _mUNIQUE_ID() {}"
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7() {}"
     }
 
     def "adds and replaces public method at end of Java source file"() {
@@ -28,8 +26,6 @@ class ApplyNonAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("UNIQUE_ID");}}')
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        parse(sourceFile) == parse('class Thing { public void existingMethod() { System.out.println("_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7");}}')
     }
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyValueChangeToAndroidResourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyValueChangeToAndroidResourceFileMutatorTest.groovy
@@ -1,11 +1,6 @@
 package org.gradle.profiler.mutations
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
-
-class ApplyValueChangeToAndroidResourceFileMutatorTest extends Specification {
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+class ApplyValueChangeToAndroidResourceFileMutatorTest extends AbstractMutatorTest {
 
     def "changes string resource at the end of source file"() {
         def sourceFile = tmpDir.newFile("strings.xml")
@@ -14,19 +9,19 @@ class ApplyValueChangeToAndroidResourceFileMutatorTest extends Specification {
         mutator.timestamp = 1234
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == '<resources><string name="foo">bar_1234_1</string></resources>'
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == '<resources><string name="foo">bar_1234_2</string></resources>'
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         sourceFile.text == '<resources><string name="foo">bar_1234_3</string></resources>'
@@ -38,7 +33,7 @@ class ApplyValueChangeToAndroidResourceFileMutatorTest extends Specification {
         def mutator = new ApplyValueChangeToAndroidResourceFileMutator(sourceFile)
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == '<resources><string name="foo">bar</string></resources>'
@@ -50,8 +45,8 @@ class ApplyValueChangeToAndroidResourceFileMutatorTest extends Specification {
         def mutator = new ApplyChangeToAndroidResourceFileMutator(sourceFile)
 
         when:
-        mutator.beforeBuild()
-        mutator.afterScenario()
+        mutator.beforeBuild(buildContext)
+        mutator.afterScenario(scenarioContext)
 
         then:
         sourceFile.text == '<resources><string name="foo">bar</string></resources>'

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyValueChangeToAndroidResourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyValueChangeToAndroidResourceFileMutatorTest.groovy
@@ -11,7 +11,7 @@ class ApplyValueChangeToAndroidResourceFileMutatorTest extends AbstractMutatorTe
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == '<resources><string name="foo">bar_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7</string></resources>'
+        sourceFile.text == '<resources><string name="foo">bar_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7</string></resources>'
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyValueChangeToAndroidResourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyValueChangeToAndroidResourceFileMutatorTest.groovy
@@ -11,9 +11,7 @@ class ApplyValueChangeToAndroidResourceFileMutatorTest extends AbstractMutatorTe
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == '<resources><string name="foo">barUNIQUE_ID</string></resources>'
-        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
-        0 * _
+        sourceFile.text == '<resources><string name="foo">bar_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_MEASURE_7</string></resources>'
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyValueChangeToAndroidResourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyValueChangeToAndroidResourceFileMutatorTest.groovy
@@ -6,25 +6,14 @@ class ApplyValueChangeToAndroidResourceFileMutatorTest extends AbstractMutatorTe
         def sourceFile = tmpDir.newFile("strings.xml")
         sourceFile.text = '<resources><string name="foo">bar</string></resources>'
         def mutator = new ApplyValueChangeToAndroidResourceFileMutator(sourceFile)
-        mutator.timestamp = 1234
 
         when:
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == '<resources><string name="foo">bar_1234_1</string></resources>'
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == '<resources><string name="foo">bar_1234_2</string></resources>'
-
-        when:
-        mutator.beforeBuild(buildContext)
-
-        then:
-        sourceFile.text == '<resources><string name="foo">bar_1234_3</string></resources>'
+        sourceFile.text == '<resources><string name="foo">barUNIQUE_ID</string></resources>'
+        1 * buildContext.uniqueBuildId >> "UNIQUE_ID"
+        0 * _
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ClearArtifactTransformCacheMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ClearArtifactTransformCacheMutatorTest.groovy
@@ -1,13 +1,6 @@
 package org.gradle.profiler.mutations
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
-
-
-class ClearArtifactTransformCacheMutatorTest extends Specification {
-    @Rule
-    TemporaryFolder tmpDir = new TemporaryFolder()
+class ClearArtifactTransformCacheMutatorTest extends AbstractMutatorTest {
 
     def "removes directories with transforms prefix"() {
         def userHome = tmpDir.newFolder()
@@ -24,7 +17,7 @@ class ClearArtifactTransformCacheMutatorTest extends Specification {
 
         when:
         def mutator = new ClearArtifactTransformCacheMutator(userHome, AbstractCleanupMutator.CleanupSchedule.BUILD)
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
 
         then:
         file.file

--- a/src/test/groovy/org/gradle/profiler/mutations/ClearBuildCacheMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ClearBuildCacheMutatorTest.groovy
@@ -1,16 +1,11 @@
 package org.gradle.profiler.mutations
 
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
 
 import static org.gradle.profiler.mutations.AbstractCleanupMutator.CleanupSchedule.BUILD
 import static org.gradle.profiler.mutations.AbstractCleanupMutator.CleanupSchedule.CLEANUP
 import static org.gradle.profiler.mutations.AbstractCleanupMutator.CleanupSchedule.SCENARIO
 
-class ClearBuildCacheMutatorTest extends Specification {
-    @Rule
-    TemporaryFolder tmpDir = new TemporaryFolder()
+class ClearBuildCacheMutatorTest extends AbstractMutatorTest {
 
     File gradleUserHome
     File buildCache1Entry
@@ -34,42 +29,42 @@ class ClearBuildCacheMutatorTest extends Specification {
 
         when:
         remakeCacheEntries()
-        mutator.beforeScenario()
+        mutator.beforeScenario(scenarioContext)
         then:
         !buildCache1Entry.exists()
         !buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.beforeCleanup()
+        mutator.beforeCleanup(buildContext)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.afterCleanup(null)
+        mutator.afterCleanup(buildContext, null)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.afterBuild(null)
+        mutator.afterBuild(buildContext, null)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()
@@ -80,42 +75,42 @@ class ClearBuildCacheMutatorTest extends Specification {
 
         when:
         remakeCacheEntries()
-        mutator.beforeScenario()
+        mutator.beforeScenario(scenarioContext)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.beforeCleanup()
+        mutator.beforeCleanup(buildContext)
         then:
         !buildCache1Entry.exists()
         !buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.afterCleanup(null)
+        mutator.afterCleanup(buildContext, null)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.afterBuild(null)
+        mutator.afterBuild(buildContext, null)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()
@@ -126,42 +121,42 @@ class ClearBuildCacheMutatorTest extends Specification {
 
         when:
         remakeCacheEntries()
-        mutator.beforeScenario()
+        mutator.beforeScenario(scenarioContext)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.beforeCleanup()
+        mutator.beforeCleanup(buildContext)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.afterCleanup(null)
+        mutator.afterCleanup(buildContext, null)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
         then:
         !buildCache1Entry.exists()
         !buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.afterBuild(null)
+        mutator.afterBuild(buildContext, null)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()
 
         when:
         remakeCacheEntries()
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
         then:
         buildCache1Entry.exists()
         buildCache2Entry.exists()

--- a/src/test/groovy/org/gradle/profiler/mutations/ClearBuildCacheMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ClearBuildCacheMutatorTest.groovy
@@ -1,6 +1,5 @@
 package org.gradle.profiler.mutations
 
-
 import static org.gradle.profiler.mutations.AbstractCleanupMutator.CleanupSchedule.BUILD
 import static org.gradle.profiler.mutations.AbstractCleanupMutator.CleanupSchedule.CLEANUP
 import static org.gradle.profiler.mutations.AbstractCleanupMutator.CleanupSchedule.SCENARIO

--- a/src/test/groovy/org/gradle/profiler/mutations/GitCheckoutMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/GitCheckoutMutatorTest.groovy
@@ -1,6 +1,5 @@
 package org.gradle.profiler.mutations
 
-
 import org.gradle.profiler.TestGitRepo
 
 class GitCheckoutMutatorTest extends AbstractMutatorTest {

--- a/src/test/groovy/org/gradle/profiler/mutations/GitCheckoutMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/GitCheckoutMutatorTest.groovy
@@ -1,49 +1,46 @@
 package org.gradle.profiler.mutations
 
-import org.gradle.profiler.TestGitRepo
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
 
-class GitCheckoutMutatorTest extends Specification {
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+import org.gradle.profiler.TestGitRepo
+
+class GitCheckoutMutatorTest extends AbstractMutatorTest {
 
     def "checks out target commit"() {
         def repo = new TestGitRepo(tmpDir.newFolder())
         def mutator = new GitCheckoutMutator(repo.directory, repo.modifiedCommit, repo.originalCommit)
 
         when:
-        mutator.beforeScenario()
+        mutator.beforeScenario(scenarioContext)
         then:
         repo.atFinalCommit()
 
         when:
-        mutator.beforeCleanup()
+        mutator.beforeCleanup(buildContext)
         then:
         repo.atModifiedCommit()
 
         when:
-        mutator.afterCleanup()
+        mutator.afterCleanup(buildContext, null)
         then:
         repo.atModifiedCommit()
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
         then:
         repo.atOriginalCommit()
 
         when:
-        mutator.afterBuild(new RuntimeException("Error"))
+        mutator.afterBuild(buildContext, new RuntimeException("Error"))
         then:
         repo.atOriginalCommit()
 
         when:
-        mutator.afterBuild(null)
+        mutator.afterBuild(buildContext, null)
         then:
         repo.atFinalCommit()
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
         then:
         repo.atFinalCommit()
     }
@@ -54,37 +51,37 @@ class GitCheckoutMutatorTest extends Specification {
         def mutator = new GitCheckoutMutator(repo.directory, null, repo.getOriginalCommit())
 
         when:
-        mutator.beforeScenario()
+        mutator.beforeScenario(scenarioContext)
         then:
         repo.atFinalCommit()
 
         when:
-        mutator.beforeCleanup()
+        mutator.beforeCleanup(buildContext)
         then:
         repo.atFinalCommit()
 
         when:
-        mutator.afterCleanup()
+        mutator.afterCleanup(buildContext, null)
         then:
         repo.atFinalCommit()
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
         then:
         repo.atOriginalCommit()
 
         when:
-        mutator.afterBuild(new RuntimeException("Error"))
+        mutator.afterBuild(buildContext, new RuntimeException("Error"))
         then:
         repo.atOriginalCommit()
 
         when:
-        mutator.afterBuild(null)
+        mutator.afterBuild(buildContext, null)
         then:
         repo.atFinalCommit()
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
         then:
         repo.atFinalCommit()
     }

--- a/src/test/groovy/org/gradle/profiler/mutations/GitRevertMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/GitRevertMutatorTest.groovy
@@ -1,6 +1,5 @@
 package org.gradle.profiler.mutations
 
-
 import org.gradle.profiler.TestGitRepo
 
 class GitRevertMutatorTest extends AbstractMutatorTest {

--- a/src/test/groovy/org/gradle/profiler/mutations/GitRevertMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/GitRevertMutatorTest.groovy
@@ -1,55 +1,52 @@
 package org.gradle.profiler.mutations
 
-import org.gradle.profiler.TestGitRepo
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
-import spock.lang.Specification
 
-class GitRevertMutatorTest extends Specification {
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+import org.gradle.profiler.TestGitRepo
+
+class GitRevertMutatorTest extends AbstractMutatorTest {
 
     def "reverts things properly"() {
         def repo = new TestGitRepo(tmpDir.newFolder())
         def mutator = new GitRevertMutator(repo.directory, [repo.finalCommit, repo.modifiedCommit])
 
         when:
-        mutator.beforeScenario()
+        mutator.beforeScenario(scenarioContext)
         then:
         repo.atFinalCommit()
         repo.hasFinalContent()
 
         when:
-        mutator.beforeCleanup()
+        mutator.beforeCleanup(buildContext)
         then:
         repo.atFinalCommit()
         repo.hasFinalContent()
 
         when:
-        mutator.afterCleanup()
+        mutator.afterCleanup(buildContext, null)
         then:
         repo.atFinalCommit()
         repo.hasFinalContent()
 
         when:
-        mutator.beforeBuild()
+        mutator.beforeBuild(buildContext)
         then:
         repo.atFinalCommit()
         repo.hasOriginalContent()
 
         when:
-        mutator.afterBuild(new RuntimeException("Error"))
+        mutator.afterBuild(buildContext, new RuntimeException("Error"))
         then:
         repo.atFinalCommit()
         repo.hasOriginalContent()
 
         when:
-        mutator.afterBuild(null)
+        mutator.afterBuild(buildContext, null)
         then:
         repo.atFinalCommit()
         repo.hasFinalContent()
 
         when:
-        mutator.afterScenario()
+        mutator.afterScenario(scenarioContext)
         then:
         repo.atFinalCommit()
         repo.hasFinalContent()


### PR DESCRIPTION
Fixes #166.

Instead of a timestamp to identify the scenario use a unique ID for the profiler invocation (using `UUID.randomUUID()`) and append the scenario name to it.

Instead of using a counter to distinguish between invocations append the phase name (`WARM_UP` or `MEASURE`) and the build number to the scenario ID to generate unique text for each build.