### PR TITLE
Revert "Expose projectDir in BuildContext and ScenarioContext"

### DIFF
--- a/src/main/java/org/gradle/profiler/DefaultBuildContext.java
+++ b/src/main/java/org/gradle/profiler/DefaultBuildContext.java
@@ -1,7 +1,5 @@
 package org.gradle.profiler;
 
-import java.io.File;
-
 public class DefaultBuildContext implements BuildContext {
     private final ScenarioContext scenarioContext;
     private final Phase phase;
@@ -16,11 +14,6 @@ public class DefaultBuildContext implements BuildContext {
     @Override
     public String getUniqueScenarioId() {
         return scenarioContext.getUniqueScenarioId();
-    }
-
-    @Override
-    public File getProjectDir() {
-        return scenarioContext.getProjectDir();
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/DefaultScenarioContext.java
+++ b/src/main/java/org/gradle/profiler/DefaultScenarioContext.java
@@ -3,30 +3,22 @@ package org.gradle.profiler;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.hash.Hashing;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 public class DefaultScenarioContext implements ScenarioContext {
     private final UUID invocationId;
     private final String scenarioName;
-    private final File projectDir;
 
     @VisibleForTesting
-    public DefaultScenarioContext(UUID invocationId, String scenarioName, File projectDir) {
+    public DefaultScenarioContext(UUID invocationId, String scenarioName) {
         this.invocationId = invocationId;
         this.scenarioName = scenarioName;
-        this.projectDir = projectDir;
     }
 
     @Override
     public String getUniqueScenarioId() {
         return String.format("_%s_%s", invocationId.toString().replaceAll("-", "_"), mangleName(scenarioName));
-    }
-
-    @Override
-    public File getProjectDir() {
-        return projectDir;
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/ScenarioContext.java
+++ b/src/main/java/org/gradle/profiler/ScenarioContext.java
@@ -1,15 +1,11 @@
 package org.gradle.profiler;
 
-import java.io.File;
-
 public interface ScenarioContext {
     static ScenarioContext from(InvocationSettings invocationSettings, ScenarioDefinition scenarioDefinition) {
-        return new DefaultScenarioContext(invocationSettings.getInvocationId(), scenarioDefinition.getName(), invocationSettings.getProjectDir());
+        return new DefaultScenarioContext(invocationSettings.getInvocationId(), scenarioDefinition.getName());
     }
 
     String getUniqueScenarioId();
-
-    File getProjectDir();
 
     BuildContext withBuild(Phase phase, int count);
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/AbstractMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/AbstractMutatorTest.groovy
@@ -1,23 +1,13 @@
 package org.gradle.profiler.mutations
 
-import org.gradle.profiler.BuildContext
 import org.gradle.profiler.DefaultScenarioContext
 import org.gradle.profiler.Phase
-import org.gradle.profiler.ScenarioContext
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
 abstract class AbstractMutatorTest extends Specification {
-    @Rule
-    TemporaryFolder tmpDir = new TemporaryFolder()
-    ScenarioContext scenarioContext
-    BuildContext buildContext
-
-    def setup() {
-        def projectDir = tmpDir.getRoot()
-        projectDir.mkdirs()
-        scenarioContext = new DefaultScenarioContext(UUID.fromString("276d92f3-16ac-4064-9a18-5f1dfd67992f"), "testScenario", projectDir)
-        buildContext = scenarioContext.withBuild(Phase.MEASURE, 7)
-    }
+    @Rule TemporaryFolder tmpDir = new TemporaryFolder()
+    def scenarioContext = new DefaultScenarioContext(UUID.fromString("276d92f3-16ac-4064-9a18-5f1dfd67992f"), "testScenario")
+    def buildContext = scenarioContext.withBuild(Phase.MEASURE, 7)
 }


### PR DESCRIPTION
This reverts the exposing of `projectDir` on `BuildContext` and `ScenarioContext`. Let's do this differently, and expose things like the `InvocationSettings` and `ScenarioDefinition` in a more complete way instead.