### PR TITLE
Use reproducible JARs for the packaged artifacts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,6 +59,16 @@ allprojects {
     }
 }
 
+subprojects {
+    // Subprojects are packaged into the Gradle profiler Jar, so let's make them reproducible
+    tasks.withType<Jar>().configureEach {
+        isReproducibleFileOrder = true
+        isPreserveFileTimestamps = false
+        dirMode = Integer.parseInt("0755", 8)
+        fileMode = Integer.parseInt("0644", 8)
+    }
+}
+
 java {
     withSourcesJar()
 }


### PR DESCRIPTION
So that we can get build cache hits for the tests.