### PR TITLE
Encourage the use of quotes around system-properties keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ Here is an example:
         tasks = ["build"]
         gradle-args = ["--parallel"]
         system-properties {
-            key = "value"
+            "key" = "value"
         }
         cleanup-tasks = ["clean"]
         run-using = tooling-api // value can be "cli" or "tooling-api"

--- a/src/main/java/org/gradle/profiler/ConfigUtil.java
+++ b/src/main/java/org/gradle/profiler/ConfigUtil.java
@@ -14,7 +14,7 @@ public class ConfigUtil {
 	public static Map<String, String> map(Config config, String key, Map<String, String> defaultValues) {
 		if (config.hasPath(key)) {
 			Map<String, String> props = new LinkedHashMap<>();
-			for (Map.Entry<String, ConfigValue> entry : config.getConfig(key).entrySet()) {
+			for (Map.Entry<String, ConfigValue> entry : config.getObject(key).entrySet()) {
 				props.put(entry.getKey(), entry.getValue().unwrapped().toString());
 			}
 			return props;

--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -777,14 +777,14 @@ a {
     versions = "$minimalSupportedGradleVersion"
     tasks = assemble
     system-properties {
-        org.gradle.test = "value-1"
+        "org.gradle.test" = "value-1"
     }
 }
 b {
     versions = "$minimalSupportedGradleVersion"
     tasks = assemble
     system-properties {
-        org.gradle.test = "value-2"
+        "org.gradle.test" = "value-2"
     }
 }
 """

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -143,6 +143,26 @@ class ScenarioLoaderTest extends Specification {
         toolingApi.invoker == GradleBuildInvoker.ToolingApi
     }
 
+    def "scenario can define system properties"() {
+        def settings = settings()
+        scenarioFile << """
+            instantExecution {
+                system-properties {
+                    "org.gradle.unsafe.instant-execution" = true
+                    "org.gradle.unsafe.instant-execution.fail-on-problems" = false
+                }
+            }
+        """
+        def scenarios = loadScenarios(scenarioFile, settings, Mock(GradleBuildConfigurationReader))
+
+        expect:
+        def instantExecution = scenarios[0] as GradleScenarioDefinition
+        instantExecution.systemProperties == [
+            '"org.gradle.unsafe.instant-execution"': "true",
+            '"org.gradle.unsafe.instant-execution.fail-on-problems"': "false"
+        ]
+    }
+
     def "scenario can define what state the daemon should be in for each measured build"() {
         def settings = settings(GradleBuildInvoker.ToolingApi)
         scenarioFile << """

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -158,8 +158,8 @@ class ScenarioLoaderTest extends Specification {
         expect:
         def instantExecution = scenarios[0] as GradleScenarioDefinition
         instantExecution.systemProperties == [
-            '"org.gradle.unsafe.instant-execution"': "true",
-            '"org.gradle.unsafe.instant-execution.fail-on-problems"': "false"
+            "org.gradle.unsafe.instant-execution": "true",
+            "org.gradle.unsafe.instant-execution.fail-on-problems": "false"
         ]
     }
 


### PR DESCRIPTION
The unadvised use of dot notation can cause some head stratching when the system
property names overlap:

```
system-properties {
  foo.bar = false
  foo.bar.baz = true
}
```