### PR TITLE
Add support for specifying # of builds in a scenario definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ A scenario can define changes that should be applied to the source before each b
 - `git-checkout`: Checks out a specific commit for the build step, and a different one for the cleanup step.
 - `git-revert`: Reverts a given set of commits before the build and resets it afterward.
 - `jvm-args`: Sets or overrides the jvm arguments set by `org.gradle.jvmargs` in gradle.properties.
+- `warm-ups`: Number of warmups to perform before measurement
+- `iterations`: Number of builds to actually measure
 
 They can be added to a scenario file like this:
 

--- a/README.md
+++ b/README.md
@@ -250,12 +250,12 @@ A scenario can define changes that should be applied to the source before each b
 - `clear-instant-execution-state-before`: Deletes the contents of the `.instant-execution-state` directory before the scenario is executed (`SCENARIO`), before cleanup (`CLEANUP`) or before the build is executed (`BUILD`).
 - `clear-project-cache-before`: Deletes the contents of the `.gradle` and `buildSrc/.gradle` project cache directories before the scenario is executed (`SCENARIO`), before cleanup (`CLEANUP`) or before the build is executed (`BUILD`).
 - `clear-transform-cache-before`: Deletes the contents of the transform cache before the scenario is executed (`SCENARIO`), before cleanup (`CLEANUP`) or before the build is executed (`BUILD`).
-- `show-build-cache-size`: Shows the number of files and their size in the build cache before scenario execution, and after each cleanup and build round..
 - `git-checkout`: Checks out a specific commit for the build step, and a different one for the cleanup step.
 - `git-revert`: Reverts a given set of commits before the build and resets it afterward.
-- `jvm-args`: Sets or overrides the jvm arguments set by `org.gradle.jvmargs` in gradle.properties.
-- `warm-ups`: Number of warmups to perform before measurement
 - `iterations`: Number of builds to actually measure
+- `jvm-args`: Sets or overrides the jvm arguments set by `org.gradle.jvmargs` in gradle.properties.
+- `show-build-cache-size`: Shows the number of files and their size in the build cache before scenario execution, and after each cleanup and build round..
+- `warm-ups`: Number of warmups to perform before measurement
 
 They can be added to a scenario file like this:
 

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -50,7 +50,7 @@ class ScenarioLoader {
     private static final String BUCK = "buck";
     private static final String MAVEN = "maven";
     private static final String WARM_UP_COUNT = "warm-ups";
-    private static final String BUILD_COUNT = "builds";
+    private static final String ITERATIONS = "iterations";
     private static final String MEASURED_BUILD_OPERATIONS = "measured-build-ops";
     private static final String APPLY_ABI_CHANGE_TO = "apply-abi-change-to";
     private static final String APPLY_NON_ABI_CHANGE_TO = "apply-non-abi-change-to";
@@ -87,7 +87,7 @@ class ScenarioLoader {
         RUN_USING,
         SYSTEM_PROPERTIES,
         WARM_UP_COUNT,
-        BUILD_COUNT,
+        ITERATIONS,
         MEASURED_BUILD_OPERATIONS,
         APPLY_ABI_CHANGE_TO,
         APPLY_NON_ABI_CHANGE_TO,
@@ -324,7 +324,7 @@ class ScenarioLoader {
     }
 
     private static int getBuildCount(InvocationSettings settings, Config scenario) {
-        return getBuildCount(settings, ConfigUtil.optionalInteger(scenario, BUILD_COUNT));
+        return getBuildCount(settings, ConfigUtil.optionalInteger(scenario, ITERATIONS));
     }
 
     private static int getBuildCount(InvocationSettings settings, Integer providedValue) {

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -50,6 +50,7 @@ class ScenarioLoader {
     private static final String BUCK = "buck";
     private static final String MAVEN = "maven";
     private static final String WARM_UP_COUNT = "warm-ups";
+    private static final String BUILD_COUNT = "builds";
     private static final String MEASURED_BUILD_OPERATIONS = "measured-build-ops";
     private static final String APPLY_ABI_CHANGE_TO = "apply-abi-change-to";
     private static final String APPLY_NON_ABI_CHANGE_TO = "apply-non-abi-change-to";
@@ -86,6 +87,7 @@ class ScenarioLoader {
         RUN_USING,
         SYSTEM_PROPERTIES,
         WARM_UP_COUNT,
+        BUILD_COUNT,
         MEASURED_BUILD_OPERATIONS,
         APPLY_ABI_CHANGE_TO,
         APPLY_NON_ABI_CHANGE_TO,
@@ -224,7 +226,7 @@ class ScenarioLoader {
 
             BuildMutatorFactory buildMutatorFactory = new BuildMutatorFactory(mutators);
 
-            int buildCount = getBuildCount(settings);
+            int buildCount = getBuildCount(settings, scenario);
 
             if (scenario.hasPath(BAZEL) && settings.isBazel()) {
                 if (settings.isProfile()) {
@@ -318,11 +320,22 @@ class ScenarioLoader {
     }
 
     private static int getBuildCount(InvocationSettings settings) {
+        return getBuildCount(settings, (Integer) null);
+    }
+
+    private static int getBuildCount(InvocationSettings settings, Config scenario) {
+        return getBuildCount(settings, ConfigUtil.optionalInteger(scenario, BUILD_COUNT));
+    }
+
+    private static int getBuildCount(InvocationSettings settings, Integer providedValue) {
         if (settings.isDryRun()) {
             return 1;
         }
         if (settings.getBuildCount() != null) {
             return settings.getBuildCount();
+        }
+        if (providedValue != null) {
+            return providedValue;
         }
         if (settings.isBenchmark()) {
             return 10;

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -89,7 +89,7 @@ class ScenarioLoaderTest extends Specification {
             entitled {
                 title = "This is a scenario with a title"
             }
-            
+
             untitled {
             }
         """
@@ -274,12 +274,12 @@ class ScenarioLoaderTest extends Specification {
         profileScenario.buildCount == 2
 
         where:
-        runUsing      | daemon | warmups | profileWarmups
-        "tooling-api" | "warm" | 6       | 2
-        "tooling-api" | "cold" | 1       | 1
-        "cli"         | "warm" | 6       | 2
-        "cli"         | "cold" | 1       | 1
-        "cli"         | "none" | 1       | 1
+        runUsing      | daemon
+        "tooling-api" | "warm"
+        "tooling-api" | "cold"
+        "cli"         | "warm"
+        "cli"         | "cold"
+        "cli"         | "none"
     }
 
     def "can load build operations to benchmark"() {
@@ -328,7 +328,7 @@ class ScenarioLoaderTest extends Specification {
 
         scenarioFile << """
             default {
-                android-studio-sync { }               
+                android-studio-sync { }
             }
         """
         def scenarios = loadScenarios(scenarioFile, settings, Mock(GradleBuildConfigurationReader))
@@ -348,7 +348,7 @@ class ScenarioLoaderTest extends Specification {
                 android-studio-sync {
                     build-variant = "developmentDebug"
                     skip-source-generation = true
-                }               
+                }
             }
         """
         def scenarios = loadScenarios(scenarioFile, settings, Mock(GradleBuildConfigurationReader))
@@ -400,7 +400,7 @@ class ScenarioLoaderTest extends Specification {
             bela {
                 tasks = ["bela"]
             }
-            
+
             include file("${otherConf.absolutePath.replace((char) '\\', (char) '/')}")
         """
         def scenarios = loadScenarios(scenarioFile, settings, Mock(GradleBuildConfigurationReader))
@@ -469,7 +469,7 @@ class ScenarioLoaderTest extends Specification {
         scenarioFile << """
             default {
                 tasks = ["help"]
-                
+
                 apply-abi-change-to = ["${fileForMutation1.name}", "${fileForMutation2.name}"]
             }
         """


### PR DESCRIPTION
I thought I would be able to specify the # of builds to measure, just like I can already specify # of warm-ups. Since it wasn't supported out of the box, I thought I'd add it in - but let me know if I'm missing something here.