### PR TITLE
Use canonical paths for temp-files

### DIFF
--- a/src/main/java/org/gradle/profiler/DefaultGradleBuildConfigurationReader.java
+++ b/src/main/java/org/gradle/profiler/DefaultGradleBuildConfigurationReader.java
@@ -34,7 +34,7 @@ public class DefaultGradleBuildConfigurationReader implements GradleBuildConfigu
         this.projectDir = projectDir;
         this.gradleUserHome = gradleUserHome;
         this.daemonControl = daemonControl;
-        initScript = File.createTempFile("gradle-profiler", ".gradle");
+        initScript = File.createTempFile("gradle-profiler", ".gradle").getCanonicalFile();
         initScript.deleteOnExit();
         buildDetails = File.createTempFile("gradle-profiler", "build-details");
         buildDetails.deleteOnExit();

--- a/src/main/java/org/gradle/profiler/GeneratedInitScript.java
+++ b/src/main/java/org/gradle/profiler/GeneratedInitScript.java
@@ -27,7 +27,7 @@ public abstract class GeneratedInitScript implements GradleArgsCalculator {
 
     public GeneratedInitScript() {
         try {
-            initScript = File.createTempFile("gradleProfiler" + getClass().getSimpleName(), ".gradle");
+            initScript = File.createTempFile("gradleProfiler" + getClass().getSimpleName(), ".gradle").getCanonicalFile();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/org/gradle/profiler/instrument/GradleInstrumentation.java
+++ b/src/main/java/org/gradle/profiler/instrument/GradleInstrumentation.java
@@ -45,7 +45,7 @@ public abstract class GradleInstrumentation implements GradleArgsCalculator {
 
     private File unpackPlugin(String jarName) {
         try {
-            File pluginJar = File.createTempFile(jarName, "jar");
+            File pluginJar = File.createTempFile(jarName, "jar").getCanonicalFile();
             try (InputStream inputStream = getClass().getResourceAsStream("/META-INF/jars/" + jarName + ".jar")) {
                 Files.copy(inputStream, pluginJar.toPath(), StandardCopyOption.REPLACE_EXISTING);
             }


### PR DESCRIPTION
when they are inputs to the build. We currently can't watch symlinks on macOS, since we get the events for the canonical path. `/var` is a symlink to `/private/var` on macOS, and the tmp dir is in `/var`.