### PR TITLE
Remove all of the transforms cache dir

### DIFF
--- a/src/main/java/org/gradle/profiler/mutations/ClearArtifactTransformCacheMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ClearArtifactTransformCacheMutator.java
@@ -4,10 +4,6 @@ import com.typesafe.config.Config;
 import org.gradle.profiler.BuildMutator;
 
 import java.io.File;
-import java.io.FilenameFilter;
-import java.util.Arrays;
-import java.util.Objects;
-import java.util.stream.Stream;
 
 public class ClearArtifactTransformCacheMutator extends AbstractCacheCleanupMutator {
 
@@ -17,15 +13,7 @@ public class ClearArtifactTransformCacheMutator extends AbstractCacheCleanupMuta
 
     @Override
     protected void cleanupCacheDir(File cacheDir) {
-        filesAsStream(
-            cacheDir,
-            (dir, name) -> name.startsWith("files-")
-        ).flatMap(file -> filesAsStream(file, (dir, name) -> !name.endsWith(".lock")))
-            .forEach(AbstractCleanupMutator::delete);
-    }
-
-    private Stream<File> filesAsStream(File dir, FilenameFilter filter) {
-        return Arrays.stream(Objects.requireNonNull(dir.listFiles(filter)));
+        delete(cacheDir);
     }
 
     public static class Configurator extends AbstractCleanupMutator.Configurator {


### PR DESCRIPTION
This makes us independent of the structure of said directory. Gradle 6.8 will have a new structure for the directory: https://github.com/gradle/gradle/pull/14588.