### PR TITLE
Add buildLog to InvocationSettings

### DIFF
--- a/src/main/java/org/gradle/profiler/BazelScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/BazelScenarioInvoker.java
@@ -28,11 +28,11 @@ public class BazelScenarioInvoker extends ScenarioInvoker<BazelScenarioDefinitio
         try {
             for (int iteration = 1; iteration <= scenario.getWarmUpCount(); iteration++) {
                 BuildContext buildContext = scenarioContext.withBuild(WARM_UP, iteration);
-                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir()), resultConsumer);
+                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir(), settings.getBuildLog()), resultConsumer);
             }
             for (int iteration = 1; iteration <= scenario.getBuildCount(); iteration++) {
                 BuildContext buildContext = scenarioContext.withBuild(MEASURE, iteration);
-                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir()), resultConsumer);
+                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir(), settings.getBuildLog()), resultConsumer);
             }
         } finally {
             mutator.afterScenario(scenarioContext);

--- a/src/main/java/org/gradle/profiler/BuckScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/BuckScenarioInvoker.java
@@ -43,11 +43,11 @@ public class BuckScenarioInvoker extends ScenarioInvoker<BuckScenarioDefinition,
         try {
             for (int iteration = 1; iteration <= scenario.getWarmUpCount(); iteration++) {
                 BuildContext buildContext = scenarioContext.withBuild(WARM_UP, iteration);
-                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir()), resultConsumer);
+                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir(), settings.getBuildLog()), resultConsumer);
             }
             for (int iteration = 1; iteration <= scenario.getBuildCount(); iteration++) {
                 BuildContext buildContext = scenarioContext.withBuild(MEASURE, iteration);
-                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir()), resultConsumer);
+                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir(), settings.getBuildLog()), resultConsumer);
             }
         } finally {
             mutator.afterScenario(scenarioContext);

--- a/src/main/java/org/gradle/profiler/CommandExec.java
+++ b/src/main/java/org/gradle/profiler/CommandExec.java
@@ -84,14 +84,18 @@ public class CommandExec {
             executor.execute(() -> {
                 byte[] buffer = new byte[4096];
                 while (true) {
-                    if (readStream(process.getInputStream(), outputStream, diagnosticOutput, command, buffer)) break;
+                    if (readStream(process.getInputStream(), outputStream, diagnosticOutput, command, buffer)) {
+                        break;
+                    }
                 }
             });
             if (errorStream != null) {
                 executor.execute(() -> {
                     byte[] buffer = new byte[4096];
                     while (true) {
-                        if (readStream(process.getErrorStream(), errorStream, diagnosticOutput, command, buffer)) break;
+                        if (readStream(process.getErrorStream(), errorStream, diagnosticOutput, command, buffer)) {
+                            break;
+                        }
                     }
                 });
             }
@@ -135,6 +139,12 @@ public class CommandExec {
             diagnoticStream.write(buffer, 0, nread);
         } catch (IOException e) {
             throw new RuntimeException("Could not write output from child process for command '" + command + "'", e);
+        } finally {
+            try {
+                outputStream.flush();
+            } catch (IOException e) {
+                throw new RuntimeException("Could not write output from child process for command '" + command + "'", e);
+            }
         }
         return false;
     }

--- a/src/main/java/org/gradle/profiler/CommandExec.java
+++ b/src/main/java/org/gradle/profiler/CommandExec.java
@@ -60,7 +60,7 @@ public class CommandExec {
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
         }
-        run(new ProcessBuilder(commandLine), outputStream, Logging.detailed(), null).waitForSuccess();
+        run(new ProcessBuilder(commandLine), new BufferedOutputStream(outputStream), Logging.detailed(), null).waitForSuccess();
     }
 
     public void run(ProcessBuilder processBuilder) {

--- a/src/main/java/org/gradle/profiler/CommandLineParser.java
+++ b/src/main/java/org/gradle/profiler/CommandLineParser.java
@@ -1,6 +1,10 @@
 package org.gradle.profiler;
 
-import joptsimple.*;
+import joptsimple.ArgumentAcceptingOptionSpec;
+import joptsimple.OptionException;
+import joptsimple.OptionParser;
+import joptsimple.OptionSet;
+import joptsimple.OptionSpecBuilder;
 import org.gradle.profiler.report.CsvGenerator;
 import org.gradle.profiler.report.CsvGenerator.Format;
 
@@ -124,24 +128,24 @@ class CommandLineParser {
         }
         CsvGenerator.Format csvFormat = CsvGenerator.Format.parse(parsedOptions.valueOf(csvFormatOption));
 
-        return new InvocationSettings(
-            projectDir,
-            profiler,
-            benchmark,
-            outputDir,
-            invoker,
-            dryRun,
-            scenarioFile,
-            versions,
-            targetNames,
-            sysProperties,
-            gradleUserHome,
-            warmups,
-            iterations,
-            measureConfig,
-            benchmarkedBuildOperations,
-            csvFormat
-        );
+        return new InvocationSettings.InvocationSettingsBuilder()
+            .setProjectDir(projectDir)
+            .setProfiler(profiler)
+            .setBenchmark(benchmark)
+            .setOutputDir(outputDir)
+            .setInvoker(invoker)
+            .setDryRun(dryRun)
+            .setScenarioFile(scenarioFile)
+            .setVersions(versions)
+            .setTargets(targetNames)
+            .setSysProperties(sysProperties)
+            .setGradleUserHome(gradleUserHome)
+            .setWarmupCount(warmups)
+            .setIterations(iterations)
+            .setMeasureConfigTime(measureConfig)
+            .setMeasuredBuildOperations(benchmarkedBuildOperations)
+            .setCsvFormat(csvFormat)
+            .build();
     }
 
     private File findOutputDir() {

--- a/src/main/java/org/gradle/profiler/CompositeProfiler.java
+++ b/src/main/java/org/gradle/profiler/CompositeProfiler.java
@@ -71,24 +71,24 @@ class CompositeProfiler extends Profiler {
 
     private ScenarioSettings settingsFor(final Profiler prof, final ScenarioSettings scenarioSettings) {
         InvocationSettings settings = scenarioSettings.getInvocationSettings();
-        InvocationSettings newSettings = new InvocationSettings(
-            settings.getProjectDir(),
-            prof,
-            settings.isBenchmark(),
-            settings.getOutputDir(),
-            settings.getInvoker(),
-            settings.isDryRun(),
-            settings.getScenarioFile(),
-            settings.getVersions(),
-            settings.getTargets(),
-            settings.getSystemProperties(),
-            settings.getGradleUserHome(),
-            settings.getWarmUpCount(),
-            settings.getBuildCount(),
-            settings.isMeasureConfigTime(),
-            settings.getMeasuredBuildOperations(),
-            settings.getCsvFormat()
-        );
+        InvocationSettings newSettings = new InvocationSettings.InvocationSettingsBuilder()
+            .setProjectDir(settings.getProjectDir())
+            .setProfiler(prof)
+            .setBenchmark(settings.isBenchmark())
+            .setOutputDir(settings.getOutputDir())
+            .setInvoker(settings.getInvoker())
+            .setDryRun(settings.isDryRun())
+            .setScenarioFile(settings.getScenarioFile())
+            .setVersions(settings.getVersions())
+            .setTargets(settings.getTargets())
+            .setSysProperties(settings.getSystemProperties())
+            .setGradleUserHome(settings.getGradleUserHome())
+            .setWarmupCount(settings.getWarmUpCount())
+            .setIterations(settings.getBuildCount())
+            .setMeasureConfigTime(settings.isMeasureConfigTime())
+            .setMeasuredBuildOperations(settings.getMeasuredBuildOperations())
+            .setCsvFormat(settings.getCsvFormat()
+        ).build();
         return new ScenarioSettings(newSettings, scenarioSettings.getScenario());
     }
 

--- a/src/main/java/org/gradle/profiler/CompositeProfiler.java
+++ b/src/main/java/org/gradle/profiler/CompositeProfiler.java
@@ -87,8 +87,8 @@ class CompositeProfiler extends Profiler {
             .setIterations(settings.getBuildCount())
             .setMeasureConfigTime(settings.isMeasureConfigTime())
             .setMeasuredBuildOperations(settings.getMeasuredBuildOperations())
-            .setCsvFormat(settings.getCsvFormat()
-        ).build();
+            .setCsvFormat(settings.getCsvFormat())
+            .build();
         return new ScenarioSettings(newSettings, scenarioSettings.getScenario());
     }
 

--- a/src/main/java/org/gradle/profiler/InvocationSettings.java
+++ b/src/main/java/org/gradle/profiler/InvocationSettings.java
@@ -1,12 +1,13 @@
 package org.gradle.profiler;
 
-import org.gradle.profiler.report.CsvGenerator;
-
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.PrintStream;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
+import static org.gradle.profiler.report.CsvGenerator.Format;
 
 public class InvocationSettings {
     private final File projectDir;
@@ -24,11 +25,16 @@ public class InvocationSettings {
     private final Integer iterations;
     private final boolean measureConfigTime;
     private final List<String> measuredBuildOperations;
-    private final CsvGenerator.Format csvFormat;
+    private final Format csvFormat;
+    /**
+     * The log file which the build should write stdout and stderr to.
+     * If {@code null}, the stdout and stderr are stored in memory.
+     */
+    private final File buildLog;
 
     private final UUID invocationId = UUID.randomUUID();
 
-    public InvocationSettings(
+    private InvocationSettings(
         File projectDir,
         Profiler profiler,
         boolean benchmark,
@@ -37,15 +43,16 @@ public class InvocationSettings {
         boolean dryRun,
         File scenarioFile,
         List<String> versions,
-        List<String> getTargets,
+        List<String> targets,
         Map<String,
-        String> sysProperties,
+            String> sysProperties,
         File gradleUserHome,
         Integer warmupCount,
         Integer iterations,
         boolean measureConfigTime,
         List<String> measuredBuildOperations,
-        CsvGenerator.Format csvFormat
+        Format csvFormat,
+        File buildLog
     ) {
         this.benchmark = benchmark;
         this.projectDir = projectDir;
@@ -55,7 +62,7 @@ public class InvocationSettings {
         this.dryRun = dryRun;
         this.scenarioFile = scenarioFile;
         this.versions = versions;
-        this.targets = getTargets;
+        this.targets = targets;
         this.sysProperties = sysProperties;
         this.gradleUserHome = gradleUserHome;
         this.warmupCount = warmupCount;
@@ -63,6 +70,12 @@ public class InvocationSettings {
         this.measureConfigTime = measureConfigTime;
         this.measuredBuildOperations = measuredBuildOperations;
         this.csvFormat = csvFormat;
+        this.buildLog = buildLog;
+    }
+
+    @Nullable
+    public File getBuildLog() {
+        return buildLog;
     }
 
     public File getOutputDir() {
@@ -141,7 +154,7 @@ public class InvocationSettings {
         return measuredBuildOperations;
     }
 
-    public CsvGenerator.Format getCsvFormat() {
+    public Format getCsvFormat() {
         return csvFormat;
     }
 
@@ -168,6 +181,136 @@ public class InvocationSettings {
             for (Map.Entry<String, String> entry : getSystemProperties().entrySet()) {
                 out.println("  " + entry.getKey() + "=" + entry.getValue());
             }
+        }
+    }
+
+
+    public static final class InvocationSettingsBuilder {
+        private File projectDir;
+        private Profiler profiler;
+        private boolean benchmark;
+        private boolean dryRun;
+        private File scenarioFile;
+        private File outputDir;
+        private BuildInvoker invoker;
+        private List<String> versions;
+        private List<String> targets;
+        private Map<String, String> sysProperties;
+        private File gradleUserHome;
+        private Integer warmupCount;
+        private Integer iterations;
+        private boolean measureConfigTime;
+        private List<String> measuredBuildOperations;
+        private Format csvFormat;
+        private File buildLog;
+
+        public InvocationSettingsBuilder() {
+        }
+
+        public InvocationSettingsBuilder setProjectDir(File projectDir) {
+            this.projectDir = projectDir;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setProfiler(Profiler profiler) {
+            this.profiler = profiler;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setBenchmark(boolean benchmark) {
+            this.benchmark = benchmark;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setDryRun(boolean dryRun) {
+            this.dryRun = dryRun;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setScenarioFile(File scenarioFile) {
+            this.scenarioFile = scenarioFile;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setOutputDir(File outputDir) {
+            this.outputDir = outputDir;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setInvoker(BuildInvoker invoker) {
+            this.invoker = invoker;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setVersions(List<String> versions) {
+            this.versions = versions;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setTargets(List<String> targets) {
+            this.targets = targets;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setSysProperties(Map<String, String> sysProperties) {
+            this.sysProperties = sysProperties;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setGradleUserHome(File gradleUserHome) {
+            this.gradleUserHome = gradleUserHome;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setWarmupCount(Integer warmupCount) {
+            this.warmupCount = warmupCount;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setIterations(Integer iterations) {
+            this.iterations = iterations;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setMeasureConfigTime(boolean measureConfigTime) {
+            this.measureConfigTime = measureConfigTime;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setMeasuredBuildOperations(List<String> measuredBuildOperations) {
+            this.measuredBuildOperations = measuredBuildOperations;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setCsvFormat(Format csvFormat) {
+            this.csvFormat = csvFormat;
+            return this;
+        }
+
+        public void setBuildLog(File buildLog) {
+            this.buildLog = buildLog;
+        }
+
+        public InvocationSettings build() {
+            return new InvocationSettings(
+                projectDir,
+                profiler,
+                benchmark,
+                outputDir,
+                invoker,
+                dryRun,
+                scenarioFile,
+                versions,
+                targets,
+                sysProperties,
+                gradleUserHome,
+                warmupCount,
+                iterations,
+                measureConfigTime,
+                measuredBuildOperations,
+                csvFormat,
+                buildLog
+            );
         }
     }
 }

--- a/src/main/java/org/gradle/profiler/InvocationSettings.java
+++ b/src/main/java/org/gradle/profiler/InvocationSettings.java
@@ -44,8 +44,7 @@ public class InvocationSettings {
         File scenarioFile,
         List<String> versions,
         List<String> targets,
-        Map<String,
-            String> sysProperties,
+        Map<String, String> sysProperties,
         File gradleUserHome,
         Integer warmupCount,
         Integer iterations,
@@ -184,7 +183,6 @@ public class InvocationSettings {
         }
     }
 
-
     public static final class InvocationSettingsBuilder {
         private File projectDir;
         private Profiler profiler;
@@ -203,9 +201,6 @@ public class InvocationSettings {
         private List<String> measuredBuildOperations;
         private Format csvFormat;
         private File buildLog;
-
-        public InvocationSettingsBuilder() {
-        }
 
         public InvocationSettingsBuilder setProjectDir(File projectDir) {
             this.projectDir = projectDir;

--- a/src/main/java/org/gradle/profiler/MavenScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/MavenScenarioInvoker.java
@@ -26,11 +26,11 @@ public class MavenScenarioInvoker extends ScenarioInvoker<MavenScenarioDefinitio
         try {
             for (int iteration = 1; iteration <= scenario.getWarmUpCount(); iteration++) {
                 BuildContext buildContext = scenarioContext.withBuild(WARM_UP, iteration);
-                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir()), resultConsumer);
+                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir(), settings.getBuildLog()), resultConsumer);
             }
             for (int iteration = 1; iteration <= scenario.getBuildCount(); iteration++) {
                 BuildContext buildContext = scenarioContext.withBuild(MEASURE, iteration);
-                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir()), resultConsumer);
+                runMeasured(buildContext, mutator, measureCommandLineExecution(buildContext, commandLine, settings.getProjectDir(), settings.getBuildLog()), resultConsumer);
             }
         } finally {
             mutator.afterScenario(scenarioContext);

--- a/src/main/java/org/gradle/profiler/ScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/ScenarioInvoker.java
@@ -67,10 +67,14 @@ public abstract class ScenarioInvoker<T extends ScenarioDefinition, R extends Bu
     /**
      * Returns a {@link Supplier} that returns the result of the given command.
      */
-    protected Supplier<BuildInvocationResult> measureCommandLineExecution(BuildContext buildContext, List<String> commandLine, File workingDir) {
+    Supplier<BuildInvocationResult> measureCommandLineExecution(BuildContext buildContext, List<String> commandLine, File workingDir, File buildLog) {
         return () -> {
             Timer timer = new Timer();
-            new CommandExec().inDir(workingDir).run(commandLine);
+            if (buildLog == null) {
+                new CommandExec().inDir(workingDir).run(commandLine);
+            } else {
+                new CommandExec().inDir(workingDir).runAndCollectOutput(buildLog, commandLine);
+            }
             Duration executionTime = timer.elapsed();
             return new BuildInvocationResult(buildContext, executionTime);
         };

--- a/src/test/groovy/org/gradle/profiler/CommandExecTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/CommandExecTest.groovy
@@ -16,6 +16,6 @@ class CommandExecTest extends Specification {
         new CommandExec(tmpDir.root).runAndCollectOutput(output, "echo", "hello")
 
         then:
-        output.text == 'hello'
+        output.text.trim() == 'hello'
     }
 }

--- a/src/test/groovy/org/gradle/profiler/CommandExecTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/CommandExecTest.groovy
@@ -1,0 +1,21 @@
+package org.gradle.profiler
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class CommandExecTest extends Specification {
+    @Rule
+    TemporaryFolder tmpDir = new TemporaryFolder()
+
+    void 'can direct output to a file'() {
+        given:
+        File output = new File(tmpDir.root, "output.txt")
+
+        when:
+        new CommandExec(tmpDir.root).runAndCollectOutput(output, "echo", "hello")
+
+        then:
+        output.text == 'hello'
+    }
+}

--- a/src/test/groovy/org/gradle/profiler/CommandExecTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/CommandExecTest.groovy
@@ -2,8 +2,10 @@ package org.gradle.profiler
 
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
+import spock.lang.Requires
 import spock.lang.Specification
 
+@Requires({ !OperatingSystem.windows })
 class CommandExecTest extends Specification {
     @Rule
     TemporaryFolder tmpDir = new TemporaryFolder()

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -31,24 +31,24 @@ class ScenarioLoaderTest extends Specification {
         Integer iterations = null,
         List<String> measuredBuildOperations = ImmutableList.of()
     ) {
-        new InvocationSettings(
-            projectDir,
-            Profiler.NONE,
-            benchmark,
-            outputDir,
-            invoker,
-            false,
-            scenarioFile,
-            [],
-            [],
-            [:],
-            gradleUserHomeDir,
-            warmups,
-            iterations,
-            false,
-            measuredBuildOperations,
-            CsvGenerator.Format.WIDE
-        )
+        new InvocationSettings.InvocationSettingsBuilder()
+            .setProjectDir(projectDir)
+            .setProfiler(Profiler.NONE)
+            .setBenchmark(benchmark)
+            .setOutputDir(outputDir)
+            .setInvoker(invoker)
+            .setDryRun(false)
+            .setScenarioFile(scenarioFile)
+            .setVersions([])
+            .setTargets([])
+            .setSysProperties([:])
+            .setGradleUserHome(gradleUserHomeDir)
+            .setWarmupCount(warmups)
+            .setIterations(iterations)
+            .setMeasureConfigTime(false)
+            .setMeasuredBuildOperations(measuredBuildOperations)
+            .setCsvFormat(CsvGenerator.Format.WIDE
+            ).build()
     }
 
     def "can load single scenario"() {


### PR DESCRIPTION
This is an attempt to resolve https://github.com/gradle/gradle-profiler/issues/243.
Previously, the build log is stored in memory, and we get OOMs when it's huge.
Now we allow users to specify a buildLog file which the build log will be redirected to.