### PR TITLE
Add scenario title to use in reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,13 @@ Here is an example:
     
     # Scenarios are run in alphabetical order
     assemble {
+        # Show a slightly more human-readable title in reports
+        title = "Assemble"
         # Run the 'assemble' task
         tasks = ["assemble"]
     }
     clean_build {
+        title = "Clean Build"
         versions = ["3.1", "/Users/me/gradle"]
         tasks = ["build"]
         gradle-args = ["--parallel"]
@@ -207,12 +210,14 @@ Here is an example:
         warm-ups = 10
     }
     ideaModel {
+        title = "IDEA model"
         # Fetch the IDEA tooling model
         model = "org.gradle.tooling.model.idea.IdeaProject"
         # Can also run tasks
         # tasks = ["assemble"]
     }
     androidStudioSync {
+        title = "Android Studio Sync"
         # Simulate an Android studio sync
         android-studio-sync {
             # Skip source generation on sync

--- a/src/main/java/org/gradle/profiler/AdhocGradleScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/AdhocGradleScenarioDefinition.java
@@ -20,6 +20,7 @@ public class AdhocGradleScenarioDefinition extends GradleScenarioDefinition {
     ) {
         super(
             "default",
+            null,
             invoker,
             version,
             buildAction,

--- a/src/main/java/org/gradle/profiler/BazelScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/BazelScenarioDefinition.java
@@ -9,14 +9,14 @@ import java.util.stream.Collectors;
 public class BazelScenarioDefinition extends ScenarioDefinition {
     private final List<String> targets;
 
-    public BazelScenarioDefinition(String scenarioName, List<String> targets, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
-        super(scenarioName, buildMutator, warmUpCount, buildCount, outputDir);
+    public BazelScenarioDefinition(String scenarioName, String title, List<String> targets, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
+        super(scenarioName, title, buildMutator, warmUpCount, buildCount, outputDir);
         this.targets = targets;
     }
 
     @Override
     public String getDisplayName() {
-        return getName() + " using bazel";
+        return getTitle() + " using bazel";
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/BuckScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/BuckScenarioDefinition.java
@@ -10,15 +10,15 @@ public class BuckScenarioDefinition extends ScenarioDefinition {
     private final List<String> targets;
     private final String type;
 
-    public BuckScenarioDefinition(String scenarioName, List<String> targets, String type, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
-        super(scenarioName, buildMutator, warmUpCount, buildCount, outputDir);
+    public BuckScenarioDefinition(String scenarioName, String title, List<String> targets, String type, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
+        super(scenarioName, title, buildMutator, warmUpCount, buildCount, outputDir);
         this.targets = targets;
         this.type = type;
     }
 
     @Override
     public String getDisplayName() {
-        return getName() + " using buck";
+        return getTitle() + " using buck";
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
@@ -24,6 +24,7 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
 
     public GradleScenarioDefinition(
         String name,
+        String title,
         GradleBuildInvoker invoker,
         GradleBuildConfiguration buildConfiguration,
         BuildAction buildAction,
@@ -37,7 +38,7 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
         List<String> jvmArgs,
         List<String> measuredBuildOperations
     ) {
-        super(name, buildMutator, warmUpCount, buildCount, outputDir);
+        super(name, title, buildMutator, warmUpCount, buildCount, outputDir);
         this.invoker = invoker;
         this.buildAction = buildAction;
         this.buildConfiguration = buildConfiguration;
@@ -50,7 +51,7 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
 
     @Override
     public String getDisplayName() {
-        return getName() + " using " + buildConfiguration.getGradleVersion();
+        return getTitle() + " using " + buildConfiguration.getGradleVersion();
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/MavenScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/MavenScenarioDefinition.java
@@ -9,14 +9,14 @@ import java.util.stream.Collectors;
 public class MavenScenarioDefinition extends ScenarioDefinition {
     private final List<String> targets;
 
-    public MavenScenarioDefinition(String scenarioName, List<String> targets, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
-        super(scenarioName, buildMutator, warmUpCount, buildCount, outputDir);
+    public MavenScenarioDefinition(String scenarioName, String title, List<String> targets, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
+        super(scenarioName, title, buildMutator, warmUpCount, buildCount, outputDir);
         this.targets = targets;
     }
 
     @Override
     public String getDisplayName() {
-        return getName() + " using maven";
+        return getTitle() + " using maven";
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/ScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/ScenarioDefinition.java
@@ -1,5 +1,6 @@
 package org.gradle.profiler;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.PrintStream;
 import java.util.function.Consumer;
@@ -7,21 +8,30 @@ import java.util.function.Supplier;
 
 public abstract class ScenarioDefinition {
     private final String name;
+    private final String title;
     private final Supplier<BuildMutator> buildMutator;
     private final int warmUpCount;
     private final int buildCount;
-    private final File outpuDir;
+    private final File outputDir;
 
-    public ScenarioDefinition(String name, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
+    public ScenarioDefinition(String name, @Nullable String title, Supplier<BuildMutator> buildMutator, int warmUpCount, int buildCount, File outputDir) {
         this.name = name;
+        this.title = title;
         this.buildMutator = buildMutator;
         this.warmUpCount = warmUpCount;
         this.buildCount = buildCount;
-        this.outpuDir = outputDir;
+        this.outputDir = outputDir;
     }
 
     /**
-     * A human consumable and unique display name for this scenario.
+     * A specific title defined for the scenario to be used in reports (defaults to {@link #getName()}.
+     */
+    public String getTitle() {
+        return title != null ? title : name;
+    }
+
+    /**
+     * A human consumable and unique display name for this scenario using {@link #getTitle()}.
      */
     public abstract String getDisplayName();
 
@@ -45,7 +55,7 @@ public abstract class ScenarioDefinition {
     }
 
     public File getOutputDir() {
-        return outpuDir;
+        return outputDir;
     }
 
     public Supplier<BuildMutator> getBuildMutator() {

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -198,7 +198,7 @@ class ScenarioLoader {
                     throw new IllegalArgumentException("Unrecognized key '" + scenarioName + "." + key + "' defined in scenario file " + scenarioFile);
                 }
             }
-            String title = config.hasPath(TITLE) ? config.getString(TITLE) : null;
+            String title = scenario.hasPath(TITLE) ? scenario.getString(TITLE) : null;
 
             List<Supplier<BuildMutator>> mutators = new ArrayList<>();
             maybeAddMutator(scenario, scenarioName, settings.getProjectDir(), APPLY_ABI_CHANGE_TO, ApplyAbiChangeToSourceFileMutator.class, mutators);

--- a/src/main/java/org/gradle/profiler/report/CsvGenerator.java
+++ b/src/main/java/org/gradle/profiler/report/CsvGenerator.java
@@ -52,7 +52,7 @@ public class CsvGenerator extends AbstractGenerator {
         for (BuildScenarioResult scenario : allScenarios) {
             for (int i = 0; i < scenario.getSamples().size(); i++) {
                 writer.write(",");
-                writer.write(scenario.getScenarioDefinition().getName());
+                writer.write(scenario.getScenarioDefinition().getTitle());
             }
         }
         writer.newLine();
@@ -131,7 +131,7 @@ public class CsvGenerator extends AbstractGenerator {
         for (BuildScenarioResult scenario : allScenarios) {
             for (BuildInvocationResult result : scenario.getResults()) {
                 for (Sample<? super BuildInvocationResult> sample : scenario.getSamples()) {
-                    writer.write(scenario.getScenarioDefinition().getName());
+                    writer.write(scenario.getScenarioDefinition().getTitle());
                     writer.write(",");
                     writer.write(scenario.getScenarioDefinition().getBuildToolDisplayName());
                     writer.write(",");

--- a/src/main/java/org/gradle/profiler/report/HtmlGenerator.java
+++ b/src/main/java/org/gradle/profiler/report/HtmlGenerator.java
@@ -53,7 +53,7 @@ public class HtmlGenerator extends AbstractGenerator {
         List<? extends BuildScenarioResult> allScenarios = benchmarkResult.getScenarios();
         for (BuildScenarioResult scenario : allScenarios) {
             writer.write("<th colspan='" + scenario.getSamples().size() + "'>");
-            writer.write(scenario.getScenarioDefinition().getName());
+            writer.write(scenario.getScenarioDefinition().getTitle());
             writer.write("</th>");
         }
         writer.write("</tr>\n");

--- a/src/main/java/org/gradle/profiler/report/HtmlGenerator.java
+++ b/src/main/java/org/gradle/profiler/report/HtmlGenerator.java
@@ -146,7 +146,7 @@ public class HtmlGenerator extends AbstractGenerator {
         for (BuildScenarioResult scenario : allScenarios) {
             writer.write("{\n");
             writer.write("            label: '");
-            writer.write(scenario.getScenarioDefinition().getName());
+            writer.write(scenario.getScenarioDefinition().getTitle());
             writer.write(" ");
             writer.write(scenario.getScenarioDefinition().getBuildToolDisplayName());
             writer.write("',\n");

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -81,6 +81,28 @@ class ScenarioLoaderTest extends Specification {
         scenario.action.tasks.empty
     }
 
+    def "can load single scenarios with and without title"() {
+        def settings = settings()
+        settings.targets.addAll("entitled", "untitled") // don't use the target as the default tasks
+
+        scenarioFile << """
+            entitled {
+                title = "This is a scenario with a title"
+            }
+            
+            untitled {
+            }
+        """
+        def scenarios = loadScenarios(scenarioFile, settings, Mock(GradleBuildConfigurationReader))
+        expect:
+        def entitled = scenarios[0] as GradleScenarioDefinition
+        def untitled = scenarios[1] as GradleScenarioDefinition
+        entitled.name == "entitled"
+        entitled.title == "This is a scenario with a title"
+        untitled.name == "untitled"
+        untitled.title == "untitled"
+    }
+
     def "scenario uses invoker specified on command-line when none is specified"() {
         scenarioFile << """
             default {


### PR DESCRIPTION
Fixes https://github.com/gradle/gradle-profiler/issues/164

If a title is specified for the scenario, it will be used in reports instead of the name of the scenario.

```hocon
default {
    title = "Base scenario"
}
```