### PR TITLE
Use stable APIs to instrument build operations and time to first task

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ The following command line options only apply when measuring Gradle builds:
 - `--no-daemon`: Uses the `gradle` command-line client with the `--no-daemon` option to run the builds. The default is to use the Gradle tooling API and Gradle daemon.
 - `--cold-daemon`: Use a cold daemon (one that has just started) rather than a warm daemon (one that has already run some builds). The default is to use a warm daemon.
 - `--cli`: Uses the `gradle` command-line client to run the builds. The default is to use the Gradle tooling API and Gradle daemon.
-- `--measure-config-time`: Measure some additional details about configuration time.
-- `--measure-build-op`: Additionally measure the cumulative time spent in the given build operation.
+- `--measure-config-time`: Measure some additional details about configuration time. Only supported for Gradle 6.1 and later.
+- `--measure-build-op`: Additionally measure the cumulative time spent in the given build operation. Only supported for Gradle 6.1 and later.
 - `-D<key>=<value>`: Defines a system property when running the build, overriding the default for the build.
 
 ## Advanced profiling scenarios

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-milestone-3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
@@ -106,8 +106,8 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
         if (getWarmUpCount() < 1) {
             reporter.accept("You can not skip warm-ups when profiling or benchmarking a Gradle build. Use --no-daemon or --cold-daemon if you want to profile or benchmark JVM startup");
         }
-        if (settings.isMeasureConfigTime() && buildConfiguration.getGradleVersion().compareTo(GradleVersion.version("5.0")) < 0) {
-            reporter.accept("Measuring build configuration is only supported for Gradle 5.0 and later");
+        if (settings.isMeasureConfigTime() && buildConfiguration.getGradleVersion().compareTo(GradleVersion.version("6.1-milestone-3")) < 0) {
+            reporter.accept("Measuring build configuration is only supported for Gradle 6.1-milestone-3 and later");
         }
         settings.getProfiler().validate(new ScenarioSettings(settings, this), reporter);
     }

--- a/src/test/groovy/org/gradle/profiler/AbstractProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AbstractProfilerIntegrationTest.groovy
@@ -1,6 +1,6 @@
 package org.gradle.profiler
 
-import com.google.common.collect.ImmutableList
+
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Shared
@@ -16,7 +16,7 @@ abstract class AbstractProfilerIntegrationTest extends Specification {
         "3.3", "3.4.1", "3.5",
         "4.0", "4.1", "4.2.1", "4.7",
         "5.2.1", "5.5.1", "5.6.3",
-        "6.0.1", "6.1-milestone-2"
+        "6.0.1", "6.1-milestone-3"
     ]
     @Shared
     String minimalSupportedGradleVersion = supportedGradleVersions.first()
@@ -133,7 +133,7 @@ genrule(
         final List<String> lines
 
         FileFixture(File logFile) {
-            lines = ImmutableList.copyOf(logFile.readLines())
+            lines = logFile.readLines()
         }
 
         @Override

--- a/src/test/groovy/org/gradle/profiler/BuildOperationInstrumentationIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/BuildOperationInstrumentationIntegrationTest.groovy
@@ -2,12 +2,9 @@ package org.gradle.profiler
 
 import spock.lang.Unroll
 
-import static org.hamcrest.CoreMatchers.equalTo
-import static org.hamcrest.CoreMatchers.hasItem
-import static org.hamcrest.CoreMatchers.not
+import static org.hamcrest.CoreMatchers.*
 import static org.junit.Assert.assertThat
 import static org.junit.Assert.assertTrue
-
 
 class BuildOperationInstrumentationIntegrationTest extends AbstractProfilerIntegrationTest {
 
@@ -53,10 +50,10 @@ class BuildOperationInstrumentationIntegrationTest extends AbstractProfilerInteg
         Long.valueOf(taskStart[0][1]) > 0
 
         where:
-        gradleVersion                | instantExecution
-        "5.0"                        | false
-        latestSupportedGradleVersion | false
-        latestSupportedGradleVersion | true
+        [gradleVersion, instantExecution] << [
+            ["6.1-milestone-3", latestSupportedGradleVersion] as Set, // simplify this once the latest version is > 6.1-milestone-3
+            [true, false]
+        ].combinations()
     }
 
     @Unroll
@@ -128,7 +125,7 @@ class BuildOperationInstrumentationIntegrationTest extends AbstractProfilerInteg
                     'measured-build-ops = ["org.gradle.api.internal.tasks.SnapshotTaskInputsBuildOperationType"]'
                 ]
             ],
-            ["5.5.1", latestSupportedGradleVersion]
+            ["6.1-milestone-3", latestSupportedGradleVersion] as Set
         ].combinations().collectMany {
             def scenario = it[0]
             def gradleVersion = it[1]
@@ -191,9 +188,8 @@ class BuildOperationInstrumentationIntegrationTest extends AbstractProfilerInteg
 
         where:
         gradleVersion                | instantExecution
-        "5.6.3"                      | false
-        latestSupportedGradleVersion | false
-        latestSupportedGradleVersion | true
+        "6.1-milestone-3"            | false
+        "6.1-milestone-3"            | true
     }
 
     private void instrumentedBuildForSnapshottingBenchmark() {
@@ -222,10 +218,10 @@ class BuildOperationInstrumentationIntegrationTest extends AbstractProfilerInteg
         thrown(IllegalArgumentException)
 
         and:
-        output.contains("Scenario using Gradle ${gradleVersion}: Measuring build configuration is only supported for Gradle 5.0 and later")
+        output.contains("Scenario using Gradle ${gradleVersion}: Measuring build configuration is only supported for Gradle 6.1-milestone-3 and later")
 
         where:
-        gradleVersion << [minimalSupportedGradleVersion, "4.0", "4.10"]
+        gradleVersion << [minimalSupportedGradleVersion, "4.0", "4.10", "6.0"]
     }
 
     def "complains when attempting to benchmark configuration time for build using unsupported Gradle version from scenario file"() {
@@ -234,7 +230,7 @@ class BuildOperationInstrumentationIntegrationTest extends AbstractProfilerInteg
         def scenarioFile = file("performance.scenarios")
         scenarioFile.text = """
             assemble { 
-                versions = ["${minimalSupportedGradleVersion}", "4.0", "4.10", "${latestSupportedGradleVersion}"]
+                versions = ["${minimalSupportedGradleVersion}", "4.0", "4.10", "6.0", "${latestSupportedGradleVersion}"]
             }
         """
 
@@ -245,8 +241,8 @@ class BuildOperationInstrumentationIntegrationTest extends AbstractProfilerInteg
         thrown(IllegalArgumentException)
 
         and:
-        output.contains("Scenario assemble using Gradle ${minimalSupportedGradleVersion}: Measuring build configuration is only supported for Gradle 5.0 and later")
-        output.contains("Scenario assemble using Gradle 4.0: Measuring build configuration is only supported for Gradle 5.0 and later")
-        output.contains("Scenario assemble using Gradle 4.10: Measuring build configuration is only supported for Gradle 5.0 and later")
+        output.contains("Scenario assemble using Gradle ${minimalSupportedGradleVersion}: Measuring build configuration is only supported for Gradle 6.1-milestone-3 and later")
+        output.contains("Scenario assemble using Gradle 4.0: Measuring build configuration is only supported for Gradle 6.1-milestone-3 and later")
+        output.contains("Scenario assemble using Gradle 4.10: Measuring build configuration is only supported for Gradle 6.1-milestone-3 and later")
     }
 }


### PR DESCRIPTION
Use the metrics collector APIs added in Gradle 6.1 to implement `--measure-config-time` and `--measure-build-op`. These APIs work with instant execution and will be stable going forward. This should mean the instrumentation is more reliable and that we can remove the workarounds for gradle-profiler from Gradle itself.