### PR TITLE
Reduce build operation measurement overhead

### DIFF
--- a/src/main/java/org/gradle/profiler/buildops/BuildOperationInstrumentation.java
+++ b/src/main/java/org/gradle/profiler/buildops/BuildOperationInstrumentation.java
@@ -49,9 +49,13 @@ public class BuildOperationInstrumentation extends GradleInstrumentation {
         if (measureConfigTime) {
             writer.print(".measureConfigurationTime(" + newFile(configurationTimeDataFile) + ")");
         }
-        buildOperationDataFiles.forEach((opName, dataFile) ->
-            writer.print(String.format(".measureBuildOperation('%s', %s)", opName, newFile(dataFile)))
-        );
+        if (!buildOperationDataFiles.isEmpty()) {
+            writer.print(".measureBuildOperations(");
+            buildOperationDataFiles.forEach((opName, dataFile) ->
+                writer.print(String.format("'%s': %s,", opName, newFile(dataFile)))
+            );
+            writer.print(")");
+        }
     }
 
     private String newFile(File dataFile) {

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/BuildOperationTrace.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/BuildOperationTrace.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -31,7 +31,6 @@ public class BuildOperationTrace {
 
     private final BuildEventListenerRegistryInternal registry;
     private final BuildServiceRegistry sharedServices;
-    private final Map<String, File> capturedBuildOperations = new LinkedHashMap<>();
 
     public BuildOperationTrace(GradleInternal gradle) {
         registry = gradle.getServices().get(BuildEventListenerRegistryInternal.class);
@@ -46,12 +45,11 @@ public class BuildOperationTrace {
         return this;
     }
 
-    public BuildOperationTrace measureBuildOperation(String buildOperationName, File outFile) {
+    public BuildOperationTrace measureBuildOperations(Map<String, File> capturedBuildOperations) {
         Provider<BuildOperationDurationRecordingListener> listenerProvider = sharedServices.registerIfAbsent("measure-build-operations", BuildOperationDurationRecordingListener.class, spec -> {
-            spec.getParameters().getCapturedBuildOperations().set(capturedBuildOperations);
+            spec.getParameters().getCapturedBuildOperations().set(new HashMap<>(capturedBuildOperations));
         });
         registry.onOperationCompletion(listenerProvider);
-        capturedBuildOperations.put(buildOperationName, outFile);
         return this;
     }
 

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/BuildOperationTrace.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/BuildOperationTrace.java
@@ -2,7 +2,7 @@ package org.gradle.trace.buildops;
 
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.provider.Property;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
@@ -87,7 +87,7 @@ public class BuildOperationTrace {
 
     public static abstract class BuildOperationDurationRecordingListener implements BuildService<BuildOperationDurationRecordingListener.Params>, BuildOperationListener, AutoCloseable {
         interface Params extends BuildServiceParameters {
-            Property<Map<String, File>> getCapturedBuildOperations();
+            MapProperty<String, File> getCapturedBuildOperations();
         }
 
         private final List<BuildOperationCollector> collectors;


### PR DESCRIPTION
Instead of registering a `BuildOperationListener` for every build operation type captured, we now add only one that handles all the captured build operations. This reduces the overhead of the observation significantly from 68.5%, though it still stays rather high at 14.1%.

Fixes #214 