### PR TITLE
Coverage for instant execution with --measure-config-time and --measure-build-op

### DIFF
--- a/src/test/groovy/org/gradle/profiler/AbstractProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AbstractProfilerIntegrationTest.groovy
@@ -12,7 +12,12 @@ abstract class AbstractProfilerIntegrationTest extends Specification {
     private static int NUMBER_OF_STATS = 8;
 
     @Shared
-    List<String> supportedGradleVersions = ["3.3", "3.4.1", "3.5", "4.0", "4.1", "4.2.1", "4.7", "5.2.1", "5.5.1", "5.6.3", "6.0.1"]
+    List<String> supportedGradleVersions = [
+        "3.3", "3.4.1", "3.5",
+        "4.0", "4.1", "4.2.1", "4.7",
+        "5.2.1", "5.5.1", "5.6.3",
+        "6.0.1", "6.1-milestone-2"
+    ]
     @Shared
     String minimalSupportedGradleVersion = supportedGradleVersions.first()
     @Shared

--- a/src/test/groovy/org/gradle/profiler/BuildOperationInstrumentationIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/BuildOperationInstrumentationIntegrationTest.groovy
@@ -2,8 +2,15 @@ package org.gradle.profiler
 
 import spock.lang.Unroll
 
+import static org.hamcrest.CoreMatchers.equalTo
+import static org.hamcrest.CoreMatchers.hasItem
+import static org.hamcrest.CoreMatchers.not
+import static org.junit.Assert.assertThat
+import static org.junit.Assert.assertTrue
+
 
 class BuildOperationInstrumentationIntegrationTest extends AbstractProfilerIntegrationTest {
+
     @Unroll
     def "can benchmark configuration time for build using #gradleVersion (instant-execution: #instantExecution)"() {
         given:
@@ -40,6 +47,11 @@ class BuildOperationInstrumentationIntegrationTest extends AbstractProfilerInteg
         lines.get(26).matches("stddev,\\d+\\.\\d+,\\d+\\.\\d+")
         lines.get(27).matches("confidence,\\d+\\.\\d+,\\d+\\.\\d+")
 
+        and:
+        def taskStart = lines.get(10) =~ /measured build #1,\d+,(\d+)/
+        taskStart.matches()
+        Long.valueOf(taskStart[0][1]) > 0
+
         where:
         gradleVersion                | instantExecution
         "5.0"                        | false
@@ -50,38 +62,33 @@ class BuildOperationInstrumentationIntegrationTest extends AbstractProfilerInteg
     @Unroll
     def "can benchmark snapshotting build operation time via #via for build using #gradleVersion (instant-execution: #instantExecution)"() {
         given:
-        instrumentedBuildScript()
-        buildFile << """
-            apply plugin: 'java'
-        """
+        instrumentedBuildForSnapshottingBenchmark()
 
-        // We don't capture snapshotting time (yet) if the build cache is not enabled
-        new File(projectDir, "gradle.properties").text = "org.gradle.caching=true"
-
-        def sourceFile = new File(projectDir, "src/main/java/A.java")
-        sourceFile.parentFile.mkdirs()
-        sourceFile.text = "class A {}"
-
-        when:
-        def extraArgs = []
+        and:
+        String[] args = [
+            "--project-dir", projectDir.absolutePath,
+            "--output-dir", outputDir.absolutePath,
+            "--gradle-version", gradleVersion,
+            "--benchmark"
+        ]
         if (scenarioConfiguration) {
-            def scenarioFile = new File(projectDir, "performance.scenarios")
+            def scenarioFile = file("performance.scenarios")
             scenarioFile.text = """
             default {
                 tasks = ["assemble"]
                 ${scenarioConfiguration}
             }
             """
-            extraArgs.addAll("--scenario-file", scenarioFile.absolutePath)
+            args += ["--scenario-file", scenarioFile.absolutePath]
         }
-        extraArgs.addAll(commandLine)
+        args += commandLine
         if (instantExecution) {
-            extraArgs << "-Dorg.gradle.unsafe.instant-execution=true"
+            args += "-Dorg.gradle.unsafe.instant-execution=true"
         }
-        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", gradleVersion, "--benchmark",
-            *extraArgs,
-            scenarioConfiguration ? "default" : "assemble"
-        )
+        args += scenarioConfiguration ? "default" : "assemble"
+
+        when:
+        new Main().run(*args)
 
         then:
         def lines = resultFile.lines
@@ -122,12 +129,85 @@ class BuildOperationInstrumentationIntegrationTest extends AbstractProfilerInteg
                 ]
             ],
             ["5.5.1", latestSupportedGradleVersion]
-        ].combinations().collect {
+        ].combinations().collectMany {
             def scenario = it[0]
             def gradleVersion = it[1]
-            def instantExecution = gradleVersion == latestSupportedGradleVersion
-            scenario + gradleVersion + instantExecution
+            if (gradleVersion == latestSupportedGradleVersion) {
+                [scenario + gradleVersion + false, scenario + gradleVersion + true]
+            } else {
+                [scenario + gradleVersion + false]
+            }
         }
+    }
+
+    @Unroll
+    def "can combine measuring configuration time and build operation using #gradleVersion (instant-execution: #instantExecution)"() {
+        given:
+        instrumentedBuildForSnapshottingBenchmark()
+
+        and:
+        String[] args = [
+            "--project-dir", projectDir.absolutePath,
+            "--output-dir", outputDir.absolutePath,
+            "--gradle-version", gradleVersion,
+            "--benchmark",
+            "--measure-config-time",
+            "--measure-build-op", "org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationType",
+            "assemble"
+        ]
+        if (instantExecution) {
+            args += "-Dorg.gradle.unsafe.instant-execution=true"
+        }
+
+        when:
+        new Main().run(*args)
+
+        then:
+        def lines = resultFile.lines
+        assertThat(lines.size(), equalTo(totalLinesForExecutions(16)))
+        lines.get(0) == "scenario,default,default,default"
+        lines.get(1) == "version,${gradleVersion},${gradleVersion},${gradleVersion}"
+        lines.get(2) == "tasks,assemble,assemble,assemble"
+        lines.get(3) == "value,execution,task start,SnapshotTaskInputsBuildOperationType"
+        lines.get(4).matches("warm-up build #1,\\d+,\\d+,\\d+")
+        lines.get(9).matches("warm-up build #6,\\d+,\\d+,\\d+")
+        lines.get(10).matches("measured build #1,\\d+,\\d+,\\d+")
+        lines.get(20).matches("mean,\\d+\\.\\d+,\\d+\\.\\d+,\\d+\\.\\d+")
+        lines.get(23).matches("median,\\d+\\.\\d+,\\d+\\.\\d+,\\d+\\.\\d+")
+        lines.get(26).matches("stddev,\\d+\\.\\d+,\\d+\\.\\d+,\\d+\\.\\d+")
+        lines.get(27).matches("confidence,\\d+\\.\\d+,\\d+\\.\\d+,\\d+\\.\\d+")
+
+        and:
+        def buildLines = lines.subList(10, 19).collect { it.tokenize(',') }
+        def executions = buildLines.collect { Long.valueOf(it.get(1)) } as Set
+        def taskStarts = buildLines.collect { Long.valueOf(it.get(2)) } as Set
+        def buildOps = buildLines.collect { Long.valueOf(it.get(3)) } as Set
+        assertThat("non zero execution times", executions, hasItem(not(equalTo(0L))))
+        assertThat("non zero task start times", taskStarts, hasItem(not(equalTo(0L))))
+        assertThat("non zero build-op times", buildOps, hasItem(not(equalTo(0L))))
+        assertTrue("different execution times", executions.size() > 1)
+        assertTrue("different task start times", taskStarts.size() > 1)
+        assertTrue("different build-op times", buildOps.size() > 1)
+
+        where:
+        gradleVersion                | instantExecution
+        "5.6.3"                      | false
+        latestSupportedGradleVersion | false
+        latestSupportedGradleVersion | true
+    }
+
+    private void instrumentedBuildForSnapshottingBenchmark() {
+        instrumentedBuildScript()
+        buildFile << """
+            apply plugin: 'java'
+        """
+
+        // We don't capture snapshotting time (yet) if the build cache is not enabled
+        file("gradle.properties").text = "org.gradle.caching=true"
+
+        def sourceFile = file("src/main/java/A.java")
+        sourceFile.parentFile.mkdirs()
+        sourceFile.text = "class A {}"
     }
 
     @Unroll

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/BuildOperationTrace.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/BuildOperationTrace.java
@@ -41,6 +41,11 @@ public class BuildOperationTrace {
         return this;
     }
 
+    /**
+     * ATTENTION do not rename!
+     * See <code>BuildOperationListenersCodec</code> in <code>gradle/gradle</code>.
+     * TODO:instant-execution replace with event handling when available
+     */
     private static class TimeToFirstTaskRecordingListener extends DetachingBuildOperationListener {
 
         private final Path outPath;
@@ -79,6 +84,11 @@ public class BuildOperationTrace {
         }
     }
 
+    /**
+     * ATTENTION do not rename!
+     * See <code>BuildOperationListenersCodec</code> in <code>gradle/gradle</code>.
+     * TODO:instant-execution replace with event handling when available
+     */
     private static class BuildOperationDurationRecordingListener extends DetachingBuildOperationListener {
 
         private final Class<?> capturedBuildOperation;


### PR DESCRIPTION
And documentation of name references of listeners in `gradle/gradle`.
Also see https://github.com/gradle/gradle/pull/11454
