### PR TITLE
Extract publication logic to buildSrc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,10 @@
-import java.net.URI
 import com.moowork.gradle.node.npm.NpxTask
 
 plugins {
     id("profiler.java-library")
     groovy
     application
-    `maven-publish`
+    id("profiler.publication")
     id("com.github.node-gradle.node") version "2.2.4"
 }
 
@@ -137,40 +136,6 @@ tasks.register("testHtmlReports") {
 
 val profilerDistribution = artifacts.add("archives", tasks.distZip.flatMap { it.archiveFile }) {
     type = "zip"
-}
-
-publishing {
-    publications {
-        register<MavenPublication>("mavenJava") {
-            from(components["java"])
-            artifact(profilerDistribution)
-            pom {
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
-            }
-        }
-    }
-
-    repositories {
-        maven {
-            name = "GradleBuildInternal"
-            url = gradleInternalRepositoryUrl()
-            credentials {
-                username = project.findProperty("artifactoryUsername") as String?
-                password = project.findProperty("artifactoryPassword") as String?
-            }
-        }
-    }
-}
-
-fun Project.gradleInternalRepositoryUrl(): URI {
-    val isSnapshot = version.toString().endsWith("-SNAPSHOT")
-    val repositoryQualifier = if (isSnapshot) "snapshots" else "releases"
-    return uri("https://repo.gradle.org/gradle/ext-$repositoryQualifier-local")
 }
 
 buildScan {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("profiler.java-library")
     groovy
     application
+    `maven-publish`
     id("profiler.publication")
     id("com.github.node-gradle.node") version "2.2.4"
 }
@@ -136,6 +137,20 @@ tasks.register("testHtmlReports") {
 
 val profilerDistribution = artifacts.add("archives", tasks.distZip.flatMap { it.archiveFile }) {
     type = "zip"
+}
+
+publishing {
+    publications {
+        named<MavenPublication>("mavenJava") {
+            artifact(profilerDistribution)
+        }
+    }
+}
+
+fun Project.gradleInternalRepositoryUrl(): java.net.URI {
+    val isSnapshot = version.toString().endsWith("-SNAPSHOT")
+    val repositoryQualifier = if (isSnapshot) "snapshots" else "releases"
+    return uri("https://repo.gradle.org/gradle/ext-$repositoryQualifier-local")
 }
 
 buildScan {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.moowork.gradle.node.npm.NpxTask
+import java.net.URI
 
 plugins {
     id("profiler.java-library")
@@ -147,7 +148,7 @@ publishing {
     }
 }
 
-fun Project.gradleInternalRepositoryUrl(): java.net.URI {
+fun Project.gradleInternalRepositoryUrl(): URI {
     val isSnapshot = version.toString().endsWith("-SNAPSHOT")
     val repositoryQualifier = if (isSnapshot) "snapshots" else "releases"
     return uri("https://repo.gradle.org/gradle/ext-$repositoryQualifier-local")

--- a/buildSrc/src/main/kotlin/profiler.publication.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.publication.gradle.kts
@@ -8,16 +8,6 @@ publishing {
     publications {
         register<MavenPublication>("mavenJava") {
             from(components["java"])
-
-            if (project.parent == null) {
-                afterEvaluate {
-                    val profilerDistribution = artifacts.add("archives", tasks.named<Zip>("distZip").flatMap { it.archiveFile }) {
-                        type = "zip"
-                    }
-                    artifact(profilerDistribution)
-                }
-            }
-
             pom {
                 licenses {
                     license {

--- a/buildSrc/src/main/kotlin/profiler.publication.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.publication.gradle.kts
@@ -1,0 +1,49 @@
+import java.net.URI
+
+plugins {
+    id("maven-publish")
+}
+
+publishing {
+    publications {
+        register<MavenPublication>("mavenJava") {
+            from(components["java"])
+
+            if (project.parent == null) {
+                afterEvaluate {
+                    val profilerDistribution = artifacts.add("archives", tasks.named<Zip>("distZip").flatMap { it.archiveFile }) {
+                        type = "zip"
+                    }
+                    artifact(profilerDistribution)
+                }
+            }
+
+            pom {
+                licenses {
+                    license {
+                        name.set("The Apache License, Version 2.0")
+                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
+            }
+        }
+    }
+
+    repositories {
+        maven {
+            name = "GradleBuildInternal"
+            url = gradleInternalRepositoryUrl()
+            credentials {
+                username = project.findProperty("artifactoryUsername") as String?
+                password = project.findProperty("artifactoryPassword") as String?
+            }
+        }
+    }
+}
+
+
+fun Project.gradleInternalRepositoryUrl(): URI {
+    val isSnapshot = property("profiler.version").toString().endsWith("-SNAPSHOT")
+    val repositoryQualifier = if (isSnapshot) "snapshots" else "releases"
+    return uri("https://repo.gradle.org/gradle/ext-$repositoryQualifier-local")
+}

--- a/subprojects/client-protocol/build.gradle.kts
+++ b/subprojects/client-protocol/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("profiler.embedded-library")
     id("groovy")
+    id("profiler.publication")
 }
 
 dependencies {


### PR DESCRIPTION
After introducing `client-protocol` subproject, we need to publish
more than 1 project, so we extract the common logic to buildSrc.