### PR TITLE
Add support for profiling and benchmarking Android Studio sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The following command line options only apply when measuring Gradle builds:
 - `--measure-config-time`: Measure some additional details about configuration time. Only supported for Gradle 6.1 and later.
 - `--measure-build-op`: Additionally measure the cumulative time spent in the given build operation. Only supported for Gradle 6.1 and later.
 - `-D<key>=<value>`: Defines a system property when running the build, overriding the default for the build.
+- `--studio-install-dir`: The Android Studio installation directory. Required when measuring Android Studio sync.
 
 ## Advanced profiling scenarios
 
@@ -233,13 +234,8 @@ Here is an example:
     }
     androidStudioSync {
         title = "Android Studio Sync"
-        # Simulate an Android studio sync
+        # Measure an Android studio sync
         android-studio-sync {
-            # Skip source generation on sync
-            skip-source-generation = true // if not specified defaults to "false"
-            # If the above flag is set to "false", the Android studio sync simulation runs "generateDebugSources" tasks by default
-            # This behavior can be overridden in case if the project has different product flavors (e.g. "development", "production", etc.) 
-            build-variant = "developmentDebug" // if not specified defaults to "debug"
         }
     }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     implementation("org.apache.ant:ant-compress:1.5")
     implementation("commons-io:commons-io:2.6")
     implementation("org.gradle.org.openjdk.jmc:flightrecorder:7.0.0-alpha01")
-    implementation("com.android.tools.build:builder-model:3.0.0")
     implementation("com.google.code.gson:gson:2.8.6") {
         because("To write JSON output")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,9 @@ dependencies {
     implementation("org.apache.ant:ant-compress:1.5")
     implementation("commons-io:commons-io:2.6")
     implementation("org.gradle.org.openjdk.jmc:flightrecorder:7.0.0-alpha01")
+    implementation("com.googlecode.plist:dd-plist:1.23") {
+        because("To extract launch details from Android Studio installation")
+    }
     implementation("com.google.code.gson:gson:2.8.6") {
         because("To write JSON output")
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,15 +49,6 @@ dependencies {
     testRuntimeOnly("org.objenesis:objenesis:2.6")
 }
 
-allprojects {
-    pluginManager.withPlugin("java") {
-        java {
-            sourceCompatibility = JavaVersion.VERSION_1_8
-            targetCompatibility = JavaVersion.VERSION_1_8
-        }
-    }
-}
-
 subprojects {
     // Subprojects are packaged into the Gradle profiler Jar, so let's make them reproducible
     tasks.withType<Jar>().configureEach {
@@ -106,6 +97,12 @@ tasks.processResources {
         }
     }
     from(generateHtmlReportJavaScript)
+}
+
+tasks.test {
+    // Use the current JVM. Some tests require JFR, which is only available in some JVM implementations
+    // For now assume that the current JVM has JFR support and that CI will inject the correct implementation
+    javaLauncher.set(null as JavaLauncher?)
 }
 
 val testReports = mapOf(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,13 +14,6 @@ allprojects {
     version = property("profiler.version") as String
 }
 
-repositories {
-    jcenter()
-    maven {
-        url = uri("https://repo.gradle.org/gradle/repo")
-    }
-}
-
 val gradleRuntime by configurations.creating
 val profilerPlugins by configurations.creating
 
@@ -47,11 +40,12 @@ dependencies {
     gradleRuntime(versions.toolingApi)
     profilerPlugins(project(":chrome-trace"))
     profilerPlugins(project(":build-operations"))
+    profilerPlugins(project(":instrumentation-support"))
     profilerPlugins(project(":studio-agent"))
 
     runtimeOnly("org.slf4j:slf4j-simple:1.7.10")
-    testImplementation("org.codehaus.groovy:groovy:2.4.7")
-    testImplementation("org.spockframework:spock-core:1.1-groovy-2.4")
+    testImplementation(versions.groovy)
+    testImplementation(versions.spock)
     testRuntimeOnly("cglib:cglib:3.2.6")
     testRuntimeOnly("org.objenesis:objenesis:2.6")
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    id("java-gradle-plugin")
+    `kotlin-dsl`
+}
+
+repositories {
+    jcenter()
+}

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-    id("java-gradle-plugin")
     `kotlin-dsl`
 }
 

--- a/buildSrc/src/main/kotlin/profiler.embedded-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.embedded-library.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    id("profiler.java-library")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}

--- a/buildSrc/src/main/kotlin/profiler.embedded-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.embedded-library.gradle.kts
@@ -1,7 +1,3 @@
 plugins {
     id("profiler.java-library")
 }
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-}

--- a/buildSrc/src/main/kotlin/profiler.java-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.java-library.gradle.kts
@@ -2,8 +2,17 @@ plugins {
     id("java-library")
 }
 
+repositories {
+    jcenter()
+    maven {
+        url = uri("https://repo.gradle.org/gradle/repo")
+    }
+}
+
 project.extensions.create("versions", Versions::class.java)
 
 abstract class Versions {
     val toolingApi = "org.gradle:gradle-tooling-api:6.6.1"
+    val groovy = "org.codehaus.groovy:groovy:2.4.7"
+    val spock = "org.spockframework:spock-core:1.1-groovy-2.4"
 }

--- a/buildSrc/src/main/kotlin/profiler.java-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.java-library.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+    id("java-library")
+}
+
+project.extensions.create("versions", Versions::class.java)
+
+abstract class Versions {
+    val toolingApi = "org.gradle:gradle-tooling-api:6.6.1"
+}

--- a/buildSrc/src/main/kotlin/profiler.java-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.java-library.gradle.kts
@@ -9,6 +9,12 @@ repositories {
     }
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(8))
+    }
+}
+
 project.extensions.create("versions", Versions::class.java)
 
 abstract class Versions {

--- a/buildSrc/src/main/kotlin/profiler.java-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.java-library.gradle.kts
@@ -15,7 +15,7 @@ java {
     }
 }
 
-project.extensions.create("versions", Versions::class.java)
+project.extensions.create<Versions>("versions")
 
 abstract class Versions {
     val toolingApi = "org.gradle:gradle-tooling-api:6.6.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-rc-1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,10 @@ rootProject.name = "gradle-profiler"
 
 include("chrome-trace")
 include("build-operations")
+include("client-protocol")
+include("instrumentation-support")
+include("studio-agent")
+
 rootProject.children.forEach {
     it.projectDir = rootDir.resolve( "subprojects/${it.name}")
 }

--- a/src/main/java/org/gradle/profiler/AndroidStudioSyncAction.java
+++ b/src/main/java/org/gradle/profiler/AndroidStudioSyncAction.java
@@ -36,6 +36,6 @@ public class AndroidStudioSyncAction implements BuildAction {
     @Override
     public Duration run(GradleClient gradleClient, List<String> gradleArgs, List<String> jvmArgs) {
         StudioGradleClient studioGradleClient = (StudioGradleClient) gradleClient;
-        return studioGradleClient.sync();
+        return studioGradleClient.sync(gradleArgs, jvmArgs);
     }
 }

--- a/src/main/java/org/gradle/profiler/AndroidStudioSyncAction.java
+++ b/src/main/java/org/gradle/profiler/AndroidStudioSyncAction.java
@@ -9,13 +9,7 @@ import java.util.List;
  * A mock-up of Android studio sync.
  */
 public class AndroidStudioSyncAction implements BuildAction {
-
-    private final String buildFlavor;
-    private final boolean skipSourceGeneration;
-
-    public AndroidStudioSyncAction(String buildFlavor, boolean skipSourceGeneration) {
-        this.buildFlavor = buildFlavor;
-        this.skipSourceGeneration = skipSourceGeneration;
+    public AndroidStudioSyncAction() {
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/CommandExec.java
+++ b/src/main/java/org/gradle/profiler/CommandExec.java
@@ -40,6 +40,11 @@ public class CommandExec {
         run(processBuilder);
     }
 
+    public RunHandle start(List<String> commandLine) {
+        ProcessBuilder processBuilder = new ProcessBuilder(commandLine);
+        return start(processBuilder);
+    }
+
     public String runAndCollectOutput(List<String> commandLine) {
         return runAndCollectOutput(commandLine.toArray(new String[commandLine.size()]));
     }
@@ -47,7 +52,7 @@ public class CommandExec {
     public String runAndCollectOutput(String... commandLine) {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         try {
-            run(new ProcessBuilder(commandLine), outputStream, outputStream::toString, null).waitForSuccess();
+            start(new ProcessBuilder(commandLine), outputStream, outputStream::toString, null).waitForSuccess();
         } catch (RuntimeException e) {
             System.out.print(new String(outputStream.toByteArray()));
             throw e;
@@ -78,12 +83,16 @@ public class CommandExec {
     }
 
     public void run(ProcessBuilder processBuilder) {
+        start(processBuilder).waitForSuccess();
+    }
+
+    private RunHandle start(ProcessBuilder processBuilder) {
         OutputStream outputStream = Logging.detailed();
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         run(processBuilder, new TeeOutputStream(outputStream, baos), baos::toString, null).waitForSuccess();
     }
 
-    protected RunHandle run(ProcessBuilder processBuilder, OutputStream outputStream, Supplier<String> diagnosticOutput, @Nullable InputStream inputStream) {
+    protected RunHandle start(ProcessBuilder processBuilder, OutputStream outputStream, Supplier<String> diagnosticOutput, @Nullable InputStream inputStream) {
         if (directory != null) {
             processBuilder.directory(directory);
         }

--- a/src/main/java/org/gradle/profiler/CommandLineParser.java
+++ b/src/main/java/org/gradle/profiler/CommandLineParser.java
@@ -41,6 +41,7 @@ class CommandLineParser {
             .withRequiredArg()
             .ofType(File.class)
             .defaultsTo(new File("gradle-user-home"));
+        ArgumentAcceptingOptionSpec<File> studioHomeOption = parser.accepts("studio-install-dir", "The Studio installation to use").withRequiredArg().ofType(File.class);
         ArgumentAcceptingOptionSpec<File> scenarioFileOption = parser.accepts("scenario-file", "Scenario definition file to use").withRequiredArg().ofType(File.class);
         ArgumentAcceptingOptionSpec<String> sysPropOption = parser.accepts("D", "Defines a system property").withRequiredArg();
         ArgumentAcceptingOptionSpec<File> outputDirOption = parser.accepts("output-dir", "Directory to write results to").withRequiredArg()
@@ -110,6 +111,7 @@ class CommandLineParser {
         List<String> targetNames = parsedOptions.nonOptionArguments().stream().map(Object::toString).collect(Collectors.toList());
         List<String> gradleVersions = parsedOptions.valuesOf(gradleVersionOption);
         File scenarioFile = parsedOptions.valueOf(scenarioFileOption);
+        File studioInstallDir = parsedOptions.valueOf(studioHomeOption);
 
         // TODO - should validate the various combinations of invocation options
         GradleBuildInvoker gradleInvoker = GradleBuildInvoker.ToolingApi;
@@ -157,6 +159,7 @@ class CommandLineParser {
             .setTargets(targetNames)
             .setSysProperties(sysProperties)
             .setGradleUserHome(gradleUserHome)
+            .setStudioInstallDir(studioInstallDir)
             .setWarmupCount(warmups)
             .setIterations(iterations)
             .setMeasureConfigTime(measureConfig)

--- a/src/main/java/org/gradle/profiler/CommandLineParser.java
+++ b/src/main/java/org/gradle/profiler/CommandLineParser.java
@@ -34,7 +34,7 @@ class CommandLineParser {
         AbstractOptionSpec<Void> versionOption = parser.acceptsAll(Arrays.asList("v", "version"), "Display version information");
         parser.nonOptions("The scenarios or task names to run");
         ArgumentAcceptingOptionSpec<File> projectOption = parser.accepts("project-dir", "The directory containing the build to run")
-            .withRequiredArg().ofType(File.class).defaultsTo(new File("."));
+            .withRequiredArg().ofType(File.class).defaultsTo(new File(".").getCanonicalFile());
         ArgumentAcceptingOptionSpec<String> gradleVersionOption = parser.accepts("gradle-version", "Gradle version or installation to use to run build")
             .withRequiredArg();
         ArgumentAcceptingOptionSpec<File> gradleUserHomeOption = parser.accepts("gradle-user-home", "The Gradle user home to use")

--- a/src/main/java/org/gradle/profiler/DefaultGradleBuildConfigurationReader.java
+++ b/src/main/java/org/gradle/profiler/DefaultGradleBuildConfigurationReader.java
@@ -105,8 +105,7 @@ public class DefaultGradleBuildConfigurationReader implements GradleBuildConfigu
 
     private GradleBuildConfiguration probe(GradleConnector connector) {
         GradleBuildConfiguration version;
-        ProjectConnection connection = connector.forProjectDirectory(projectDir).connect();
-        try {
+        try (ProjectConnection connection = connector.forProjectDirectory(projectDir).connect()) {
             BuildEnvironment buildEnvironment = connection.getModel(BuildEnvironment.class);
             new ToolingApiGradleClient(connection).runTasks(ImmutableList.of("help"), ImmutableList.of("-I", initScript.getAbsolutePath()), ImmutableList.of());
             List<String> buildDetails = readBuildDetails();
@@ -120,8 +119,6 @@ public class DefaultGradleBuildConfigurationReader implements GradleBuildConfigu
                 allJvmArgs,
                 Boolean.valueOf(buildDetails.get(1))
             );
-        } finally {
-            connection.close();
         }
         daemonControl.stop(version);
         return version;

--- a/src/main/java/org/gradle/profiler/GradleClientSpec.java
+++ b/src/main/java/org/gradle/profiler/GradleClientSpec.java
@@ -56,7 +56,7 @@ public abstract class GradleClientSpec {
 
         @Override
         public GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings, ProjectConnection projectConnection) {
-            return new StudioGradleClient();
+            return new StudioGradleClient(invocationSettings);
         }
     };
 

--- a/src/main/java/org/gradle/profiler/GradleClientSpec.java
+++ b/src/main/java/org/gradle/profiler/GradleClientSpec.java
@@ -61,7 +61,7 @@ public abstract class GradleClientSpec {
 
         @Override
         public GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings) {
-            return new StudioGradleClient(invocationSettings);
+            return new StudioGradleClient(buildConfiguration, invocationSettings);
         }
     };
 

--- a/src/main/java/org/gradle/profiler/GradleClientSpec.java
+++ b/src/main/java/org/gradle/profiler/GradleClientSpec.java
@@ -1,6 +1,7 @@
 package org.gradle.profiler;
 
 import org.gradle.profiler.studio.StudioGradleClient;
+import org.gradle.tooling.GradleConnector;
 import org.gradle.tooling.ProjectConnection;
 
 /**
@@ -14,7 +15,11 @@ public abstract class GradleClientSpec {
         }
 
         @Override
-        public GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings, ProjectConnection projectConnection) {
+        public GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings) {
+            GradleConnector connector = GradleConnector.newConnector()
+                .useInstallation(buildConfiguration.getGradleHome())
+                .useGradleUserHomeDir(invocationSettings.getGradleUserHome().getAbsoluteFile());
+            ProjectConnection projectConnection = connector.forProjectDirectory(invocationSettings.getProjectDir()).connect();
             return new ToolingApiGradleClient(projectConnection);
         }
     };
@@ -26,8 +31,8 @@ public abstract class GradleClientSpec {
         }
 
         @Override
-        public GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings, ProjectConnection projectConnection) {
-            return new CliGradleClient(buildConfiguration, buildConfiguration.getJavaHome(), invocationSettings.getProjectDir(), true, invocationSettings.getBuildLog());
+        public GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings) {
+            return new CliGradleClient(buildConfiguration, buildConfiguration.getJavaHome(), invocationSettings.getProjectDir(), true, , invocationSettings.getBuildLog());
         }
     };
 
@@ -43,7 +48,7 @@ public abstract class GradleClientSpec {
         }
 
         @Override
-        public GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings, ProjectConnection projectConnection) {
+        public GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings) {
             return new CliGradleClient(buildConfiguration, buildConfiguration.getJavaHome(), invocationSettings.getProjectDir(), false, invocationSettings.getBuildLog());
         }
     };
@@ -55,7 +60,7 @@ public abstract class GradleClientSpec {
         }
 
         @Override
-        public GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings, ProjectConnection projectConnection) {
+        public GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings) {
             return new StudioGradleClient(invocationSettings);
         }
     };
@@ -64,5 +69,5 @@ public abstract class GradleClientSpec {
         return true;
     }
 
-    public abstract GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings, ProjectConnection projectConnection);
+    public abstract GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings);
 }

--- a/src/main/java/org/gradle/profiler/GradleClientSpec.java
+++ b/src/main/java/org/gradle/profiler/GradleClientSpec.java
@@ -32,7 +32,7 @@ public abstract class GradleClientSpec {
 
         @Override
         public GradleClient create(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings) {
-            return new CliGradleClient(buildConfiguration, buildConfiguration.getJavaHome(), invocationSettings.getProjectDir(), true, , invocationSettings.getBuildLog());
+            return new CliGradleClient(buildConfiguration, buildConfiguration.getJavaHome(), invocationSettings.getProjectDir(), true, invocationSettings.getBuildLog());
         }
     };
 

--- a/src/main/java/org/gradle/profiler/GradleScenarioInvoker.java
+++ b/src/main/java/org/gradle/profiler/GradleScenarioInvoker.java
@@ -145,7 +145,6 @@ public class GradleScenarioInvoker extends ScenarioInvoker<GradleScenarioDefinit
             control.stopSession();
             Objects.requireNonNull(results);
             checkPid(pid, results.getDaemonPid(), scenario.getInvoker());
-            gradleClient.close();
         } finally {
             mutator.afterScenario(scenarioContext);
             gradleClient.close();

--- a/src/main/java/org/gradle/profiler/InvocationSettings.java
+++ b/src/main/java/org/gradle/profiler/InvocationSettings.java
@@ -21,6 +21,7 @@ public class InvocationSettings {
     private final List<String> targets;
     private final Map<String, String> sysProperties;
     private final File gradleUserHome;
+    private final File studioInstallDir;
     private final Integer warmupCount;
     private final Integer iterations;
     private final boolean measureConfigTime;
@@ -46,6 +47,7 @@ public class InvocationSettings {
         List<String> targets,
         Map<String, String> sysProperties,
         File gradleUserHome,
+        File studioInstallDir,
         Integer warmupCount,
         Integer iterations,
         boolean measureConfigTime,
@@ -64,6 +66,7 @@ public class InvocationSettings {
         this.targets = targets;
         this.sysProperties = sysProperties;
         this.gradleUserHome = gradleUserHome;
+        this.studioInstallDir = studioInstallDir;
         this.warmupCount = warmupCount;
         this.iterations = iterations;
         this.measureConfigTime = measureConfigTime;
@@ -145,6 +148,10 @@ public class InvocationSettings {
         return gradleUserHome;
     }
 
+    public File getStudioInstallDir() {
+        return studioInstallDir;
+    }
+
     public boolean isMeasureConfigTime() {
         return measureConfigTime;
     }
@@ -195,6 +202,7 @@ public class InvocationSettings {
         private List<String> targets;
         private Map<String, String> sysProperties;
         private File gradleUserHome;
+        private File studioInstallDir;
         private Integer warmupCount;
         private Integer iterations;
         private boolean measureConfigTime;
@@ -257,6 +265,11 @@ public class InvocationSettings {
             return this;
         }
 
+        public InvocationSettingsBuilder setStudioInstallDir(File studioInstallDir) {
+            this.studioInstallDir = studioInstallDir;
+            return this;
+        }
+
         public InvocationSettingsBuilder setWarmupCount(Integer warmupCount) {
             this.warmupCount = warmupCount;
             return this;
@@ -300,6 +313,7 @@ public class InvocationSettings {
                 targets,
                 sysProperties,
                 gradleUserHome,
+                studioInstallDir,
                 warmupCount,
                 iterations,
                 measureConfigTime,

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -266,7 +266,7 @@ class ScenarioLoader {
                 }
 
                 List<String> gradleArgs = ConfigUtil.strings(scenario, GRADLE_ARGS);
-                BuildAction buildAction = getBuildAction(scenario, scenarioFile);
+                BuildAction buildAction = getBuildAction(scenario, scenarioFile, settings);
                 GradleBuildInvoker invoker = invoker(scenario, (GradleBuildInvoker) settings.getInvoker(), buildAction);
                 int warmUpCount = getWarmUpCount(settings, invoker, scenario);
                 List<String> measuredBuildOperations = getMeasuredBuildOperations(settings, scenario);
@@ -419,26 +419,32 @@ class ScenarioLoader {
         return new RunTasksAction(tasks);
     }
 
-    private static BuildAction getBuildAction(Config scenario, File scenarioFile) {
+    private static BuildAction getBuildAction(Config scenario, File scenarioFile, InvocationSettings invocationSettings) {
         Class<?> toolingModel = getToolingModelClass(scenario, scenarioFile);
         boolean sync = scenario.hasPath(ANDROID_STUDIO_SYNC);
         List<String> tasks = ConfigUtil.strings(scenario, TASKS);
-        if (sync && toolingModel != null) {
-            throw new IllegalArgumentException("Cannot load tooling model and Android studio sync in same scenario.");
-        }
-        if (sync && !tasks.isEmpty()) {
-            throw new IllegalArgumentException("Cannot run tasks and Android studio sync in same scenario.");
-        }
-        if (toolingModel != null) {
-            return new LoadToolingModelAction(toolingModel, tasks);
-        }
+
         if (sync) {
+            if (toolingModel != null) {
+                throw new IllegalArgumentException("Cannot load tooling model and Android studio sync in same scenario.");
+            }
+            if (!tasks.isEmpty()) {
+                throw new IllegalArgumentException("Cannot run tasks and Android studio sync in same scenario.");
+            }
+            if (invocationSettings.getStudioInstallDir() == null) {
+                throw new IllegalArgumentException("Android Studio installation directory should be specified using --studio-install-dir when performing Android studio sync.");
+            }
             Config androidStudioConfig = scenario.getConfig(ANDROID_STUDIO_SYNC);
             String buildFlavor = ConfigUtil.string(androidStudioConfig, ANDROID_BUILD_VARIANT, "debug");
             boolean skipSourceGeneration = ConfigUtil.bool(androidStudioConfig, ANDROID_SKIP_SOURCE_GENERATION, false);
             return new AndroidStudioSyncAction(buildFlavor, skipSourceGeneration);
         }
-        return new RunTasksAction(tasks);
+
+        if (toolingModel != null) {
+            return new LoadToolingModelAction(toolingModel, tasks);
+        } else {
+            return new RunTasksAction(tasks);
+        }
     }
 
     private static Class<?> getToolingModelClass(Config scenario, File scenarioFile) {

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -430,7 +430,7 @@ class ScenarioLoader {
                 throw new IllegalArgumentException("Cannot run tasks and Android studio sync in same scenario.");
             }
             if (invocationSettings.getStudioInstallDir() == null) {
-                throw new IllegalArgumentException("Android Studio installation directory should be specified using --studio-install-dir when performing Android studio sync.");
+                throw new IllegalArgumentException("Android Studio installation directory should be specified using --studio-install-dir when measuring Android studio sync.");
             }
             return new AndroidStudioSyncAction();
         }

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -77,8 +77,6 @@ class ScenarioLoader {
     private static final String TYPE = "type";
     private static final String MODEL = "model";
     private static final String ANDROID_STUDIO_SYNC = "android-studio-sync";
-    private static final String ANDROID_BUILD_VARIANT = "build-variant";
-    private static final String ANDROID_SKIP_SOURCE_GENERATION = "skip-source-generation";
     private static final String JVM_ARGS = "jvm-args";
 
     private static final List<String> ALL_SCENARIO_KEYS = Arrays.asList(
@@ -434,10 +432,7 @@ class ScenarioLoader {
             if (invocationSettings.getStudioInstallDir() == null) {
                 throw new IllegalArgumentException("Android Studio installation directory should be specified using --studio-install-dir when performing Android studio sync.");
             }
-            Config androidStudioConfig = scenario.getConfig(ANDROID_STUDIO_SYNC);
-            String buildFlavor = ConfigUtil.string(androidStudioConfig, ANDROID_BUILD_VARIANT, "debug");
-            boolean skipSourceGeneration = ConfigUtil.bool(androidStudioConfig, ANDROID_SKIP_SOURCE_GENERATION, false);
-            return new AndroidStudioSyncAction(buildFlavor, skipSourceGeneration);
+            return new AndroidStudioSyncAction();
         }
 
         if (toolingModel != null) {

--- a/src/main/java/org/gradle/profiler/ToolingApiGradleClient.java
+++ b/src/main/java/org/gradle/profiler/ToolingApiGradleClient.java
@@ -16,6 +16,7 @@ public class ToolingApiGradleClient implements GradleInvoker, GradleClient {
 
     @Override
     public void close() {
+        projectConnection.close();
     }
 
     private static <T extends LongRunningOperation, R> R run(T operation, Function<T, R> function) {

--- a/src/main/java/org/gradle/profiler/instrument/GradleInstrumentation.java
+++ b/src/main/java/org/gradle/profiler/instrument/GradleInstrumentation.java
@@ -43,10 +43,10 @@ public abstract class GradleInstrumentation implements GradleArgsCalculator {
         };
     }
 
-    private File unpackPlugin(String jarName) {
+    public static File unpackPlugin(String jarName) {
         try {
             File pluginJar = File.createTempFile(jarName, "jar").getCanonicalFile();
-            try (InputStream inputStream = getClass().getResourceAsStream("/META-INF/jars/" + jarName + ".jar")) {
+            try (InputStream inputStream = GradleInstrumentation.class.getResourceAsStream("/META-INF/jars/" + jarName + ".jar")) {
                 Files.copy(inputStream, pluginJar.toPath(), StandardCopyOption.REPLACE_EXISTING);
             }
             pluginJar.deleteOnExit();

--- a/src/main/java/org/gradle/profiler/studio/LaunchConfiguration.java
+++ b/src/main/java/org/gradle/profiler/studio/LaunchConfiguration.java
@@ -11,7 +11,7 @@ public class LaunchConfiguration {
     private final String mainClass;
     private final Path agentJar;
     private final Path supportJar;
-    private final Path protocolJar;
+    private final List<Path> sharedJars;
 
     public LaunchConfiguration(Path javaCommand,
                                List<Path> classPath,
@@ -19,14 +19,14 @@ public class LaunchConfiguration {
                                String mainClass,
                                Path agentJar,
                                Path supportJar,
-                               Path protocolJar) {
+                               List<Path> sharedJars) {
         this.javaCommand = javaCommand;
         this.classPath = classPath;
         this.systemProperties = systemProperties;
         this.mainClass = mainClass;
         this.agentJar = agentJar;
         this.supportJar = supportJar;
-        this.protocolJar = protocolJar;
+        this.sharedJars = sharedJars;
     }
 
     public Path getJavaCommand() {
@@ -53,7 +53,7 @@ public class LaunchConfiguration {
         return supportJar;
     }
 
-    public Path getProtocolJar() {
-        return protocolJar;
+    public List<Path> getSharedJars() {
+        return sharedJars;
     }
 }

--- a/src/main/java/org/gradle/profiler/studio/LaunchConfiguration.java
+++ b/src/main/java/org/gradle/profiler/studio/LaunchConfiguration.java
@@ -1,0 +1,59 @@
+package org.gradle.profiler.studio;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+public class LaunchConfiguration {
+    private final Path javaCommand;
+    private final List<Path> classPath;
+    private final Map<String, String> systemProperties;
+    private final String mainClass;
+    private final Path agentJar;
+    private final Path supportJar;
+    private final Path protocolJar;
+
+    public LaunchConfiguration(Path javaCommand,
+                               List<Path> classPath,
+                               Map<String, String> systemProperties,
+                               String mainClass,
+                               Path agentJar,
+                               Path supportJar,
+                               Path protocolJar) {
+        this.javaCommand = javaCommand;
+        this.classPath = classPath;
+        this.systemProperties = systemProperties;
+        this.mainClass = mainClass;
+        this.agentJar = agentJar;
+        this.supportJar = supportJar;
+        this.protocolJar = protocolJar;
+    }
+
+    public Path getJavaCommand() {
+        return javaCommand;
+    }
+
+    public List<Path> getClassPath() {
+        return classPath;
+    }
+
+    public Map<String, String> getSystemProperties() {
+        return systemProperties;
+    }
+
+    public String getMainClass() {
+        return mainClass;
+    }
+
+    public Path getAgentJar() {
+        return agentJar;
+    }
+
+    public Path getSupportJar() {
+        return supportJar;
+    }
+
+    public Path getProtocolJar() {
+        return protocolJar;
+    }
+}

--- a/src/main/java/org/gradle/profiler/studio/LauncherConfigurationParser.java
+++ b/src/main/java/org/gradle/profiler/studio/LauncherConfigurationParser.java
@@ -24,9 +24,10 @@ public class LauncherConfigurationParser {
         Map<String, String> systemProperties = mapValues(jvmOptions.dict("Properties").toMap(), v -> v.replace("$APP_PACKAGE", studioInstallDir.toString()));
         Path javaCommand = studioInstallDir.resolve("Contents/jre/jdk/Contents/Home/bin/java");
         Path agentJar = GradleInstrumentation.unpackPlugin("studio-agent").toPath();
+        Path asmJar = GradleInstrumentation.unpackPlugin("asm").toPath();
         Path supportJar = GradleInstrumentation.unpackPlugin("instrumentation-support").toPath();
         Path protocolJar = GradleInstrumentation.unpackPlugin("client-protocol").toPath();
-        return new LaunchConfiguration(javaCommand, classPath, systemProperties, mainClass, agentJar, supportJar, protocolJar);
+        return new LaunchConfiguration(javaCommand, classPath, systemProperties, mainClass, agentJar, supportJar, Arrays.asList(asmJar, protocolJar));
     }
 
     private static <T, S> Map<String, S> mapValues(Map<String, T> map, Function<T, S> mapper) {

--- a/src/main/java/org/gradle/profiler/studio/LauncherConfigurationParser.java
+++ b/src/main/java/org/gradle/profiler/studio/LauncherConfigurationParser.java
@@ -1,0 +1,203 @@
+package org.gradle.profiler.studio;
+
+import org.gradle.profiler.instrument.GradleInstrumentation;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class LauncherConfigurationParser {
+    public LaunchConfiguration calculate(Path studioInstallDir) {
+        Path infoFile = studioInstallDir.resolve("Contents/Info.plist");
+        Dict entries = PListParser.parse(infoFile);
+        Dict jvmOptions = entries.dict("JVMOptions");
+        List<Path> classPath = Arrays.stream(jvmOptions.string("ClassPath").split(":")).map(s -> FileSystems.getDefault().getPath(s.replace("$APP_PACKAGE", studioInstallDir.toString()))).collect(Collectors.toList());
+        String mainClass = jvmOptions.string("MainClass");
+        Map<String, String> systemProperties = mapValues(jvmOptions.dict("Properties").toMap(), v -> v.replace("$APP_PACKAGE", studioInstallDir.toString()));
+        Path javaCommand = studioInstallDir.resolve("Contents/jre/jdk/Contents/Home/bin/java");
+        Path agentJar = GradleInstrumentation.unpackPlugin("studio-agent").toPath();
+        Path supportJar = GradleInstrumentation.unpackPlugin("instrumentation-support").toPath();
+        Path protocolJar = GradleInstrumentation.unpackPlugin("client-protocol").toPath();
+        return new LaunchConfiguration(javaCommand, classPath, systemProperties, mainClass, agentJar, supportJar, protocolJar);
+    }
+
+    private static <T, S> Map<String, S> mapValues(Map<String, T> map, Function<T, S> mapper) {
+        Map<String, S> result = new LinkedHashMap<>();
+        for (Map.Entry<String, T> entry : map.entrySet()) {
+            result.put(entry.getKey(), mapper.apply(entry.getValue()));
+        }
+        return result;
+    }
+
+    private static class Dict {
+        private final Map<String, ?> contents;
+
+        public Dict(Map<String, ?> contents) {
+            this.contents = contents;
+        }
+
+        Dict dict(String key) {
+            return (Dict) getEntry(key);
+        }
+
+        String string(String key) {
+            return (String) getEntry(key);
+        }
+
+        Map<String, String> toMap() {
+            return mapValues(contents, v -> (String) v);
+        }
+
+        private Object getEntry(String key) {
+            Object value = contents.get(key);
+            if (value == null) {
+                throw new IllegalArgumentException(String.format("Dictionary does not contain entry '%s'.", key));
+            }
+            return value;
+        }
+    }
+
+    private static class PListParser {
+        private final XMLStreamReader reader;
+
+        public PListParser(InputStream content) throws XMLStreamException {
+            reader = XMLInputFactory.newFactory().createXMLStreamReader(content);
+            while (reader.hasNext() && reader.getEventType() != XMLStreamReader.START_ELEMENT) {
+                reader.next();
+            }
+        }
+
+        public static Dict parse(Path infoFile) {
+            try {
+                try (InputStream inputStream = Files.newInputStream(infoFile)) {
+                    return new PListParser(inputStream).plist();
+                }
+            } catch (IOException | XMLStreamException e) {
+                throw new RuntimeException(String.format("Could not parse '%s'.", infoFile), e);
+            }
+        }
+
+        public Dict plist() throws XMLStreamException {
+            expectStart("plist");
+            expectStart("dict");
+            Dict result = dictEntries();
+            expectEnd("dict");
+            expectEnd("plist");
+            return result;
+        }
+
+        private Dict dictEntries() throws XMLStreamException {
+            Map<String, Object> entries = new LinkedHashMap<>();
+            while (maybeStart("key")) {
+                String key = expectText();
+                expectEnd("key");
+                Object value = readObject();
+                entries.put(key, value);
+            }
+            return new Dict(entries);
+        }
+
+        private Object readObject() throws XMLStreamException {
+            if (maybeStart("string")) {
+                String text = expectText();
+                expectEnd("string");
+                return text;
+            } else if (maybeStart("false")) {
+                expectEnd("false");
+                return false;
+            } else if (maybeStart("true")) {
+                expectEnd("true");
+                return true;
+            } else if (maybeStart("array")) {
+                List<Object> elements = new ArrayList<>();
+                while (true) {
+                    if (maybeStart("dict")) {
+                        elements.add(dictEntries());
+                        expectEnd("dict");
+                    } else if (maybeStart("string")) {
+                        elements.add(expectText());
+                        expectEnd("string");
+                    } else {
+                        break;
+                    }
+                }
+                expectEnd("array");
+                return elements;
+            } else if (maybeStart("dict")) {
+                Dict value = dictEntries();
+                expectEnd("dict");
+                return value;
+            }
+            throw broken("object");
+        }
+
+        private void expectStart(String name) throws XMLStreamException {
+            if (!maybeStart(name)) {
+                throw broken("<" + name + ">");
+            }
+            reader.next();
+        }
+
+        private boolean maybeStart(String name) throws XMLStreamException {
+            while (reader.getEventType() != XMLStreamReader.START_ELEMENT) {
+                if (reader.getEventType() == XMLStreamReader.SPACE) {
+                    reader.next();
+                } else {
+                    break;
+                }
+            }
+            if (reader.getEventType() != XMLStreamReader.START_ELEMENT || !reader.getLocalName().equalsIgnoreCase(name)) {
+                return false;
+            }
+            reader.next();
+            return true;
+        }
+
+        private void expectEnd(String name) throws XMLStreamException {
+            while (reader.getEventType() != XMLStreamReader.END_ELEMENT) {
+                if (reader.getEventType() == XMLStreamReader.SPACE) {
+                    reader.next();
+                } else {
+                    break;
+                }
+            }
+            if (reader.getEventType() != XMLStreamReader.END_ELEMENT || !reader.getLocalName().equalsIgnoreCase(name)) {
+                throw broken("</" + name + ">");
+            }
+            reader.next();
+        }
+
+        private String expectText() throws XMLStreamException {
+            if (reader.getEventType() != XMLStreamReader.CHARACTERS) {
+                throw broken("text");
+            }
+            String result = reader.getText();
+            reader.next();
+            return result;
+        }
+
+        private IllegalStateException broken(String expected) {
+            return new IllegalStateException(String.format("Expected %s at line %s, found %s.", expected, reader.getLocation().getLineNumber(), current()));
+        }
+
+        private String current() {
+            switch (reader.getEventType()) {
+                case XMLStreamReader.START_ELEMENT:
+                    return "<" + reader.getLocalName() + ">";
+                case XMLStreamReader.SPACE:
+                case XMLStreamReader.CHARACTERS:
+                    return "\"" + reader.getText() + "\"";
+                default:
+                    return "??";
+            }
+        }
+    }
+}

--- a/src/main/java/org/gradle/profiler/studio/StudioGradleClient.java
+++ b/src/main/java/org/gradle/profiler/studio/StudioGradleClient.java
@@ -36,12 +36,12 @@ public class StudioGradleClient implements GradleClient {
         System.out.println("* Main class: " + launchConfiguration.getMainClass());
 
         server = new Server("agent");
-        studioProcess = startStudio(launchConfiguration, studioInstallDir, server);
+        studioProcess = startStudio(launchConfiguration, studioInstallDir, invocationSettings, server);
         agentConnection = server.waitForIncoming(Duration.ofMinutes(1));
         agentConnection.send(new ConnectionParameters(buildConfiguration.getGradleHome()));
     }
 
-    private CommandExec.RunHandle startStudio(LaunchConfiguration launchConfiguration, Path studioInstallDir, Server server) {
+    private CommandExec.RunHandle startStudio(LaunchConfiguration launchConfiguration, Path studioInstallDir, InvocationSettings invocationSettings, Server server) {
         List<String> commandLine = new ArrayList<>();
         commandLine.add(launchConfiguration.getJavaCommand().toString());
         commandLine.add("-cp");
@@ -54,6 +54,7 @@ public class StudioGradleClient implements GradleClient {
         commandLine.add("java.base/jdk.internal.misc=ALL-UNNAMED");
         commandLine.add("-Xbootclasspath/a:" + Joiner.on(File.pathSeparator).join(launchConfiguration.getSharedJars()));
         commandLine.add(launchConfiguration.getMainClass());
+        commandLine.add(invocationSettings.getProjectDir().toString());
         System.out.println("* Using command line: " + commandLine);
 
         return new CommandExec().inDir(studioInstallDir.toFile()).start(commandLine);

--- a/src/main/java/org/gradle/profiler/studio/StudioGradleClient.java
+++ b/src/main/java/org/gradle/profiler/studio/StudioGradleClient.java
@@ -50,10 +50,10 @@ public class StudioGradleClient implements GradleClient {
         for (Map.Entry<String, String> systemProperty : launchConfiguration.getSystemProperties().entrySet()) {
             commandLine.add("-D" + systemProperty.getKey() + "=" + systemProperty.getValue());
         }
-        commandLine.add("-javaagent:" + launchConfiguration.getAgentJar() + "=" + server.getPort());
+        commandLine.add("-javaagent:" + launchConfiguration.getAgentJar() + "=" + server.getPort() + "," + launchConfiguration.getSupportJar());
         commandLine.add("--add-exports");
         commandLine.add("java.base/jdk.internal.misc=ALL-UNNAMED");
-        commandLine.add("-Xbootclasspath/a:" + launchConfiguration.getProtocolJar());
+        commandLine.add("-Xbootclasspath/a:" + Joiner.on(File.pathSeparator).join(launchConfiguration.getSharedJars()));
         commandLine.add(launchConfiguration.getMainClass());
         System.out.println("* Using command line: " + commandLine);
 

--- a/src/main/java/org/gradle/profiler/studio/StudioGradleClient.java
+++ b/src/main/java/org/gradle/profiler/studio/StudioGradleClient.java
@@ -19,6 +19,9 @@ public class StudioGradleClient implements GradleClient {
     private boolean hasRun;
 
     public StudioGradleClient(GradleBuildConfiguration buildConfiguration, InvocationSettings invocationSettings) {
+        if (!OperatingSystem.isMacOS()) {
+            throw new IllegalArgumentException("Support for Android studio is currently only implemented on macOS.");
+        }
         Path studioInstallDir = invocationSettings.getStudioInstallDir().toPath();
         Logging.startOperation("Starting Android Studio at " + studioInstallDir);
 

--- a/src/main/java/org/gradle/profiler/studio/StudioGradleClient.java
+++ b/src/main/java/org/gradle/profiler/studio/StudioGradleClient.java
@@ -1,12 +1,80 @@
 package org.gradle.profiler.studio;
 
+import com.google.common.base.Joiner;
 import org.gradle.profiler.GradleClient;
+import org.gradle.profiler.InvocationSettings;
+import org.gradle.profiler.Logging;
+import org.gradle.profiler.client.protocol.Server;
+import org.gradle.profiler.client.protocol.ServerConnection;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class StudioGradleClient implements GradleClient {
+    private final Server server;
+    private final Process studioProcess;
+    private final ServerConnection agentConnection;
+
+    public StudioGradleClient(InvocationSettings invocationSettings) {
+        Path studioInstallDir = invocationSettings.getStudioInstallDir().toPath();
+        Logging.startOperation("Starting Android Studio at " + studioInstallDir);
+
+        LaunchConfiguration launchConfiguration = new LauncherConfigurationParser().calculate(studioInstallDir);
+        System.out.println();
+        System.out.println("* Java command: " + launchConfiguration.getJavaCommand());
+        System.out.println("* Classpath:");
+        for (Path entry : launchConfiguration.getClassPath()) {
+            System.out.println("  " + entry);
+        }
+        System.out.println("* System properties:");
+        for (Map.Entry<String, String> entry : launchConfiguration.getSystemProperties().entrySet()) {
+            System.out.println("  " + entry.getKey() + " -> " + entry.getValue());
+        }
+        System.out.println("* Main class: " + launchConfiguration.getMainClass());
+
+        server = new Server("agent");
+        studioProcess = startStudio(launchConfiguration, studioInstallDir, server);
+        agentConnection = server.waitForIncoming();
+    }
+
+    private Process startStudio(LaunchConfiguration launchConfiguration, Path studioInstallDir, Server server) {
+        List<String> commandLine = new ArrayList<>();
+        commandLine.add(launchConfiguration.getJavaCommand().toString());
+        commandLine.add("-cp");
+        commandLine.add(Joiner.on(File.pathSeparator).join(launchConfiguration.getClassPath()));
+        for (Map.Entry<String, String> systemProperty : launchConfiguration.getSystemProperties().entrySet()) {
+            commandLine.add("-D" + systemProperty.getKey() + "=" + systemProperty.getValue());
+        }
+        commandLine.add("-javaagent:" + launchConfiguration.getAgentJar() + "=" + server.getPort());
+        commandLine.add("--add-exports");
+        commandLine.add("java.base/jdk.internal.misc=ALL-UNNAMED");
+        commandLine.add("-Xbootclasspath/a:" + launchConfiguration.getProtocolJar());
+        commandLine.add(launchConfiguration.getMainClass());
+        System.out.println("* Using command line: " + commandLine);
+
+        try {
+            return new ProcessBuilder(commandLine).inheritIO().directory(studioInstallDir.toFile()).start();
+        } catch (IOException e) {
+            throw new RuntimeException("Could not start Android Studio.", e);
+        }
+    }
+
     @Override
-    public void close() {
+    public void close() throws IOException {
+        System.out.println("* Waiting for Android Studio to stop...");
+        try {
+            studioProcess.waitFor();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        System.out.println("* Android Studio stopped.");
+
+        server.close();
     }
 
     public Duration sync() {

--- a/src/main/java/org/gradle/profiler/studio/StudioGradleClient.java
+++ b/src/main/java/org/gradle/profiler/studio/StudioGradleClient.java
@@ -83,7 +83,7 @@ public class StudioGradleClient implements GradleClient {
         // Use a long time out because it can take quite some time between the tapi action completing and studio finishing the sync
         SyncStarted started = agentConnection.receiveSyncStarted(Duration.ofMinutes(10));
         agentConnection.send(new SyncParameters(gradleArgs, jvmArgs));
-        System.out.println("* Sync has started");
+        System.out.println("* Sync has started, waiting for it to complete...");
         SyncCompleted completed = agentConnection.receiveSyncCompeted(Duration.ofHours(1));
         System.out.println("* Sync has completed");
         return Duration.ofMillis(completed.getDurationMillis());

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -44,6 +44,7 @@ class ScenarioLoaderTest extends Specification {
             .setTargets([])
             .setSysProperties([:])
             .setGradleUserHome(gradleUserHomeDir)
+            .setStudioInstallDir(tmpDir.newFolder())
             .setWarmupCount(warmups)
             .setIterations(iterations)
             .setMeasureConfigTime(false)

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -160,7 +160,7 @@ class ScenarioLoaderTest extends Specification {
         expect:
         def instantExecution = scenarios[0] as GradleScenarioDefinition
         instantExecution.systemProperties == [
-            "org.gradle.unsafe.instant-execution": "true",
+            "org.gradle.unsafe.instant-execution"                 : "true",
             "org.gradle.unsafe.instant-execution.fail-on-problems": "false"
         ]
     }
@@ -340,28 +340,6 @@ class ScenarioLoaderTest extends Specification {
         scenarios*.name == ["default"]
         def scenarioDefinition = scenarios[0] as GradleScenarioDefinition
         scenarioDefinition.action instanceof AndroidStudioSyncAction
-        scenarioDefinition.action.skipSourceGeneration == false
-        scenarioDefinition.action.buildFlavor == "debug"
-    }
-
-    def "loads Android studio sync included config"() {
-        def settings = settings()
-
-        scenarioFile << """
-            default {
-                android-studio-sync {
-                    build-variant = "developmentDebug"
-                    skip-source-generation = true
-                }
-            }
-        """
-        def scenarios = loadScenarios(scenarioFile, settings, Mock(GradleBuildConfigurationReader))
-        expect:
-        scenarios*.name == ["default"]
-        def scenarioDefinition = scenarios[0] as GradleScenarioDefinition
-        scenarioDefinition.action instanceof AndroidStudioSyncAction
-        scenarioDefinition.action.skipSourceGeneration == true
-        scenarioDefinition.action.buildFlavor == "developmentDebug"
     }
 
     def "loads default scenarios only"() {

--- a/subprojects/build-operations/build.gradle
+++ b/subprojects/build-operations/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java-library'
+    id 'profiler.embedded-library'
 }
 
 dependencies {

--- a/subprojects/chrome-trace/build.gradle
+++ b/subprojects/chrome-trace/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'java-gradle-plugin'
+    id 'profiler.embedded-library'
 }
 
 dependencies {

--- a/subprojects/client-protocol/build.gradle.kts
+++ b/subprojects/client-protocol/build.gradle.kts
@@ -1,3 +1,9 @@
 plugins {
     id("profiler.embedded-library")
+    id("groovy")
+}
+
+dependencies {
+    testImplementation(versions.groovy)
+    testImplementation(versions.spock)
 }

--- a/subprojects/client-protocol/build.gradle.kts
+++ b/subprojects/client-protocol/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    id("profiler.embedded-library")
+}

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Client.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Client.java
@@ -3,6 +3,7 @@ package org.gradle.profiler.client.protocol;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
+import java.time.Duration;
 
 /**
  * A singleton that runs inside a client process to communicate with the controller process.
@@ -24,7 +25,7 @@ public class Client {
                 connection = new Connection(socket);
                 serializer = new Serializer("controller process", connection);
             } catch (IOException e) {
-                throw new RuntimeException("Could not connect to contoller process.", e);
+                throw new RuntimeException("Could not connect to controller process.", e);
             }
         }
     }
@@ -38,6 +39,12 @@ public class Client {
     public void send(SyncCompleted message) {
         synchronized (lock) {
             serializer.send(message);
+        }
+    }
+
+    public SyncParameters receiveParameters(Duration timeout) {
+        synchronized (lock) {
+            return serializer.receive(SyncParameters.class, timeout);
         }
     }
 

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Client.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Client.java
@@ -1,0 +1,51 @@
+package org.gradle.profiler.client.protocol;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+
+/**
+ * A singleton that runs inside a client process to communicate with the controller process.
+ */
+public class Client {
+    public static final Client INSTANCE = new Client();
+
+    private final Object lock = new Object();
+    private Connection connection;
+    private Serializer serializer;
+
+    public void connect(int port) throws IOException {
+        synchronized (lock) {
+            if (connection != null) {
+                throw new IllegalStateException("This client is already connected.");
+            }
+            Socket socket = new Socket(InetAddress.getLoopbackAddress(), port);
+            connection = new Connection(socket);
+            serializer = new Serializer("controller process", connection);
+        }
+    }
+
+    public void send(SyncStarted message) {
+        synchronized (lock) {
+            serializer.send(message);
+        }
+    }
+
+    public void send(SyncCompleted message) {
+        synchronized (lock) {
+            serializer.send(message);
+        }
+    }
+
+    public void disconnect() throws IOException {
+        synchronized (lock) {
+            try {
+                if (connection != null) {
+                    connection.close();
+                }
+            } finally {
+                connection = null;
+            }
+        }
+    }
+}

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Client.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Client.java
@@ -14,14 +14,18 @@ public class Client {
     private Connection connection;
     private Serializer serializer;
 
-    public void connect(int port) throws IOException {
+    public void connect(int port) {
         synchronized (lock) {
             if (connection != null) {
                 throw new IllegalStateException("This client is already connected.");
             }
-            Socket socket = new Socket(InetAddress.getLoopbackAddress(), port);
-            connection = new Connection(socket);
-            serializer = new Serializer("controller process", connection);
+            try {
+                Socket socket = new Socket(InetAddress.getLoopbackAddress(), port);
+                connection = new Connection(socket);
+                serializer = new Serializer("controller process", connection);
+            } catch (IOException e) {
+                throw new RuntimeException("Could not connect to contoller process.", e);
+            }
         }
     }
 

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Client.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Client.java
@@ -42,9 +42,15 @@ public class Client {
         }
     }
 
-    public SyncParameters receiveParameters(Duration timeout) {
+    public SyncParameters receiveSyncParameters(Duration timeout) {
         synchronized (lock) {
             return serializer.receive(SyncParameters.class, timeout);
+        }
+    }
+
+    public ConnectionParameters receiveConnectionParameters(Duration timeout) {
+        synchronized (lock) {
+            return serializer.receive(ConnectionParameters.class, timeout);
         }
     }
 

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Connection.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Connection.java
@@ -5,6 +5,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.net.Socket;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Connection implements Closeable {
     private final Socket socket;
@@ -26,24 +28,40 @@ public class Connection implements Closeable {
         return inputStream.readByte();
     }
 
-    public int readInt() throws IOException {
-        return inputStream.readInt();
-    }
-
-    public long readLong() throws IOException {
-        return inputStream.readLong();
-    }
-
     public void writeByte(byte value) throws IOException {
         outputStream.writeByte(value);
+    }
+
+    public int readInt() throws IOException {
+        return inputStream.readInt();
     }
 
     public void writeInt(int value) throws IOException {
         outputStream.writeInt(value);
     }
 
+    public long readLong() throws IOException {
+        return inputStream.readLong();
+    }
+
     public void writeLong(long value) throws IOException {
         outputStream.writeLong(value);
+    }
+
+    public void writeStrings(List<String> strings) throws IOException {
+        outputStream.writeInt(strings.size());
+        for (String s : strings) {
+            outputStream.writeUTF(s);
+        }
+    }
+
+    public List<String> readStrings() throws IOException {
+        int count = inputStream.readInt();
+        List<String> strings = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            strings.add(inputStream.readUTF());
+        }
+        return strings;
     }
 
     public void flush() throws IOException {

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Connection.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Connection.java
@@ -48,11 +48,12 @@ public class Connection implements Closeable {
         outputStream.writeLong(value);
     }
 
-    public void writeStrings(List<String> strings) throws IOException {
-        outputStream.writeInt(strings.size());
-        for (String s : strings) {
-            outputStream.writeUTF(s);
-        }
+    public String readString() throws IOException {
+        return inputStream.readUTF();
+    }
+
+    public void writeString(String value) throws IOException {
+        outputStream.writeUTF(value);
     }
 
     public List<String> readStrings() throws IOException {
@@ -62,6 +63,13 @@ public class Connection implements Closeable {
             strings.add(inputStream.readUTF());
         }
         return strings;
+    }
+
+    public void writeStrings(List<String> strings) throws IOException {
+        outputStream.writeInt(strings.size());
+        for (String s : strings) {
+            outputStream.writeUTF(s);
+        }
     }
 
     public void flush() throws IOException {

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Connection.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Connection.java
@@ -1,0 +1,53 @@
+package org.gradle.profiler.client.protocol;
+
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+
+public class Connection implements Closeable {
+    private final Socket socket;
+    private final DataOutputStream outputStream;
+    private final DataInputStream inputStream;
+
+    public Connection(Socket socket) throws IOException {
+        this.socket = socket;
+        outputStream = new DataOutputStream(socket.getOutputStream());
+        inputStream = new DataInputStream(socket.getInputStream());
+    }
+
+    @Override
+    public void close() throws IOException {
+        socket.close();
+    }
+
+    public byte readByte() throws IOException {
+        return inputStream.readByte();
+    }
+
+    public int readInt() throws IOException {
+        return inputStream.readInt();
+    }
+
+    public long readLong() throws IOException {
+        return inputStream.readLong();
+    }
+
+    public void writeByte(byte value) throws IOException {
+        outputStream.writeByte(value);
+    }
+
+    public void writeInt(int value) throws IOException {
+        outputStream.writeInt(value);
+    }
+
+    public void writeLong(long value) throws IOException {
+        outputStream.writeLong(value);
+    }
+
+    public void flush() throws IOException {
+        outputStream.flush();
+        socket.getOutputStream().flush();
+    }
+}

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/ConnectionParameters.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/ConnectionParameters.java
@@ -1,0 +1,15 @@
+package org.gradle.profiler.client.protocol;
+
+import java.io.File;
+
+public class ConnectionParameters extends Message {
+    private final File gradleInstallation;
+
+    public ConnectionParameters(File gradleInstallation) {
+        this.gradleInstallation = gradleInstallation;
+    }
+
+    public File getGradleInstallation() {
+        return gradleInstallation;
+    }
+}

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Message.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Message.java
@@ -1,0 +1,4 @@
+package org.gradle.profiler.client.protocol;
+
+public class Message {
+}

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Serializer.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Serializer.java
@@ -1,0 +1,65 @@
+package org.gradle.profiler.client.protocol;
+
+import java.io.EOFException;
+import java.io.IOException;
+
+public class Serializer {
+    private final String peerName;
+    private final Connection connection;
+
+    public Serializer(String peerName, Connection connection) {
+        this.peerName = peerName;
+        this.connection = connection;
+    }
+
+    public void send(SyncStarted message) {
+        try {
+            connection.writeByte((byte) 1);
+            connection.writeInt(message.getId());
+            connection.flush();
+        } catch (IOException e) {
+            throw couldNotWrite(e);
+        }
+    }
+
+    public void send(SyncCompleted message) {
+        try {
+            connection.writeByte((byte) 2);
+            connection.writeInt(message.getId());
+            connection.writeLong(message.getDurationMillis());
+            connection.flush();
+        } catch (IOException e) {
+            throw couldNotWrite(e);
+        }
+    }
+
+    private RuntimeException couldNotWrite(IOException e) {
+        return new RuntimeException(String.format("Could not write to %s.", peerName), e);
+    }
+
+    public Message receive() {
+        try {
+            byte tag;
+            try {
+                tag = connection.readByte();
+            } catch (EOFException e) {
+                // Disconnected
+                return null;
+            }
+            int id;
+            switch (tag) {
+                case 1:
+                    id = connection.readInt();
+                    return new SyncStarted(id);
+                case 2:
+                    id = connection.readInt();
+                    long durationMillis = connection.readLong();
+                    return new SyncCompleted(id, durationMillis);
+                default:
+                    throw new IllegalArgumentException("Received unexpected message on connection.");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(String.format("Could not read from %s.", peerName), e);
+        }
+    }
+}

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Server.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Server.java
@@ -8,9 +8,9 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 /**
  * An endpoint for communicating with a single client process.
@@ -43,9 +43,9 @@ public class Server implements Closeable {
         }
     }
 
-    public ServerConnection waitForIncoming() {
+    public ServerConnection waitForIncoming(Duration timeout) {
         try {
-            int keys = selector.select(TimeUnit.MINUTES.toMillis(2));
+            int keys = selector.select(timeout.toMillis());
             if (keys != 1) {
                 throw new IllegalStateException(String.format("Timeout waiting for incoming connection from %s.", peerName));
             }

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Server.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/Server.java
@@ -1,0 +1,73 @@
+package org.gradle.profiler.client.protocol;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * An endpoint for communicating with a single client process.
+ */
+public class Server implements Closeable {
+
+    private final ServerSocketChannel serverSocketChannel;
+    private final Selector selector;
+    private final List<ServerConnection> connections = new ArrayList<>();
+    private final String peerName;
+
+    public Server(String peerName) {
+        this.peerName = peerName;
+        try {
+            serverSocketChannel = ServerSocketChannel.open();
+            serverSocketChannel.bind(new InetSocketAddress((InetAddress) null, 0));
+            serverSocketChannel.configureBlocking(false);
+            selector = Selector.open();
+            serverSocketChannel.register(selector, SelectionKey.OP_ACCEPT);
+        } catch (IOException e) {
+            throw new RuntimeException(String.format("Could not start listening for incoming %s connections.", peerName), e);
+        }
+    }
+
+    public int getPort() {
+        try {
+            return ((InetSocketAddress) serverSocketChannel.getLocalAddress()).getPort();
+        } catch (IOException e) {
+            throw new RuntimeException("Could not determine local port.", e);
+        }
+    }
+
+    public ServerConnection waitForIncoming() {
+        try {
+            int keys = selector.select(TimeUnit.MINUTES.toMillis(2));
+            if (keys != 1) {
+                throw new IllegalStateException(String.format("Timeout waiting for incoming connection from %s.", peerName));
+            }
+            SocketChannel channel = serverSocketChannel.accept();
+            ServerConnection connection = new ServerConnection(peerName, new Connection(channel.socket()));
+            connections.add(connection);
+            return connection;
+        } catch (IOException e) {
+            throw new RuntimeException(String.format("Could not receive incoming connection from %s.", peerName), e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            for (ServerConnection connection : connections) {
+                connection.close();
+            }
+            serverSocketChannel.close();
+            selector.close();
+        } finally {
+            connections.clear();
+        }
+    }
+}

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/ServerConnection.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/ServerConnection.java
@@ -1,0 +1,53 @@
+package org.gradle.profiler.client.protocol;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.function.Consumer;
+
+public class ServerConnection implements Closeable {
+    private final Object lock = new Object();
+    private final String peerName;
+    private final Connection connection;
+    private Thread receiveThread;
+
+    public ServerConnection(String peerName, Connection connection) {
+        this.peerName = peerName;
+        this.connection = connection;
+    }
+
+    public void receive(Consumer<Message> consumer) {
+        synchronized (lock) {
+            if (receiveThread != null) {
+                throw new IllegalStateException("Already receiving on another thread.");
+            }
+            receiveThread = new Thread(() -> {
+                Serializer serializer = new Serializer(peerName, connection);
+                while (true) {
+                    Message message = serializer.receive();
+                    if (message == null) {
+                        // Disconnected
+                        System.out.println(String.format("* %s has disconnected.", peerName));
+                        return;
+                    }
+                    consumer.accept(message);
+                }
+            });
+            receiveThread.start();
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        synchronized (lock) {
+            if (receiveThread != null) {
+                try {
+                    receiveThread.join();
+                } catch (InterruptedException e) {
+                    throw new IOException(e);
+                }
+            }
+            receiveThread = null;
+        }
+        connection.close();
+    }
+}

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/ServerConnection.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/ServerConnection.java
@@ -2,52 +2,31 @@ package org.gradle.profiler.client.protocol;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.function.Consumer;
+import java.time.Duration;
 
 public class ServerConnection implements Closeable {
-    private final Object lock = new Object();
-    private final String peerName;
     private final Connection connection;
-    private Thread receiveThread;
+    private final Serializer serializer;
 
     public ServerConnection(String peerName, Connection connection) {
-        this.peerName = peerName;
         this.connection = connection;
-    }
-
-    public void receive(Consumer<Message> consumer) {
-        synchronized (lock) {
-            if (receiveThread != null) {
-                throw new IllegalStateException("Already receiving on another thread.");
-            }
-            receiveThread = new Thread(() -> {
-                Serializer serializer = new Serializer(peerName, connection);
-                while (true) {
-                    Message message = serializer.receive();
-                    if (message == null) {
-                        // Disconnected
-                        System.out.println(String.format("* %s has disconnected.", peerName));
-                        return;
-                    }
-                    consumer.accept(message);
-                }
-            });
-            receiveThread.start();
-        }
+        this.serializer = new Serializer(peerName, connection);
     }
 
     @Override
     public void close() throws IOException {
-        synchronized (lock) {
-            if (receiveThread != null) {
-                try {
-                    receiveThread.join();
-                } catch (InterruptedException e) {
-                    throw new IOException(e);
-                }
-            }
-            receiveThread = null;
-        }
         connection.close();
+    }
+
+    public void send(SyncParameters syncParameters) {
+        serializer.send(syncParameters);
+    }
+
+    public SyncStarted receiveSyncStarted(Duration timeout) {
+        return serializer.receive(SyncStarted.class, timeout);
+    }
+
+    public SyncCompleted receiveSyncCompeted(Duration timeout) {
+        return serializer.receive(SyncCompleted.class, timeout);
     }
 }

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/ServerConnection.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/ServerConnection.java
@@ -22,6 +22,10 @@ public class ServerConnection implements Closeable {
         serializer.send(syncParameters);
     }
 
+    public void send(ConnectionParameters connectionParameters) {
+        serializer.send(connectionParameters);
+    }
+
     public SyncStarted receiveSyncStarted(Duration timeout) {
         return serializer.receive(SyncStarted.class, timeout);
     }

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/SyncCompleted.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/SyncCompleted.java
@@ -1,0 +1,24 @@
+package org.gradle.profiler.client.protocol;
+
+public class SyncCompleted extends Message {
+    private final int id;
+    private final long durationMillis;
+
+    public SyncCompleted(int id, long durationMillis) {
+        this.id = id;
+        this.durationMillis = durationMillis;
+    }
+
+    @Override
+    public String toString() {
+        return "sync completed " + id + " in " + durationMillis + "ms";
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public long getDurationMillis() {
+        return durationMillis;
+    }
+}

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/SyncParameters.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/SyncParameters.java
@@ -1,0 +1,21 @@
+package org.gradle.profiler.client.protocol;
+
+import java.util.List;
+
+public class SyncParameters extends Message {
+    private final List<String> gradleArgs;
+    private final List<String> jvmArgs;
+
+    public SyncParameters(List<String> gradleArgs, List<String> jvmArgs) {
+        this.gradleArgs = gradleArgs;
+        this.jvmArgs = jvmArgs;
+    }
+
+    public List<String> getGradleArgs() {
+        return gradleArgs;
+    }
+
+    public List<String> getJvmArgs() {
+        return jvmArgs;
+    }
+}

--- a/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/SyncStarted.java
+++ b/subprojects/client-protocol/src/main/java/org/gradle/profiler/client/protocol/SyncStarted.java
@@ -1,0 +1,18 @@
+package org.gradle.profiler.client.protocol;
+
+public class SyncStarted extends Message {
+    private final int id;
+
+    public SyncStarted(int id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "sync started " + id;
+    }
+
+    public int getId() {
+        return id;
+    }
+}

--- a/subprojects/client-protocol/src/test/groovy/org/gradle/profiler/client/protocol/ProtocolTest.groovy
+++ b/subprojects/client-protocol/src/test/groovy/org/gradle/profiler/client/protocol/ProtocolTest.groovy
@@ -1,0 +1,35 @@
+package org.gradle.profiler.client.protocol
+
+import spock.lang.Specification
+
+import java.util.concurrent.LinkedBlockingQueue
+
+class ProtocolTest extends Specification {
+    def "client can sent events to server"() {
+        when:
+        def server = new Server("some client")
+        def client = Client.INSTANCE
+        client.connect(server.port)
+        def connection = server.waitForIncoming()
+        def messages = new LinkedBlockingQueue()
+        connection.receive {
+            messages.put(it)
+        }
+
+        client.send(new SyncStarted(1))
+        client.send(new SyncCompleted(1, 123))
+
+        then:
+        def m1 = messages.take()
+        m1 instanceof SyncStarted
+        m1.id == 1
+        def m2 = messages.take()
+        m2 instanceof SyncCompleted
+        m2.id == 1
+        m2.durationMillis == 123
+
+        cleanup:
+        client?.disconnect()
+        server?.close()
+    }
+}

--- a/subprojects/client-protocol/src/test/groovy/org/gradle/profiler/client/protocol/ProtocolTest.groovy
+++ b/subprojects/client-protocol/src/test/groovy/org/gradle/profiler/client/protocol/ProtocolTest.groovy
@@ -2,31 +2,32 @@ package org.gradle.profiler.client.protocol
 
 import spock.lang.Specification
 
-import java.util.concurrent.LinkedBlockingQueue
+import java.time.Duration
 
 class ProtocolTest extends Specification {
-    def "client can sent events to server"() {
+    def "can send events between client and server"() {
         when:
         def server = new Server("some client")
+        def timeout = Duration.ofSeconds(20)
         def client = Client.INSTANCE
         client.connect(server.port)
-        def connection = server.waitForIncoming()
-        def messages = new LinkedBlockingQueue()
-        connection.receive {
-            messages.put(it)
-        }
+        def serverConnection = server.waitForIncoming(timeout)
 
         client.send(new SyncStarted(1))
+        def m1 = serverConnection.receiveSyncStarted(timeout)
+
+        serverConnection.send(new SyncParameters(["gradle-arg"], ["jvm-arg"]))
+        def m2 = client.receiveParameters(timeout)
+
         client.send(new SyncCompleted(1, 123))
+        def m3 = serverConnection.receiveSyncCompeted(timeout)
 
         then:
-        def m1 = messages.take()
-        m1 instanceof SyncStarted
         m1.id == 1
-        def m2 = messages.take()
-        m2 instanceof SyncCompleted
-        m2.id == 1
-        m2.durationMillis == 123
+        m2.gradleArgs == ["gradle-arg"]
+        m2.jvmArgs == ["jvm-arg"]
+        m3.id == 1
+        m3.durationMillis == 123
 
         cleanup:
         client?.disconnect()

--- a/subprojects/client-protocol/src/test/groovy/org/gradle/profiler/client/protocol/ProtocolTest.groovy
+++ b/subprojects/client-protocol/src/test/groovy/org/gradle/profiler/client/protocol/ProtocolTest.groovy
@@ -13,21 +13,25 @@ class ProtocolTest extends Specification {
         client.connect(server.port)
         def serverConnection = server.waitForIncoming(timeout)
 
+        serverConnection.send(new ConnectionParameters(new File("gradle-home")))
+        def m1 = client.receiveConnectionParameters(timeout)
+
         client.send(new SyncStarted(1))
-        def m1 = serverConnection.receiveSyncStarted(timeout)
+        def m2 = serverConnection.receiveSyncStarted(timeout)
 
         serverConnection.send(new SyncParameters(["gradle-arg"], ["jvm-arg"]))
-        def m2 = client.receiveParameters(timeout)
+        def m3 = client.receiveSyncParameters(timeout)
 
         client.send(new SyncCompleted(1, 123))
-        def m3 = serverConnection.receiveSyncCompeted(timeout)
+        def m4 = serverConnection.receiveSyncCompeted(timeout)
 
         then:
-        m1.id == 1
-        m2.gradleArgs == ["gradle-arg"]
-        m2.jvmArgs == ["jvm-arg"]
-        m3.id == 1
-        m3.durationMillis == 123
+        m1.gradleInstallation.path == "gradle-home"
+        m2.id == 1
+        m3.gradleArgs == ["gradle-arg"]
+        m3.jvmArgs == ["jvm-arg"]
+        m4.id == 1
+        m4.durationMillis == 123
 
         cleanup:
         client?.disconnect()

--- a/subprojects/instrumentation-support/build.gradle.kts
+++ b/subprojects/instrumentation-support/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+    id("profiler.embedded-library")
+}
+
+dependencies {
+    implementation(versions.toolingApi)
+    implementation(project(":client-protocol"))
+}

--- a/subprojects/instrumentation-support/src/main/java/org/gradle/profiler/studio/instrumented/Interceptor.java
+++ b/subprojects/instrumentation-support/src/main/java/org/gradle/profiler/studio/instrumented/Interceptor.java
@@ -1,17 +1,42 @@
 package org.gradle.profiler.studio.instrumented;
 
+import org.gradle.profiler.client.protocol.Client;
+import org.gradle.profiler.client.protocol.SyncParameters;
+import org.gradle.profiler.client.protocol.SyncStarted;
 import org.gradle.tooling.ResultHandler;
 import org.gradle.tooling.internal.consumer.AbstractLongRunningOperation;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Injected into Studio and called from instrumented classes.
  */
 public class Interceptor {
+    private static final AtomicInteger COUNTER = new AtomicInteger();
+
     /**
      * Called immediately prior to starting an operation.
      */
     public static ResultHandler<Object> onStartOperation(AbstractLongRunningOperation<?> operation, ResultHandler<Object> handler) {
         System.out.println("* Starting tooling API operation " + operation);
-        return handler;
+        int id = COUNTER.incrementAndGet();
+
+        SyncParameters syncParameters;
+        try {
+            Client client = Client.INSTANCE;
+            client.send(new SyncStarted(id));
+            syncParameters = client.receiveParameters(Duration.ofSeconds(60));
+        } catch (Throwable throwable) {
+            throwable.printStackTrace();
+            // Continue with original handler
+            return handler;
+        }
+
+        System.out.println("* Using Gradle args: " + syncParameters.getGradleArgs());
+        System.out.println("* Using JVM args: " + syncParameters.getJvmArgs());
+        operation.addArguments(syncParameters.getGradleArgs());
+        operation.addJvmArguments(syncParameters.getJvmArgs());
+        return new RecordingResultHandler(handler, id, System.nanoTime());
     }
 }

--- a/subprojects/instrumentation-support/src/main/java/org/gradle/profiler/studio/instrumented/Interceptor.java
+++ b/subprojects/instrumentation-support/src/main/java/org/gradle/profiler/studio/instrumented/Interceptor.java
@@ -1,0 +1,17 @@
+package org.gradle.profiler.studio.instrumented;
+
+import org.gradle.tooling.ResultHandler;
+import org.gradle.tooling.internal.consumer.AbstractLongRunningOperation;
+
+/**
+ * Injected into Studio and called from instrumented classes.
+ */
+public class Interceptor {
+    /**
+     * Called immediately prior to starting an operation.
+     */
+    public static ResultHandler<Object> onStartOperation(AbstractLongRunningOperation<?> operation, ResultHandler<Object> handler) {
+        System.out.println("* Starting tooling API operation " + operation);
+        return handler;
+    }
+}

--- a/subprojects/instrumentation-support/src/main/java/org/gradle/profiler/studio/instrumented/RecordingResultHandler.java
+++ b/subprojects/instrumentation-support/src/main/java/org/gradle/profiler/studio/instrumented/RecordingResultHandler.java
@@ -1,0 +1,37 @@
+package org.gradle.profiler.studio.instrumented;
+
+import org.gradle.profiler.client.protocol.Client;
+import org.gradle.profiler.client.protocol.SyncCompleted;
+import org.gradle.tooling.GradleConnectionException;
+import org.gradle.tooling.ResultHandler;
+
+public class RecordingResultHandler implements ResultHandler<Object> {
+    private final ResultHandler<Object> delegate;
+    private final int id;
+    private final long startTimeNanos;
+
+    public RecordingResultHandler(ResultHandler<Object> delegate, int id, long startTimeNanos) {
+        this.delegate = delegate;
+        this.id = id;
+        this.startTimeNanos = startTimeNanos;
+    }
+
+    @Override
+    public void onComplete(Object result) {
+        System.out.println("OPERATION COMPLETE: " + result);
+        sendEvent();
+        delegate.onComplete(result);
+    }
+
+    @Override
+    public void onFailure(GradleConnectionException failure) {
+        System.out.println("OPERATION FAILED: " + failure);
+        sendEvent();
+        delegate.onFailure(failure);
+    }
+
+    private void sendEvent() {
+        long durationMillis = (System.nanoTime() - startTimeNanos) / 1000000;
+        Client.INSTANCE.send(new SyncCompleted(id, durationMillis));
+    }
+}

--- a/subprojects/studio-agent/build.gradle.kts
+++ b/subprojects/studio-agent/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    id("profiler.embedded-library")
+}
+
+dependencies {
+    implementation(project(":client-protocol"))
+}

--- a/subprojects/studio-agent/build.gradle.kts
+++ b/subprojects/studio-agent/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 dependencies {
+    implementation("org.ow2.asm:asm:8.0.1")
     implementation(project(":client-protocol"))
 }
 

--- a/subprojects/studio-agent/build.gradle.kts
+++ b/subprojects/studio-agent/build.gradle.kts
@@ -2,9 +2,20 @@ plugins {
     id("profiler.embedded-library")
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 dependencies {
     implementation("org.ow2.asm:asm:8.0.1")
     implementation(project(":client-protocol"))
+}
+
+tasks.compileJava {
+    options.compilerArgs.add("--add-exports")
+    options.compilerArgs.add("java.base/jdk.internal.misc=ALL-UNNAMED")
 }
 
 tasks.jar {

--- a/subprojects/studio-agent/build.gradle.kts
+++ b/subprojects/studio-agent/build.gradle.kts
@@ -5,3 +5,9 @@ plugins {
 dependencies {
     implementation(project(":client-protocol"))
 }
+
+tasks.jar {
+    manifest {
+        attributes("Premain-Class" to "org.gradle.profiler.studio.agent.Agent")
+    }
+}

--- a/subprojects/studio-agent/src/main/java/org/gradle/profiler/studio/agent/Agent.java
+++ b/subprojects/studio-agent/src/main/java/org/gradle/profiler/studio/agent/Agent.java
@@ -1,0 +1,20 @@
+package org.gradle.profiler.studio.agent;
+
+import org.gradle.profiler.client.protocol.Client;
+
+import java.io.IOException;
+import java.lang.instrument.Instrumentation;
+
+public class Agent {
+    public static void premain(String agentArgs, Instrumentation inst) {
+        System.out.println("PROFILER AGENT RUNNING");
+
+        int port = Integer.parseInt(agentArgs);
+        try {
+            Client.INSTANCE.connect(port);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        System.out.println("CONNECTED TO CONTROLLER PROCESS");
+    }
+}

--- a/subprojects/studio-agent/src/main/java/org/gradle/profiler/studio/agent/Agent.java
+++ b/subprojects/studio-agent/src/main/java/org/gradle/profiler/studio/agent/Agent.java
@@ -1,20 +1,126 @@
 package org.gradle.profiler.studio.agent;
 
+import jdk.internal.misc.Unsafe;
 import org.gradle.profiler.client.protocol.Client;
+import org.objectweb.asm.*;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.Instrumentation;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.ProtectionDomain;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 public class Agent {
     public static void premain(String agentArgs, Instrumentation inst) {
         System.out.println("PROFILER AGENT RUNNING");
 
-        int port = Integer.parseInt(agentArgs);
-        try {
-            Client.INSTANCE.connect(port);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+        String[] args = agentArgs.split(",");
+        int port = Integer.parseInt(args[0]);
+        Path supportClasses = FileSystems.getDefault().getPath(args[1]);
+        Client.INSTANCE.connect(port);
+        System.out.println("* Connected to controller process");
+
+        inst.addTransformer(new InstrumentingTransformer(supportClasses));
+    }
+
+    private static class InstrumentingTransformer implements ClassFileTransformer {
+        private boolean supportClassesInjected;
+        private final Path supportClassesJar;
+
+        public InstrumentingTransformer(Path supportClassesJar) {
+            this.supportClassesJar = supportClassesJar;
         }
-        System.out.println("CONNECTED TO CONTROLLER PROCESS");
+
+        @Override
+        public byte[] transform(ClassLoader loader, String className, Class<?> classBeingRedefined, ProtectionDomain protectionDomain, byte[] originalByteCode) {
+            if (className.equals("org/gradle/tooling/internal/consumer/DefaultPhasedBuildActionExecuter")) {
+                maybeInjectSupportClasses(loader);
+                return instrument(originalByteCode);
+            }
+            return null;
+        }
+
+        private byte[] instrument(byte[] originalByteCode) {
+            Type interceptor = Type.getObjectType("org/gradle/profiler/studio/instrumented/Interceptor");
+            Type resultHandler = Type.getObjectType("org/gradle/tooling/ResultHandler");
+            Type abstractHandlerType = Type.getObjectType("org/gradle/tooling/internal/consumer/AbstractLongRunningOperation");
+            String runMethodDescriptor = Type.getMethodDescriptor(Type.VOID_TYPE, resultHandler);
+            String startOperationDescriptor = Type.getMethodDescriptor(resultHandler, abstractHandlerType, resultHandler);
+
+            ClassReader reader = new ClassReader(originalByteCode);
+            ClassWriter writer = new ClassWriter(0);
+            ClassVisitor visitor = new ClassVisitor(Opcodes.ASM8, writer) {
+                @Override
+                public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+                    MethodVisitor methodVisitor = super.visitMethod(access, name, descriptor, signature, exceptions);
+                    if (name.equals("run") && descriptor.equals(runMethodDescriptor)) {
+                        return new MethodVisitor(Opcodes.ASM8, methodVisitor) {
+                            @Override
+                            public void visitCode() {
+                                super.visitCode();
+                                visitVarInsn(Opcodes.ALOAD, 0);
+                                visitVarInsn(Opcodes.ALOAD, 1);
+                                visitMethodInsn(Opcodes.INVOKESTATIC, interceptor.getInternalName(), "onStartOperation", startOperationDescriptor, false);
+                                visitVarInsn(Opcodes.ASTORE, 1);
+                            }
+
+                            @Override
+                            public void visitMaxs(int maxStack, int maxLocals) {
+                                super.visitMaxs(Math.max(2, maxStack), maxLocals);
+                            }
+                        };
+                    }
+                    return methodVisitor;
+                }
+            };
+            reader.accept(visitor, 0);
+
+            return writer.toByteArray();
+        }
+
+        private synchronized void maybeInjectSupportClasses(ClassLoader loader) {
+            if (supportClassesInjected) {
+                return;
+            }
+
+            System.out.println("* Injecting support classes from " + supportClassesJar);
+
+            try {
+                try (InputStream jarInputStream = Files.newInputStream(supportClassesJar)) {
+                    ZipInputStream inputStream = new ZipInputStream(jarInputStream);
+                    while (true) {
+                        ZipEntry entry = inputStream.getNextEntry();
+                        if (entry == null) {
+                            break;
+                        }
+                        if (entry.getName().endsWith(".class")) {
+                            injectClass(loader, entry.getName().substring(0, entry.getName().length() - 6), entry.getSize(), inputStream);
+                        }
+                    }
+                }
+            } catch (IOException e) {
+                throw new RuntimeException("Could not inject support classes.", e);
+            }
+
+            supportClassesInjected = true;
+        }
+
+        private static void injectClass(ClassLoader loader, String internalName, long length, InputStream inputStream) throws IOException {
+            byte[] bytecode = new byte[(int) length];
+            int remaining = bytecode.length;
+            while (remaining > 0) {
+                int nread = inputStream.read(bytecode, bytecode.length - remaining, remaining);
+                if (nread < 0) {
+                    break;
+                }
+                remaining -= nread;
+            }
+            Unsafe.getUnsafe().defineClass(internalName, bytecode, 0, bytecode.length, loader, null);
+        }
     }
 }


### PR DESCRIPTION
Replaces the previous "sync mock" with a real sync triggered from Android Studio.

Introduces a new "Gradle client" implementation that runs Studio with an agent that intercepts calls to the tooling API in order to inject the correct settings and collect duration information.

This initial implementation has a few limitations:

1. A human still needs to trigger sync in Studio. The profiler displays instructions on the console.
2. It only works on macOS for now.

These are things that could be improved in the future.