### PR TITLE
Fix two issues with Android Studio Sync support 

### DIFF
--- a/src/main/java/org/gradle/profiler/studio/StudioGradleClient.java
+++ b/src/main/java/org/gradle/profiler/studio/StudioGradleClient.java
@@ -57,7 +57,7 @@ public class StudioGradleClient implements GradleClient {
         commandLine.add("java.base/jdk.internal.misc=ALL-UNNAMED");
         commandLine.add("-Xbootclasspath/a:" + Joiner.on(File.pathSeparator).join(launchConfiguration.getSharedJars()));
         commandLine.add(launchConfiguration.getMainClass());
-        commandLine.add(invocationSettings.getProjectDir().toString());
+        commandLine.add(invocationSettings.getProjectDir().getAbsolutePath());
         System.out.println("* Using command line: " + commandLine);
 
         return new CommandExec().inDir(studioInstallDir.toFile()).start(commandLine);


### PR DESCRIPTION
First commit fixes the case where running the profiler from inside the project under test directory passing `.` as the project dir by using an absolute path.

Second commit fixes the case where the path to studio install directory is actually a JetBrains Toolbox Launcher by resolving the actual Studio install directory from the launcher info file.

With these two fixes I was able to produce flame graphs for Studio Sync on my mac.