### PR TITLE
Support passing JVM arguments with spaces to the Gradle daemon

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -7,7 +7,7 @@ jobs:
   enforce-label:
     runs-on: ubuntu-latest
     steps:
-    - uses: yogevbd/enforce-label-action@2.1.0
+    - uses: yogevbd/enforce-label-action@2.2.1
       with:
         REQUIRED_LABELS_ANY: "bug,enhancement,internal,no-changelog"
         REQUIRED_LABELS_ANY_DESCRIPTION: "Select at least one label ['bug','enhancement','internal','no-changelog'] for the PR"

--- a/src/main/java/org/gradle/profiler/CliGradleClient.java
+++ b/src/main/java/org/gradle/profiler/CliGradleClient.java
@@ -44,10 +44,7 @@ public class CliGradleClient implements GradleInvoker, GradleClient {
 
     @Override
     public void runTasks(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
-        String gradleOpts = jvmArgs.stream()
-            .peek(arg -> { if (arg.contains("\"") || arg.contains("'")) { throw new IllegalArgumentException("jvmArgs must not contain quotes, but this argument does: " + arg); } })
-            .map(arg -> "'" + arg + "'")
-            .collect(Collectors.joining(" "));
+        String gradleOpts = quoteJvmArguments(daemon, jvmArgs);
 
         List<String> commandLine = new ArrayList<>();
         gradleBuildConfiguration.addGradleCommand(commandLine);
@@ -84,5 +81,17 @@ public class CliGradleClient implements GradleInvoker, GradleClient {
             System.out.println();
             throw new RuntimeException("Build failed.", e);
         }
+    }
+
+    private static String quoteJvmArguments(boolean forSystemProperty, List<String> jvmArgs) {
+        char quotes = forSystemProperty ? '\'' : '"';
+        return jvmArgs.stream()
+            .peek(arg -> {
+                if (arg.contains("\"") || arg.contains("'")) {
+                    throw new IllegalArgumentException("jvmArgs must not contain quotes, but this argument does: " + arg);
+                }
+            })
+            .map(arg -> quotes + arg + quotes)
+            .collect(Collectors.joining(" "));
     }
 }

--- a/src/main/java/org/gradle/profiler/CliGradleClient.java
+++ b/src/main/java/org/gradle/profiler/CliGradleClient.java
@@ -44,23 +44,27 @@ public class CliGradleClient implements GradleInvoker, GradleClient {
 
     @Override
     public void runTasks(List<String> tasks, List<String> gradleArgs, List<String> jvmArgs) {
-        String gradleOpts = jvmArgs.stream().map(arg -> '"' + arg + '"').collect(Collectors.joining(" "));
+        String gradleOpts = jvmArgs.stream()
+            .peek(arg -> { if (arg.contains("\"") || arg.contains("'")) { throw new IllegalArgumentException("jvmArgs must not contain quotes, but this argument does: " + arg); } })
+            .map(arg -> "'" + arg + "'")
+            .collect(Collectors.joining(" "));
 
         List<String> commandLine = new ArrayList<>();
         gradleBuildConfiguration.addGradleCommand(commandLine);
         commandLine.addAll(gradleArgs);
         commandLine.addAll(tasks);
         commandLine.add("-Dorg.gradle.daemon=" + daemon);
-        if (daemon) {
-            commandLine.add("-Dorg.gradle.jvmargs=" + gradleOpts);
-        } else {
+        if (!daemon) {
             commandLine.add("-Dorg.gradle.jvmargs");
         }
 
         ProcessBuilder builder = new ProcessBuilder(commandLine);
         builder.directory(projectDir);
         if (daemon) {
-            builder.environment().put("GRADLE_OPTS", "-Xmx128m -Xms128m -XX:+HeapDumpOnOutOfMemoryError");
+            String orgGradleJvmArgs = jvmArgs.isEmpty()
+                ? ""
+                : " \"-Dorg.gradle.jvmargs=" + gradleOpts + "\"";
+            builder.environment().put("GRADLE_OPTS", "-Xmx128m -Xms128m -XX:+HeapDumpOnOutOfMemoryError" + orgGradleJvmArgs);
         } else {
             Logging.detailed().println("GRADLE_OPTS: " + gradleOpts);
             builder.environment().put("GRADLE_OPTS", gradleOpts);

--- a/src/test/groovy/org/gradle/profiler/GradleInvocationIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/GradleInvocationIntegrationTest.groovy
@@ -176,7 +176,7 @@ class GradleInvocationIntegrationTest extends AbstractProfilerIntegrationTest {
                 run-using = ${runUsing}
                 daemon = $daemon
                 tasks = assemble
-                jvm-args = "-DmySystemProperty=I have spaces!"
+                jvm-args = ["-DmySystemProperty=I have spaces!", "-Xms128m"]
             }
         """
 


### PR DESCRIPTION
When passing JVM arguments with spaces to the Gradle daemon, Gradle profiler failed on Windows when using the CLI invoker. This PR fixes the problem by passing in `org.gradle.jvmargs` via `GRADLE_OPTS` to the client.