### PR TITLE
Fix pid instrumentation on Eclipse J9

### DIFF
--- a/subprojects/build-operations/build.gradle
+++ b/subprojects/build-operations/build.gradle
@@ -1,7 +1,0 @@
-plugins {
-    id 'profiler.embedded-library'
-}
-
-dependencies {
-    api gradleApi()
-}

--- a/subprojects/build-operations/build.gradle.kts
+++ b/subprojects/build-operations/build.gradle.kts
@@ -1,0 +1,18 @@
+plugins {
+    id("profiler.embedded-library")
+}
+
+dependencies {
+    api(gradleApi())
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
+tasks.withType<AbstractCompile>().configureEach {
+    targetCompatibility = "8"
+    sourceCompatibility = "8"
+}

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/pid/AbstractPidCollectorBuildService.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/pid/AbstractPidCollectorBuildService.java
@@ -1,0 +1,37 @@
+package org.gradle.trace.pid;
+
+import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.internal.GradleInternal;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+import org.gradle.build.event.BuildEventsListenerRegistry;
+import org.gradle.tooling.events.FinishEvent;
+import org.gradle.tooling.events.OperationCompletionListener;
+import org.gradle.util.GFileUtils;
+
+import java.io.File;
+
+public abstract class AbstractPidCollectorBuildService implements BuildService<AbstractPidCollectorBuildService.Parameters>, OperationCompletionListener {
+
+    public static <T extends AbstractPidCollectorBuildService> void registerBuildService(Class<T> buildServiceClass, GradleInternal gradle, File outFile) {
+        Provider<T> pidCollectorService = gradle.getSharedServices().registerIfAbsent("pidCollector", buildServiceClass, spec -> spec.parameters(
+            params -> params.getPidFile().set(outFile)
+        ));
+        gradle.getServices().get(BuildEventsListenerRegistry.class).onTaskCompletion(pidCollectorService);
+    }
+
+    public interface Parameters extends BuildServiceParameters {
+        RegularFileProperty getPidFile();
+    }
+
+    protected AbstractPidCollectorBuildService() {
+        GFileUtils.writeFile(getPid().toString(), getParameters().getPidFile().get().getAsFile());
+    }
+
+    protected abstract Long getPid();
+
+    @Override
+    public void onFinish(FinishEvent event) {
+    }
+}

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/pid/PidCollector.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/pid/PidCollector.java
@@ -1,5 +1,6 @@
 package org.gradle.trace.pid;
 
+import org.gradle.api.JavaVersion;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.internal.nativeintegration.ProcessEnvironment;
 import org.gradle.util.GFileUtils;
@@ -14,7 +15,11 @@ public class PidCollector {
         ProcessEnvironment processEnvironment = gradle.getServices().get(ProcessEnvironment.class);
         GFileUtils.writeFile(processEnvironment.getPid().toString(), outFile);
         if (GradleVersion.current().compareTo(GradleVersion.version("6.1")) >= 0) {
-            PidCollectorBuildService.registerBuildService(gradle, outFile);
+            if (JavaVersion.current().isJava9Compatible()) {
+                AbstractPidCollectorBuildService.registerBuildService(PidCollectorBuildService.class, gradle, outFile);
+            } else {
+                AbstractPidCollectorBuildService.registerBuildService(PidCollectorJava8BuildService.class, gradle, outFile);
+            }
         }
     }
 }

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/pid/PidCollectorBuildService.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/pid/PidCollectorBuildService.java
@@ -1,53 +1,9 @@
 package org.gradle.trace.pid;
 
-import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.internal.GradleInternal;
-import org.gradle.api.provider.Provider;
-import org.gradle.api.services.BuildService;
-import org.gradle.api.services.BuildServiceParameters;
-import org.gradle.build.event.BuildEventsListenerRegistry;
-import org.gradle.tooling.events.FinishEvent;
-import org.gradle.tooling.events.OperationCompletionListener;
-import org.gradle.util.GFileUtils;
-
-import java.io.File;
-import java.lang.management.ManagementFactory;
-import java.lang.management.RuntimeMXBean;
-import java.lang.reflect.InvocationTargetException;
-
-public abstract class PidCollectorBuildService implements BuildService<PidCollectorBuildService.Parameters>, OperationCompletionListener {
-
-    public static void registerBuildService(GradleInternal gradle, File outFile) {
-        Provider<PidCollectorBuildService> pidCollectorService = gradle.getSharedServices().registerIfAbsent("pidCollector", PidCollectorBuildService.class, spec -> spec.parameters(
-            params -> params.getPidFile().set(outFile)
-        ));
-        gradle.getServices().get(BuildEventsListenerRegistry.class).onTaskCompletion(pidCollectorService);
-    }
-
-    public interface Parameters extends BuildServiceParameters {
-        RegularFileProperty getPidFile();
-    }
-
-    public PidCollectorBuildService() throws Exception {
-        GFileUtils.writeFile(getPid().toString(), getParameters().getPidFile().get().getAsFile());
-    }
-
-    private Integer getPid() throws NoSuchFieldException, IllegalAccessException, NoSuchMethodException, InvocationTargetException {
-        // With Gradle 6.6 we can't inject `ProcessEnvironment`, so that is why we access the runtime MXBean here.
-        // On Java 9 we could use the nicer ProcessHandle.
-        RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
-        java.lang.reflect.Field jvm = runtime.getClass().getDeclaredField("jvm");
-        jvm.setAccessible(true);
-        sun.management.VMManagement mgmt =
-            (sun.management.VMManagement) jvm.get(runtime);
-        java.lang.reflect.Method pid_method =
-            mgmt.getClass().getDeclaredMethod("getProcessId");
-        pid_method.setAccessible(true);
-
-        return (Integer) pid_method.invoke(mgmt);
-    }
+public abstract class PidCollectorBuildService extends AbstractPidCollectorBuildService {
 
     @Override
-    public void onFinish(FinishEvent event) {
+    protected Long getPid() {
+        return ProcessHandle.current().pid();
     }
 }

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/pid/PidCollectorJava8BuildService.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/pid/PidCollectorJava8BuildService.java
@@ -1,0 +1,28 @@
+package org.gradle.trace.pid;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.lang.reflect.InvocationTargetException;
+
+public abstract class PidCollectorJava8BuildService extends AbstractPidCollectorBuildService {
+
+    @Override
+    protected Long getPid() {
+        try {
+            // With Gradle 6.6 we can't inject `ProcessEnvironment`, so that is why we access the runtime MXBean here.
+            // On Java 9 we could use the nicer ProcessHandle.
+            RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
+            java.lang.reflect.Field jvm = runtime.getClass().getDeclaredField("jvm");
+            jvm.setAccessible(true);
+            sun.management.VMManagement mgmt =
+                (sun.management.VMManagement) jvm.get(runtime);
+            java.lang.reflect.Method pid_method =
+                mgmt.getClass().getDeclaredMethod("getProcessId");
+            pid_method.setAccessible(true);
+
+            return ((Integer) pid_method.invoke(mgmt)).longValue();
+        } catch (NoSuchFieldException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/pid/PidCollectorJava8BuildService.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/pid/PidCollectorJava8BuildService.java
@@ -10,7 +10,7 @@ public abstract class PidCollectorJava8BuildService extends AbstractPidCollector
     protected Long getPid() {
         try {
             // With Gradle 6.6 we can't inject `ProcessEnvironment`, so that is why we access the runtime MXBean here.
-            // On Java 9 we could use the nicer ProcessHandle.
+            // On Java 9 we use `ProcessHandle` via `PidCollectorBuildService`.
             RuntimeMXBean runtime = ManagementFactory.getRuntimeMXBean();
             java.lang.reflect.Field jvm = runtime.getClass().getDeclaredField("jvm");
             jvm.setAccessible(true);


### PR DESCRIPTION
Use the `ProcessHandle` API when available instead of using the proprietary `MXBean`. This should fix the PID instrumentation when using Eclipse J9 JVM.

Fixes #294 
