### PR TITLE
Fix Kotlin non-abi-change mutator so it produces a non-abi-change for java consumers

### DIFF
--- a/src/main/java/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutator.java
@@ -12,8 +12,11 @@ public class ApplyNonAbiChangeToKotlinSourceFileMutator extends AbstractKotlinSo
 
     @Override
     protected void applyChangeTo(BuildContext context, StringBuilder text) {
-        text.append("private fun _m")
-                .append(context.getUniqueBuildId())
-                .append("() {}");
+        text.append('\n')
+            .append("private fun _m")
+            .append(context.getUniqueScenarioId())
+            .append("() {requireNotNull(\"")
+            .append(context.getUniqueBuildId())
+            .append("\")}");
     }
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutatorTest.groovy
@@ -1,17 +1,32 @@
 package org.gradle.profiler.mutations
 
+import org.gradle.profiler.Phase
+
 class ApplyNonAbiChangeToKotlinSourceFileMutatorTest extends AbstractMutatorTest {
 
-    def "adds and replaces public method at end of source file"() {
+    def "adds public function at end of source file replacing its body"() {
         def sourceFile = tmpDir.newFile("Thing.kt")
         sourceFile.text = "class Thing { fun existingMethod() { }}"
         def mutator = new ApplyNonAbiChangeToKotlinSourceFileMutator(sourceFile)
+        def functionText = { qualifier ->
+            "class Thing { fun existingMethod() { }}\n" +
+                "private fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7() {" +
+                "requireNotNull(\"_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_$qualifier\")" +
+                "}"
+        }
 
         when:
+        mutator.beforeScenario(scenarioContext)
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7() {}"
+        sourceFile.text == functionText("MEASURE_7")
+
+        when:
+        mutator.beforeBuild(buildContext.withBuild(Phase.MEASURE, 8))
+
+        then:
+        sourceFile.text == functionText("MEASURE_8")
     }
 
     def "reverts changes when nothing has been applied"() {
@@ -38,6 +53,7 @@ class ApplyNonAbiChangeToKotlinSourceFileMutatorTest extends AbstractMutatorTest
         def mutator = new ApplyNonAbiChangeToKotlinSourceFileMutator(sourceFile)
 
         when:
+        mutator.beforeScenario(scenarioContext)
         mutator.beforeBuild(buildContext)
         mutator.afterScenario(scenarioContext)
 

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutatorTest.groovy
@@ -2,31 +2,34 @@ package org.gradle.profiler.mutations
 
 import org.gradle.profiler.Phase
 
+import java.util.function.Function
+
 class ApplyNonAbiChangeToKotlinSourceFileMutatorTest extends AbstractMutatorTest {
+
+    static Function<String, String> FUNCTION_TEXT = { qualifier ->
+        "class Thing { fun existingMethod() { }}\n" +
+            "private fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7() {" +
+            "requireNotNull(\"_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_$qualifier\")" +
+            "}"
+    }
 
     def "adds public function at end of source file replacing its body"() {
         def sourceFile = tmpDir.newFile("Thing.kt")
         sourceFile.text = "class Thing { fun existingMethod() { }}"
         def mutator = new ApplyNonAbiChangeToKotlinSourceFileMutator(sourceFile)
-        def functionText = { qualifier ->
-            "class Thing { fun existingMethod() { }}\n" +
-                "private fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7() {" +
-                "requireNotNull(\"_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_$qualifier\")" +
-                "}"
-        }
 
         when:
         mutator.beforeScenario(scenarioContext)
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == functionText("MEASURE_7")
+        sourceFile.text == FUNCTION_TEXT.apply("MEASURE_7")
 
         when:
         mutator.beforeBuild(buildContext.withBuild(Phase.MEASURE, 8))
 
         then:
-        sourceFile.text == functionText("MEASURE_8")
+        sourceFile.text == FUNCTION_TEXT.apply("MEASURE_8")
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToSourceFileMutatorTest.groovy
@@ -14,10 +14,7 @@ class ApplyNonAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}\n" +
-            "private fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7() {" +
-            "requireNotNull(\"_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7\")" +
-            "}"
+        sourceFile.text == ApplyNonAbiChangeToKotlinSourceFileMutatorTest.FUNCTION_TEXT.apply("MEASURE_7")
     }
 
     def "adds and replaces public method at end of Java source file"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToSourceFileMutatorTest.groovy
@@ -10,10 +10,14 @@ class ApplyNonAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest {
         def mutator = new ApplyNonAbiChangeToSourceFileMutator(sourceFile)
 
         when:
+        mutator.beforeScenario(scenarioContext)
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}private fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7() {}"
+        sourceFile.text == "class Thing { fun existingMethod() { }}\n" +
+            "private fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7() {" +
+            "requireNotNull(\"_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7\")" +
+            "}"
     }
 
     def "adds and replaces public method at end of Java source file"() {


### PR DESCRIPTION
Changing the signature of a private function changes kotlin metadata hence not producing a non-abi-change but an abi-change for java consumers.

This commit lets the Kotlin mutator inject a dummy method before running a scenario, and modify it's implementation body on each build.

See https://github.com/gradle/gradle-profiler/issues/212