### PR TITLE
Allow `CliInvoker` redirect build log to file

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-profiler.version=0.15.0-alpha2
+profiler.version=0.15.0-alpha6
 org.gradle.caching=true

--- a/src/main/java/org/gradle/profiler/GradleClientSpec.java
+++ b/src/main/java/org/gradle/profiler/GradleClientSpec.java
@@ -27,7 +27,7 @@ public abstract class GradleClientSpec {
 
         @Override
         public GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings, ProjectConnection projectConnection) {
-            return new CliGradleClient(buildConfiguration, buildConfiguration.getJavaHome(), invocationSettings.getProjectDir(), true);
+            return new CliGradleClient(buildConfiguration, buildConfiguration.getJavaHome(), invocationSettings.getProjectDir(), true, invocationSettings.getBuildLog());
         }
     };
 
@@ -44,7 +44,7 @@ public abstract class GradleClientSpec {
 
         @Override
         public GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings, ProjectConnection projectConnection) {
-            return new CliGradleClient(buildConfiguration, buildConfiguration.getJavaHome(), invocationSettings.getProjectDir(), false);
+            return new CliGradleClient(buildConfiguration, buildConfiguration.getJavaHome(), invocationSettings.getProjectDir(), false, invocationSettings.getBuildLog());
         }
     };
 


### PR DESCRIPTION
In https://github.com/gradle/gradle-profiler/pull/244/files we only added `buildLog` support for `ScenarioInvoker.measureCommandLineExecution`, but not for `CliInvoker`. This PR adds `buildLog` support to it.