### PR TITLE
Add coverage for Gradle 6.0

### DIFF
--- a/src/test/groovy/org/gradle/profiler/AbstractProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AbstractProfilerIntegrationTest.groovy
@@ -12,7 +12,7 @@ abstract class AbstractProfilerIntegrationTest extends Specification {
     private static int NUMBER_OF_STATS = 8;
 
     @Shared
-    List<String> supportedGradleVersions = ["3.3", "3.4.1", "3.5", "4.0", "4.1", "4.2.1", "4.7", "5.2.1", "5.5.1"]
+    List<String> supportedGradleVersions = ["3.3", "3.4.1", "3.5", "4.0", "4.1", "4.2.1", "4.7", "5.2.1", "5.5.1", "5.6.3", "6.0.1"]
     @Shared
     String minimalSupportedGradleVersion = supportedGradleVersions.first()
     @Shared

--- a/src/test/groovy/org/gradle/profiler/BuildOperationInstrumentationIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/BuildOperationInstrumentationIntegrationTest.groovy
@@ -32,7 +32,7 @@ class BuildOperationInstrumentationIntegrationTest extends AbstractProfilerInteg
     }
 
     @Unroll
-    def "can benchmark snapshotting build operation time via #via for build using 5.5.1"() {
+    def "can benchmark snapshotting build operation time via #via for build using #gradleVersion"() {
         given:
         instrumentedBuildScript()
         buildFile << """
@@ -45,8 +45,6 @@ class BuildOperationInstrumentationIntegrationTest extends AbstractProfilerInteg
         def sourceFile = new File(projectDir, "src/main/java/A.java")
         sourceFile.parentFile.mkdirs()
         sourceFile.text = "class A {}"
-
-        def gradleVersion = "5.5.1"
 
         when:
         def extraArgs = []
@@ -86,10 +84,26 @@ class BuildOperationInstrumentationIntegrationTest extends AbstractProfilerInteg
         lines.get(26).matches("stddev,\\d+\\.\\d+,\\d+\\.\\d+")
 
         where:
-        via                              | commandLine                                                                                  | scenarioConfiguration
-        'command line'                   | ["--measure-build-op", "org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationType"] | null
-        'scenario file'                  | []                                                                                           | 'measured-build-ops = ["org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationType"]'
-        'command line and scenario file' | ["--measure-build-op", "org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationType"] | 'measured-build-ops = ["org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationType"]'
+        [via, commandLine, scenarioConfiguration, gradleVersion] << [
+            [
+                [
+                    'command line',
+                    ["--measure-build-op", "org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationType"],
+                    null
+                ],
+                [
+                    'scenario file',
+                    [],
+                    'measured-build-ops = ["org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationType"]'
+                ],
+                [
+                    'command line and scenario file',
+                    ["--measure-build-op", "org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationType"],
+                    'measured-build-ops = ["org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationType"]'
+                ]
+            ],
+            ["5.5.1", latestSupportedGradleVersion]
+        ].combinations().collect { it[0] + it[1] }
     }
 
     @Unroll

--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -3,10 +3,14 @@ package org.gradle.profiler
 import org.gradle.profiler.buildscan.BuildScanProfiler
 import org.gradle.util.GradleVersion
 import spock.lang.Requires
+import spock.lang.Shared
 import spock.lang.Unroll
 
 @Unroll
 class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
+
+    @Shared
+    String latestSupportedGradle5Version = supportedGradleVersions.reverse().find { it.startsWith("5.") }
 
     def "complains when neither profile or benchmark requested"() {
         when:
@@ -212,12 +216,12 @@ println "<gradle-version: " + gradle.gradleVersion + ">"
 
         when:
         new Main().
-                run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion, "--profile", "buildscan",
+                run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradle5Version, "--profile", "buildscan",
                         "assemble")
 
         then:
-        logFile.find("<gradle-version: $latestSupportedGradleVersion>").size() == 4
-        assertBuildScanPublished(BuildScanProfiler.defaultBuildScanVersion(GradleVersion.version(latestSupportedGradleVersion)))
+        logFile.find("<gradle-version: $latestSupportedGradle5Version>").size() == 4
+        assertBuildScanPublished(BuildScanProfiler.defaultBuildScanVersion(GradleVersion.version(latestSupportedGradle5Version)))
     }
 
     def "uses build scan version used by the build if present"() {


### PR DESCRIPTION
This PR only touches test coverage and raises the latest supported Gradle version to 6.0.1.
It is a prerequisite for #169 