### PR TITLE
Remove shaded gradle API imports

### DIFF
--- a/src/main/java/org/gradle/profiler/AndroidStudioSyncAction.java
+++ b/src/main/java/org/gradle/profiler/AndroidStudioSyncAction.java
@@ -1,15 +1,17 @@
 package org.gradle.profiler;
 
 import com.android.builder.model.AndroidProject;
-
-import org.gradle.internal.impldep.org.apache.commons.lang.StringUtils;
 import org.gradle.tooling.BuildController;
 import org.gradle.tooling.events.ProgressListener;
 import org.gradle.tooling.model.gradle.BasicGradleProject;
 import org.gradle.tooling.model.gradle.GradleBuild;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * A mock-up of Android studio sync.
@@ -51,10 +53,16 @@ public class AndroidStudioSyncAction implements BuildAction {
         if (skipSourceGeneration) {
             tasks = Collections.emptyList();
         } else {
-            String taskName = String.join("", "generate", StringUtils.capitalize(buildFlavor), "Sources");
+            String taskName = String.join("", "generate", capitalize(buildFlavor), "Sources");
             tasks = Collections.singletonList(taskName);
         }
         buildInvoker.runToolingAction(tasks, gradleArgs, jvmArgs, new GetModel(), (builder) -> builder.addProgressListener(noOpListener()));
+    }
+
+    private static String capitalize(String input) {
+        return input.isEmpty()
+            ? input
+            : Character.toUpperCase(input.charAt(0)) + input.substring(1);
     }
 
     private static ProgressListener noOpListener() {

--- a/src/main/java/org/gradle/profiler/DefaultGradleBuildConfigurationReader.java
+++ b/src/main/java/org/gradle/profiler/DefaultGradleBuildConfigurationReader.java
@@ -1,8 +1,6 @@
 package org.gradle.profiler;
 
-import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.Files;
 import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ProjectConnection;
 import org.gradle.tooling.model.build.BuildEnvironment;
@@ -14,6 +12,8 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -97,7 +97,7 @@ public class DefaultGradleBuildConfigurationReader implements GradleBuildConfigu
 
     private List<String> readBuildDetails() {
         try {
-            return Files.readLines(buildDetails, Charsets.UTF_8);
+            return Files.readAllLines(buildDetails.toPath(), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException("Could not read the build's configuration.", e);
         }

--- a/src/main/java/org/gradle/profiler/flamegraph/FlameGraphSanitizer.java
+++ b/src/main/java/org/gradle/profiler/flamegraph/FlameGraphSanitizer.java
@@ -1,19 +1,29 @@
 package org.gradle.profiler.flamegraph;
 
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+
 import com.google.common.base.CharMatcher;
 import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 
-import java.io.*;
-import java.util.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 
 /**
  * Simplifies stacks to make flame graphs more readable.
@@ -112,7 +122,7 @@ public class FlameGraphSanitizer {
     private static abstract class FrameWiseSanitizeFunction implements SanitizeFunction {
         @Override
         public final List<String> map(List<String> stack) {
-            List<String> result = Lists.newArrayListWithCapacity(stack.size());
+            List<String> result = new ArrayList<>(stack.size());
             for (String frame : stack) {
                 result.add(mapFrame(frame));
             }
@@ -170,7 +180,7 @@ public class FlameGraphSanitizer {
     private static class CollapseDuplicateFrames implements SanitizeFunction {
         @Override
         public List<String> map(List<String> stack) {
-            List<String> result = Lists.newArrayList(stack);
+            List<String> result = new ArrayList<>(stack);
             ListIterator<String> iterator = result.listIterator();
             String previous = null;
             while (iterator.hasNext()) {

--- a/src/main/java/org/gradle/profiler/jfr/JfrToStacksConverter.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrToStacksConverter.java
@@ -1,7 +1,6 @@
 package org.gradle.profiler.jfr;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.io.Files;
 import org.openjdk.jmc.common.IMCFrame;
 import org.openjdk.jmc.common.IMCStackTrace;
 import org.openjdk.jmc.common.item.IItem;
@@ -23,6 +22,7 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -54,7 +54,7 @@ class JfrToStacksConverter {
 
     private void writeFoldedStacks(Map<String, Long> foldedStacks, File targetFile) {
         targetFile.getParentFile().mkdirs();
-        try (BufferedWriter writer = Files.newWriter(targetFile, StandardCharsets.UTF_8)) {
+        try (BufferedWriter writer = Files.newBufferedWriter(targetFile.toPath(), StandardCharsets.UTF_8)) {
             for (Map.Entry<String, Long> entry : foldedStacks.entrySet()) {
                 writer.write(String.format("%s %d%n", entry.getKey(), entry.getValue()));
             }

--- a/src/main/java/org/gradle/profiler/jfr/JfrToStacksConverter.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrToStacksConverter.java
@@ -2,7 +2,6 @@ package org.gradle.profiler.jfr;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Files;
-import org.gradle.internal.impldep.com.google.common.base.Charsets;
 import org.openjdk.jmc.common.IMCFrame;
 import org.openjdk.jmc.common.IMCStackTrace;
 import org.openjdk.jmc.common.item.IItem;
@@ -23,6 +22,7 @@ import org.openjdk.jmc.flightrecorder.stacktrace.StacktraceFormatToolkit;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
@@ -54,7 +54,7 @@ class JfrToStacksConverter {
 
     private void writeFoldedStacks(Map<String, Long> foldedStacks, File targetFile) {
         targetFile.getParentFile().mkdirs();
-        try (BufferedWriter writer = Files.newWriter(targetFile, Charsets.UTF_8)) {
+        try (BufferedWriter writer = Files.newWriter(targetFile, StandardCharsets.UTF_8)) {
             for (Map.Entry<String, Long> entry : foldedStacks.entrySet()) {
                 writer.write(String.format("%s %d%n", entry.getKey(), entry.getValue()));
             }


### PR DESCRIPTION
There are some imports of `org.gradle.internal.impldep.*` classes, which come from `gradleApi` and won't be there at runtime.

This PR replaces those imports by the correct ones or some alternate implementation.