### PR TITLE
Expose project dir in BuildContext and ScenarioContext

### DIFF
--- a/src/main/java/org/gradle/profiler/BuildContext.java
+++ b/src/main/java/org/gradle/profiler/BuildContext.java
@@ -1,30 +1,11 @@
 package org.gradle.profiler;
 
-import java.util.UUID;
+public interface BuildContext extends ScenarioContext {
+    String getUniqueBuildId();
 
-public class BuildContext extends ScenarioContext {
-    private final Phase phase;
-    private final int iteration;
+    Phase getPhase();
 
-    protected BuildContext(UUID invocationId, String scenarioName, Phase phase, int iteration) {
-        super(invocationId, scenarioName);
-        this.phase = phase;
-        this.iteration = iteration;
-    }
+    int getIteration();
 
-    public String getUniqueBuildId() {
-        return String.format("%s_%s_%d", getUniqueScenarioId(), phase.name(), iteration);
-    }
-
-    public Phase getPhase() {
-        return phase;
-    }
-
-    public int getIteration() {
-        return iteration;
-    }
-
-    public String getDisplayName() {
-        return phase.displayBuildNumber(iteration);
-    }
+    String getDisplayName();
 }

--- a/src/main/java/org/gradle/profiler/DefaultBuildContext.java
+++ b/src/main/java/org/gradle/profiler/DefaultBuildContext.java
@@ -1,0 +1,34 @@
+package org.gradle.profiler;
+
+import java.util.UUID;
+
+public class DefaultBuildContext extends DefaultScenarioContext implements BuildContext {
+    private final Phase phase;
+    private final int iteration;
+
+    protected DefaultBuildContext(UUID invocationId, String scenarioName, Phase phase, int iteration) {
+        super(invocationId, scenarioName);
+        this.phase = phase;
+        this.iteration = iteration;
+    }
+
+    @Override
+    public String getUniqueBuildId() {
+        return String.format("%s_%s_%d", getUniqueScenarioId(), phase.name(), iteration);
+    }
+
+    @Override
+    public Phase getPhase() {
+        return phase;
+    }
+
+    @Override
+    public int getIteration() {
+        return iteration;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return phase.displayBuildNumber(iteration);
+    }
+}

--- a/src/main/java/org/gradle/profiler/DefaultBuildContext.java
+++ b/src/main/java/org/gradle/profiler/DefaultBuildContext.java
@@ -1,5 +1,7 @@
 package org.gradle.profiler;
 
+import java.io.File;
+
 public class DefaultBuildContext implements BuildContext {
     private final ScenarioContext scenarioContext;
     private final Phase phase;
@@ -14,6 +16,11 @@ public class DefaultBuildContext implements BuildContext {
     @Override
     public String getUniqueScenarioId() {
         return scenarioContext.getUniqueScenarioId();
+    }
+
+    @Override
+    public File getProjectDir() {
+        return scenarioContext.getProjectDir();
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/DefaultBuildContext.java
+++ b/src/main/java/org/gradle/profiler/DefaultBuildContext.java
@@ -1,15 +1,24 @@
 package org.gradle.profiler;
 
-import java.util.UUID;
-
-public class DefaultBuildContext extends DefaultScenarioContext implements BuildContext {
+public class DefaultBuildContext implements BuildContext {
+    private final ScenarioContext scenarioContext;
     private final Phase phase;
     private final int iteration;
 
-    protected DefaultBuildContext(UUID invocationId, String scenarioName, Phase phase, int iteration) {
-        super(invocationId, scenarioName);
+    protected DefaultBuildContext(ScenarioContext scenarioContext, Phase phase, int iteration) {
+        this.scenarioContext = scenarioContext;
         this.phase = phase;
         this.iteration = iteration;
+    }
+
+    @Override
+    public String getUniqueScenarioId() {
+        return scenarioContext.getUniqueScenarioId();
+    }
+
+    @Override
+    public BuildContext withBuild(Phase phase, int count) {
+        return scenarioContext.withBuild(phase, count);
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/DefaultScenarioContext.java
+++ b/src/main/java/org/gradle/profiler/DefaultScenarioContext.java
@@ -3,22 +3,30 @@ package org.gradle.profiler;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.Hashing;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 public class DefaultScenarioContext implements ScenarioContext {
     private final UUID invocationId;
     private final String scenarioName;
+    private final File projectDir;
 
     @VisibleForTesting
-    public DefaultScenarioContext(UUID invocationId, String scenarioName) {
+    public DefaultScenarioContext(UUID invocationId, String scenarioName, File projectDir) {
         this.invocationId = invocationId;
         this.scenarioName = scenarioName;
+        this.projectDir = projectDir;
     }
 
     @Override
     public String getUniqueScenarioId() {
         return String.format("_%s_%s", invocationId.toString().replaceAll("-", "_"), mangleName(scenarioName));
+    }
+
+    @Override
+    public File getProjectDir() {
+        return projectDir;
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/DefaultScenarioContext.java
+++ b/src/main/java/org/gradle/profiler/DefaultScenarioContext.java
@@ -1,0 +1,41 @@
+package org.gradle.profiler;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.hash.Hashing;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+public class DefaultScenarioContext implements ScenarioContext {
+    private final UUID invocationId;
+    private final String scenarioName;
+
+    @VisibleForTesting
+    public DefaultScenarioContext(UUID invocationId, String scenarioName) {
+        this.invocationId = invocationId;
+        this.scenarioName = scenarioName;
+    }
+
+    @Override
+    public String getUniqueScenarioId() {
+        return String.format("_%s_%s", invocationId.toString().replaceAll("-", "_"), mangleName(scenarioName));
+    }
+
+    @Override
+    public BuildContext withBuild(Phase phase, int count) {
+        return new DefaultBuildContext(invocationId, scenarioName, phase, count);
+    }
+
+    /**
+     * This is to ensure that the scenario ID is a valid Java identifier part, and it is also (reasonably) unique.
+     */
+    private static String mangleName(String scenarioName) {
+        StringBuilder name = new StringBuilder();
+        for (char ch :scenarioName.toCharArray()){
+            name.append(Character.isJavaIdentifierPart(ch) ? ch : '_');
+        }
+        name.append('_');
+        name.append(Hashing.murmur3_32().hashString(scenarioName, StandardCharsets.UTF_8));
+        return name.toString();
+    }
+}

--- a/src/main/java/org/gradle/profiler/DefaultScenarioContext.java
+++ b/src/main/java/org/gradle/profiler/DefaultScenarioContext.java
@@ -23,7 +23,7 @@ public class DefaultScenarioContext implements ScenarioContext {
 
     @Override
     public BuildContext withBuild(Phase phase, int count) {
-        return new DefaultBuildContext(invocationId, scenarioName, phase, count);
+        return new DefaultBuildContext(this, phase, count);
     }
 
     /**

--- a/src/main/java/org/gradle/profiler/ScenarioContext.java
+++ b/src/main/java/org/gradle/profiler/ScenarioContext.java
@@ -1,43 +1,11 @@
 package org.gradle.profiler;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.hash.Hashing;
-
-import java.nio.charset.StandardCharsets;
-import java.util.UUID;
-
-public class ScenarioContext {
-    private final UUID invocationId;
-    private final String scenarioName;
-
-    public static ScenarioContext from(InvocationSettings invocationSettings, ScenarioDefinition scenarioDefinition) {
-        return new ScenarioContext(invocationSettings.getInvocationId(), scenarioDefinition.getName());
-    };
-
-    @VisibleForTesting
-    public ScenarioContext(UUID invocationId, String scenarioName) {
-        this.invocationId = invocationId;
-        this.scenarioName = scenarioName;
+public interface ScenarioContext {
+    static ScenarioContext from(InvocationSettings invocationSettings, ScenarioDefinition scenarioDefinition) {
+        return new DefaultScenarioContext(invocationSettings.getInvocationId(), scenarioDefinition.getName());
     }
 
-    public String getUniqueScenarioId() {
-        return String.format("_%s_%s", invocationId.toString().replaceAll("-", "_"), mangleName(scenarioName));
-    }
+    String getUniqueScenarioId();
 
-    public BuildContext withBuild(Phase phase, int count) {
-        return new BuildContext(invocationId, scenarioName, phase, count);
-    }
-
-    /**
-     * This is to ensure that the scenario ID is a valid Java identifier part, and it is also (reasonably) unique.
-     */
-    private static String mangleName(String scenarioName) {
-        StringBuilder name = new StringBuilder();
-        for (char ch :scenarioName.toCharArray()){
-            name.append(Character.isJavaIdentifierPart(ch) ? ch : '_');
-        }
-        name.append('_');
-        name.append(Hashing.murmur3_32().hashString(scenarioName, StandardCharsets.UTF_8));
-        return name.toString();
-    }
+    BuildContext withBuild(Phase phase, int count);
 }

--- a/src/main/java/org/gradle/profiler/ScenarioContext.java
+++ b/src/main/java/org/gradle/profiler/ScenarioContext.java
@@ -1,11 +1,15 @@
 package org.gradle.profiler;
 
+import java.io.File;
+
 public interface ScenarioContext {
     static ScenarioContext from(InvocationSettings invocationSettings, ScenarioDefinition scenarioDefinition) {
-        return new DefaultScenarioContext(invocationSettings.getInvocationId(), scenarioDefinition.getName());
+        return new DefaultScenarioContext(invocationSettings.getInvocationId(), scenarioDefinition.getName(), invocationSettings.getProjectDir());
     }
 
     String getUniqueScenarioId();
+
+    File getProjectDir();
 
     BuildContext withBuild(Phase phase, int count);
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/AbstractMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/AbstractMutatorTest.groovy
@@ -1,13 +1,13 @@
 package org.gradle.profiler.mutations
 
+import org.gradle.profiler.DefaultScenarioContext
 import org.gradle.profiler.Phase
-import org.gradle.profiler.ScenarioContext
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
 abstract class AbstractMutatorTest extends Specification {
     @Rule TemporaryFolder tmpDir = new TemporaryFolder()
-    def scenarioContext = new ScenarioContext(UUID.fromString("276d92f3-16ac-4064-9a18-5f1dfd67992f"), "testScenario")
+    def scenarioContext = new DefaultScenarioContext(UUID.fromString("276d92f3-16ac-4064-9a18-5f1dfd67992f"), "testScenario")
     def buildContext = scenarioContext.withBuild(Phase.MEASURE, 7)
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/AbstractMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/AbstractMutatorTest.groovy
@@ -1,13 +1,23 @@
 package org.gradle.profiler.mutations
 
+import org.gradle.profiler.BuildContext
 import org.gradle.profiler.DefaultScenarioContext
 import org.gradle.profiler.Phase
+import org.gradle.profiler.ScenarioContext
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
 abstract class AbstractMutatorTest extends Specification {
-    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
-    def scenarioContext = new DefaultScenarioContext(UUID.fromString("276d92f3-16ac-4064-9a18-5f1dfd67992f"), "testScenario")
-    def buildContext = scenarioContext.withBuild(Phase.MEASURE, 7)
+    @Rule
+    TemporaryFolder tmpDir = new TemporaryFolder()
+    ScenarioContext scenarioContext
+    BuildContext buildContext
+
+    def setup() {
+        def projectDir = tmpDir.getRoot()
+        projectDir.mkdirs()
+        scenarioContext = new DefaultScenarioContext(UUID.fromString("276d92f3-16ac-4064-9a18-5f1dfd67992f"), "testScenario", projectDir)
+        buildContext = scenarioContext.withBuild(Phase.MEASURE, 7)
+    }
 }


### PR DESCRIPTION
This is a stop-gap measure for now. We should probably expose the whole of `InvocationSettings` and `ScenarioDefinition` in these contexts later on.