### PR TITLE
Revert toolchains

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,6 +52,15 @@ dependencies {
     testRuntimeOnly("org.objenesis:objenesis:2.6")
 }
 
+allprojects {
+    pluginManager.withPlugin("java") {
+        java {
+            sourceCompatibility = JavaVersion.VERSION_1_8
+            targetCompatibility = JavaVersion.VERSION_1_8
+        }
+    }
+}
+
 subprojects {
     // Subprojects are packaged into the Gradle profiler Jar, so let's make them reproducible
     tasks.withType<Jar>().configureEach {
@@ -100,12 +109,6 @@ tasks.processResources {
         }
     }
     from(generateHtmlReportJavaScript)
-}
-
-tasks.test {
-    // Use the current JVM. Some tests require JFR, which is only available in some JVM implementations
-    // For now assume that the current JVM has JFR support and that CI will inject the correct implementation
-    javaLauncher.set(null as JavaLauncher?)
 }
 
 val testReports = mapOf(

--- a/buildSrc/src/main/kotlin/profiler.embedded-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.embedded-library.gradle.kts
@@ -1,3 +1,7 @@
 plugins {
     id("profiler.java-library")
 }
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+}

--- a/buildSrc/src/main/kotlin/profiler.java-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.java-library.gradle.kts
@@ -9,12 +9,6 @@ repositories {
     }
 }
 
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
-    }
-}
-
 project.extensions.create<Versions>("versions")
 
 abstract class Versions {

--- a/subprojects/studio-agent/build.gradle.kts
+++ b/subprojects/studio-agent/build.gradle.kts
@@ -3,9 +3,8 @@ plugins {
 }
 
 java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 dependencies {


### PR DESCRIPTION
Toolchain support seems to make builds fail now, because Oracle JDK cannot be found.