### PR TITLE
Support generating flame graphs from multiple jfr files

### DIFF
--- a/src/main/java/org/gradle/profiler/InstrumentingProfiler.java
+++ b/src/main/java/org/gradle/profiler/InstrumentingProfiler.java
@@ -79,10 +79,19 @@ public abstract class InstrumentingProfiler extends Profiler {
 
     @Override
     public void validate(ScenarioSettings settings, Consumer<String> reporter) {
+        validateMultipleIterationsWithCleanupAction(settings, reporter);
+        validateMultipleDaemons(settings, reporter);
+    }
+
+    protected void validateMultipleIterationsWithCleanupAction(ScenarioSettings settings, Consumer<String> reporter) {
         GradleScenarioDefinition scenario = settings.getScenario();
         if (scenario.getBuildCount() > 1 && !canRestartRecording() && scenario.getCleanupAction().isDoesSomething()) {
             reporter.accept("Profiler " + toString() + " does not support profiling multiple iterations with cleanup steps in between.");
         }
+    }
+
+    protected void validateMultipleDaemons(ScenarioSettings settings, Consumer<String> reporter) {
+        GradleScenarioDefinition scenario = settings.getScenario();
         if (scenario.getBuildCount() > 1 && !scenario.getInvoker().isReuseDaemon()) {
             reporter.accept("Profiler " + toString() + " does not support profiling multiple daemons.");
         }

--- a/src/main/java/org/gradle/profiler/InstrumentingProfiler.java
+++ b/src/main/java/org/gradle/profiler/InstrumentingProfiler.java
@@ -15,7 +15,7 @@ import java.util.function.Consumer;
  * <li>Use some communication mechanism to capture a snapshot from an instrumented JVM that is currently running.</li>
  * </ul>
  *
- * <p>The profiler may support starting recording multiple times for a given JVM. The implementation should indicate this by overriding {@link #canRestartRecording()}.</p>
+ * <p>The profiler may support starting recording multiple times for a given JVM. The implementation should indicate this by overriding {@link #canRestartRecording(ScenarioSettings)}.</p>
  */
 public abstract class InstrumentingProfiler extends Profiler {
     /**
@@ -85,7 +85,7 @@ public abstract class InstrumentingProfiler extends Profiler {
 
     protected void validateMultipleIterationsWithCleanupAction(ScenarioSettings settings, Consumer<String> reporter) {
         GradleScenarioDefinition scenario = settings.getScenario();
-        if (scenario.getBuildCount() > 1 && !canRestartRecording() && scenario.getCleanupAction().isDoesSomething()) {
+        if (scenario.getBuildCount() > 1 && !canRestartRecording(settings) && scenario.getCleanupAction().isDoesSomething()) {
             reporter.accept("Profiler " + toString() + " does not support profiling multiple iterations with cleanup steps in between.");
         }
     }
@@ -100,7 +100,7 @@ public abstract class InstrumentingProfiler extends Profiler {
     /**
      * Can this profiler implementation restart recording, for the same JVM?
      */
-    protected boolean canRestartRecording() {
+    protected boolean canRestartRecording(ScenarioSettings settings) {
         return false;
     }
 

--- a/src/main/java/org/gradle/profiler/jfr/JFRJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/jfr/JFRJvmArgsCalculator.java
@@ -35,7 +35,7 @@ public class JFRJvmArgsCalculator implements JvmArgsCalculator {
         if (profileOnStart) {
             String startArgs = "name=profile,settings=" + args.getJfrSettings();
             if (captureOnExit) {
-                startArgs += ",dumponexit=true,filename=" + outputFile.getAbsolutePath();
+                startArgs += ",dumponexit=true,dumponexitpath=" + outputFile.getParentFile().getAbsolutePath();
             }
             jvmArgs.add("-XX:StartFlightRecording=" + startArgs);
         }

--- a/src/main/java/org/gradle/profiler/jfr/JFRJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/jfr/JFRJvmArgsCalculator.java
@@ -29,16 +29,21 @@ public class JFRJvmArgsCalculator implements JvmArgsCalculator {
             jvmArgs.add("-XX:+UnlockCommercialFeatures");
         }
         jvmArgs.add("-XX:+FlightRecorder");
-        jvmArgs.add("-XX:FlightRecorderOptions=stackdepth=1024");
         jvmArgs.add("-XX:+UnlockDiagnosticVMOptions");
         jvmArgs.add("-XX:+DebugNonSafepoints");
+
+        StringBuilder flightRecorderOptions = new StringBuilder("-XX:FlightRecorderOptions=stackdepth=1024");
+
         if (profileOnStart) {
-            String startArgs = "name=profile,settings=" + args.getJfrSettings();
+            jvmArgs.add("-XX:StartFlightRecording=name=profile,settings=" + args.getJfrSettings());
             if (captureOnExit) {
-                startArgs += ",dumponexit=true,dumponexitpath=" + outputFile.getParentFile().getAbsolutePath();
+                flightRecorderOptions.append(",defaultrecording=true,dumponexit=true")
+                    .append(",dumponexitpath=")
+                    .append(outputFile.getParentFile().getAbsolutePath());
             }
-            jvmArgs.add("-XX:StartFlightRecording=" + startArgs);
         }
+
+        jvmArgs.add(flightRecorderOptions.toString());
     }
 
     private boolean isOracleVm() {

--- a/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
@@ -3,6 +3,7 @@ package org.gradle.profiler.jfr;
 import org.gradle.profiler.flamegraph.FlameGraphSanitizer;
 import org.gradle.profiler.flamegraph.FlameGraphTool;
 import org.openjdk.jmc.common.item.IItemCollection;
+import org.openjdk.jmc.flightrecorder.CouldNotLoadRecordingException;
 import org.openjdk.jmc.flightrecorder.JfrLoaderToolkit;
 
 import java.io.File;
@@ -10,7 +11,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import static java.util.Objects.requireNonNull;
 import static org.gradle.profiler.jfr.JfrToStacksConverter.EventType;
 import static org.gradle.profiler.jfr.JfrToStacksConverter.Options;
 
@@ -27,30 +31,38 @@ class JfrFlameGraphGenerator {
         if (!flameGraphGenerator.checkInstallation()) {
             return;
         }
+
+        List<IItemCollection> recordings = Stream.of(
+            requireNonNull(jfrFile.getParentFile().listFiles((dir, name) -> name.endsWith(".jfr")))
+        ).map(file -> {
+            try {
+                return JfrLoaderToolkit.loadEvents(file);
+            } catch (IOException | CouldNotLoadRecordingException e) {
+                throw new RuntimeException(e);
+            }
+        }).collect(Collectors.toList());
+
         try {
-            IItemCollection events = JfrLoaderToolkit.loadEvents(jfrFile);
-            generateGraphs(jfrFile, events);
-        } catch (RuntimeException e) {
-            throw e;
-        } catch (Exception e) {
+            generateGraphs(jfrFile, recordings);
+        } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private void generateGraphs(File jfrFile, IItemCollection recording) throws IOException {
+    private void generateGraphs(File jfrFile, List<IItemCollection> recordings) throws IOException {
         File flamegraphDir = new File(jfrFile.getParentFile(), jfrFile.getName() + "-flamegraphs");
         for (EventType type : EventType.values()) {
             for (DetailLevel level : DetailLevel.values()) {
-                File stacks = generateStacks(flamegraphDir, recording, type, level);
+                File stacks = generateStacks(flamegraphDir, recordings, type, level);
                 generateFlameGraph(stacks, type, level);
                 generateIcicleGraph(stacks, type, level);
             }
         }
     }
 
-    private File generateStacks(File baseDir, IItemCollection recording, EventType type, DetailLevel level) throws IOException {
+    private File generateStacks(File baseDir, List<IItemCollection> recordings, EventType type, DetailLevel level) throws IOException {
         File stacks = File.createTempFile("stacks", ".txt");
-        stacksConverter.convertToStacks(recording, stacks, new Options(type, level.isShowArguments(), level.isShowLineNumbers()));
+        stacksConverter.convertToStacks(recordings, stacks, new Options(type, level.isShowArguments(), level.isShowLineNumbers()));
         File sanitizedStacks = stacksFileName(baseDir, type, level);
         level.getSanitizer().sanitize(stacks, sanitizedStacks);
         stacks.delete();

--- a/src/main/java/org/gradle/profiler/jfr/JfrProfiler.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrProfiler.java
@@ -1,5 +1,6 @@
 package org.gradle.profiler.jfr;
 
+import org.gradle.profiler.GradleScenarioDefinition;
 import org.gradle.profiler.InstrumentingProfiler;
 import org.gradle.profiler.JvmArgsCalculator;
 import org.gradle.profiler.ScenarioSettings;
@@ -44,5 +45,13 @@ public class JfrProfiler extends InstrumentingProfiler {
 
     private File getJfrFile(ScenarioSettings settings) {
         return new File(settings.getScenario().getOutputDir(), settings.getScenario().getProfileName() + PROFILE_JFR_SUFFIX);
+    }
+
+    @Override
+    public void validate(ScenarioSettings settings, Consumer<String> reporter) {
+        GradleScenarioDefinition scenario = settings.getScenario();
+        if (scenario.getBuildCount() > 1 && !canRestartRecording() && scenario.getCleanupAction().isDoesSomething()) {
+            reporter.accept("Profiler " + toString() + " does not support profiling multiple iterations with cleanup steps in between.");
+        }
     }
 }

--- a/src/main/java/org/gradle/profiler/jfr/JfrProfiler.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrProfiler.java
@@ -1,6 +1,5 @@
 package org.gradle.profiler.jfr;
 
-import org.gradle.profiler.GradleScenarioDefinition;
 import org.gradle.profiler.InstrumentingProfiler;
 import org.gradle.profiler.JvmArgsCalculator;
 import org.gradle.profiler.ScenarioSettings;
@@ -49,9 +48,6 @@ public class JfrProfiler extends InstrumentingProfiler {
 
     @Override
     public void validate(ScenarioSettings settings, Consumer<String> reporter) {
-        GradleScenarioDefinition scenario = settings.getScenario();
-        if (scenario.getBuildCount() > 1 && !canRestartRecording() && scenario.getCleanupAction().isDoesSomething()) {
-            reporter.accept("Profiler " + toString() + " does not support profiling multiple iterations with cleanup steps in between.");
-        }
+        validateMultipleIterationsWithCleanupAction(settings, reporter);
     }
 }

--- a/src/main/java/org/gradle/profiler/jfr/JfrProfiler.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrProfiler.java
@@ -50,4 +50,9 @@ public class JfrProfiler extends InstrumentingProfiler {
     public void validate(ScenarioSettings settings, Consumer<String> reporter) {
         validateMultipleIterationsWithCleanupAction(settings, reporter);
     }
+
+    @Override
+    protected boolean canRestartRecording(ScenarioSettings settings) {
+        return !settings.getScenario().getInvoker().isReuseDaemon();
+    }
 }

--- a/src/main/java/org/gradle/profiler/jfr/JfrToStacksConverter.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrToStacksConverter.java
@@ -37,14 +37,15 @@ import java.util.stream.StreamSupport;
  * Converts JFR recordings to the collapsed stacks format used by the FlameGraph tool.
  */
 class JfrToStacksConverter {
-    public void convertToStacks(IItemCollection recording, File targetFile, Options options) {
-        Map<String, Long> foldedStacks = foldStacks(recording, options);
+    public void convertToStacks(List<IItemCollection> recordings, File targetFile, Options options) {
+        Map<String, Long> foldedStacks = foldStacks(recordings, options);
         writeFoldedStacks(foldedStacks, targetFile);
     }
 
-    private Map<String, Long> foldStacks(IItemCollection recording, Options options) {
+    private Map<String, Long> foldStacks(List<IItemCollection> recordings, Options options) {
         StackFolder folder = new StackFolder(options);
-        StreamSupport.stream(recording.spliterator(), false)
+        recordings.stream()
+            .flatMap(recording -> StreamSupport.stream(recording.spliterator(), false))
             .flatMap(eventStream -> StreamSupport.stream(eventStream.spliterator(), false))
             .filter(options.eventType::matches)
             .filter(event -> getStackTrace(event) != null)

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfilerProfiler.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfilerProfiler.java
@@ -27,7 +27,7 @@ public class JProfilerProfiler extends InstrumentingProfiler {
     }
 
     @Override
-    protected boolean canRestartRecording() {
+    protected boolean canRestartRecording(ScenarioSettings settings) {
         return true;
     }
 

--- a/src/main/java/org/gradle/profiler/yourkit/YourKitProfiler.java
+++ b/src/main/java/org/gradle/profiler/yourkit/YourKitProfiler.java
@@ -27,7 +27,7 @@ public class YourKitProfiler extends InstrumentingProfiler {
     }
 
     @Override
-    protected boolean canRestartRecording() {
+    protected boolean canRestartRecording(ScenarioSettings settings) {
         return false;
     }
 

--- a/src/test/groovy/org/gradle/profiler/JFRProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/JFRProfilerIntegrationTest.groovy
@@ -1,6 +1,7 @@
 package org.gradle.profiler
 
 import spock.lang.IgnoreIf
+import spock.lang.Requires
 import spock.lang.Unroll
 
 // TODO Re-enable once Oracle JDK 8 lookup is fixed with toolchains
@@ -141,6 +142,8 @@ class JFRProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         latestSupportedGradleVersion  | _
     }
 
+    @Requires({ !OperatingSystem.isWindows() })
+    // No perl installed on Windows
     @Unroll
     def "can profile Gradle no daemon #versionUnderTest with #iterations iterations"(String versionUnderTest, int iterations) {
         given:

--- a/src/test/groovy/org/gradle/profiler/JFRProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/JFRProfilerIntegrationTest.groovy
@@ -88,7 +88,7 @@ class JFRProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
     }
 
     @Unroll
-    def "can profile Gradle #versionUnderTest using JRF, tooling API and cold daemon"() {
+    def "can profile Gradle #versionUnderTest using JFR, tooling API and cold daemon"() {
         given:
         instrumentedBuildScript()
 
@@ -142,31 +142,41 @@ class JFRProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
     }
 
     @Unroll
-    def "can profile Gradle #versionUnderTest using JFR, `gradle` command and no daemon"() {
+    def "can profile Gradle no daemon #versionUnderTest with #iterations iterations"(String versionUnderTest, int iterations) {
         given:
         instrumentedBuildScript()
 
         when:
-        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", versionUnderTest, "--profile", "jfr", "--no-daemon", "assemble")
+        new Main().run(
+            "--project-dir", projectDir.absolutePath,
+            "--output-dir", outputDir.absolutePath,
+            "--gradle-version", versionUnderTest,
+            "--profile", "jfr",
+            "--warmups", "1",
+            "--iterations", iterations.toString(),
+            "--no-daemon",
+            "assemble")
 
         then:
-        // Probe version, 1 warm up, 1 build
+        // Probe version, 1 warm up, 2 build
         logFile.containsOne("* Running scenario using Gradle $versionUnderTest (scenario 1/1)")
         logFile.find("* Running warm-up build").size() == 1
-        logFile.find("* Running measured build").size() == 1
-        logFile.find("<gradle-version: $versionUnderTest>").size() == 3
+        logFile.find("* Running measured build").size() == iterations
+        logFile.find("<gradle-version: $versionUnderTest>").size() == 2 + iterations
         logFile.find("<daemon: true").size() == 1
-        logFile.find("<daemon: false").size() == 2
-        logFile.find("<tasks: [assemble]>").size() == 2
-        logFile.find("<invocations: 1>").size() == 3
+        logFile.find("<daemon: false").size() == 1 + iterations
+        logFile.find("<tasks: [assemble]>").size() == 1 + iterations
+        logFile.find("<invocations: 1>").size() == 2 + iterations
 
-        def profileFile = new File(outputDir, "${versionUnderTest}.jfr")
-        profileFile.exists()
+        outputDir.listFiles().findAll { it.name.endsWith(".jfr") }.size() == iterations
+        new File(outputDir, "${versionUnderTest}.jfr-flamegraphs").isDirectory()
 
         where:
-        versionUnderTest              | _
-        minimalSupportedGradleVersion | _
-        latestSupportedGradleVersion  | _
+        versionUnderTest              | iterations
+        minimalSupportedGradleVersion | 1
+        minimalSupportedGradleVersion | 2
+        latestSupportedGradleVersion  | 1
+        latestSupportedGradleVersion  | 2
     }
 
     def "cannot profile using JFR with multiple iterations and cleanup steps"() {

--- a/src/test/groovy/org/gradle/profiler/JFRProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/JFRProfilerIntegrationTest.groovy
@@ -200,32 +200,4 @@ class JFRProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         output.contains("Scenario assemble using Gradle ${minimalSupportedGradleVersion}: Profiler JFR does not support profiling multiple iterations with cleanup steps in between.")
     }
 
-    def "cannot profile using JFR with multiple iterations and cold daemon"() {
-        given:
-        instrumentedBuildScript()
-
-        when:
-        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", minimalSupportedGradleVersion, "--profile", "jfr", "--iterations", "2", "--cold-daemon", "assemble")
-
-        then:
-        thrown(IllegalArgumentException)
-
-        and:
-        output.contains("Scenario using Gradle ${minimalSupportedGradleVersion}: Profiler JFR does not support profiling multiple daemons.")
-    }
-
-    def "cannot profile using JFR with multiple iterations and no daemon"() {
-        given:
-        instrumentedBuildScript()
-
-        when:
-        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", minimalSupportedGradleVersion, "--profile", "jfr", "--iterations", "2", "--no-daemon", "assemble")
-
-        then:
-        thrown(IllegalArgumentException)
-
-        and:
-        output.contains("Scenario using Gradle ${minimalSupportedGradleVersion}: Profiler JFR does not support profiling multiple daemons.")
-    }
-
 }


### PR DESCRIPTION
Previously in `no-daemon` scenario, only the jfr file of last iteration will be used to generate flame graph, which makes troubleshooting no-daemon scenario extremely difficult. This PR support generating multiple jfr files and generate flame graphs from these files by merging them.