### PR TITLE
Allow apply-cpp-change-to for other file extensions as well

### DIFF
--- a/src/main/java/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutator.java
@@ -1,31 +1,31 @@
 package org.gradle.profiler.mutations;
 
+import com.google.common.collect.ImmutableSet;
+
 import org.apache.commons.io.FilenameUtils;
 import org.gradle.profiler.BuildContext;
 
 import java.io.File;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ApplyChangeToNativeSourceFileMutator extends AbstractFileChangeMutator {
 
     // Both lists taken from https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html
-    private final List<String> nativeSourcecodeFileEndings = Arrays.asList(
-        ".c", ".cc", ".cp", ".cxx", ".cpp", ".CPP", ".c++", ".C"
+    private static final ImmutableSet<String> nativeSourcecodeFileEndings = ImmutableSet.of(
+        "c", "cc", "cp", "cxx", "cpp", "CPP", "c++", "C"
     );
 
-    private final List<String> nativeHeaderFileEndings = Arrays.asList(
-        ".h", ".hh", ".H", ".hp", ".hxx", ".hpp", ".HPP", ".h++", ".tcc"
+    private static final ImmutableSet<String> nativeHeaderFileEndings = ImmutableSet.of(
+        "h", "hh", "H", "hp", "hxx", "hpp", "HPP", "h++", "tcc"
     );
 
     public ApplyChangeToNativeSourceFileMutator(File file) {
         super(file);
-        String fileExtension = "." + FilenameUtils.getExtension(sourceFile.getName());
-        List<String> extensionList = Stream.concat(nativeSourcecodeFileEndings.stream(), nativeHeaderFileEndings.stream())
-            .collect(Collectors.toList());
-        if (extensionList.contains(fileExtension)) {
+        String fileExtension = FilenameUtils.getExtension(sourceFile.getName());
+        boolean isSupportedExtension = Stream.concat(nativeSourcecodeFileEndings.stream(), nativeHeaderFileEndings.stream())
+            .anyMatch(fileExtension::equals);
+
+        if (isSupportedExtension) {
             return;
         }
 
@@ -35,7 +35,7 @@ public class ApplyChangeToNativeSourceFileMutator extends AbstractFileChangeMuta
     @Override
     protected void applyChangeTo(BuildContext context, StringBuilder text) {
         int insertPos;
-        String fileExtension = "." + FilenameUtils.getExtension(sourceFile.getName());
+        String fileExtension = FilenameUtils.getExtension(sourceFile.getName());
         if (nativeSourcecodeFileEndings.contains(fileExtension)) {
             insertPos = text.length();
             applyChangeAt(context, text, insertPos);

--- a/src/main/java/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutator.java
@@ -28,7 +28,6 @@ public class ApplyChangeToNativeSourceFileMutator extends AbstractFileChangeMuta
         if (isSupportedExtension) {
             return;
         }
-
         throw new IllegalArgumentException("Can only modify C/C++ source or header files");
     }
 

--- a/src/main/java/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutator.java
@@ -1,22 +1,42 @@
 package org.gradle.profiler.mutations;
 
+import org.apache.commons.io.FilenameUtils;
 import org.gradle.profiler.BuildContext;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ApplyChangeToNativeSourceFileMutator extends AbstractFileChangeMutator {
 
+    // Both lists taken from https://gcc.gnu.org/onlinedocs/gcc/Overall-Options.html
+    private final List<String> nativeSourcecodeFileEndings = Arrays.asList(
+        ".c", ".cc", ".cp", ".cxx", ".cpp", ".CPP", ".c++", ".C"
+    );
+
+    private final List<String> nativeHeaderFileEndings = Arrays.asList(
+        ".h", ".hh", ".H", ".hp", ".hxx", ".hpp", ".HPP", ".h++", ".tcc"
+    );
+
     public ApplyChangeToNativeSourceFileMutator(File file) {
         super(file);
-        if (!sourceFile.getName().endsWith(".cpp") && !sourceFile.getName().endsWith(".h") && !sourceFile.getName().endsWith(".hpp")) {
-            throw new IllegalArgumentException("Can only modify C++ source or header files");
+        String fileExtension = "." + FilenameUtils.getExtension(sourceFile.getName());
+        List<String> extensionList = Stream.concat(nativeSourcecodeFileEndings.stream(), nativeHeaderFileEndings.stream())
+            .collect(Collectors.toList());
+        if (extensionList.contains(fileExtension)) {
+            return;
         }
+
+        throw new IllegalArgumentException("Can only modify C/C++ source or header files");
     }
 
     @Override
     protected void applyChangeTo(BuildContext context, StringBuilder text) {
         int insertPos;
-        if (sourceFile.getName().endsWith(".cpp")) {
+        String fileExtension = "." + FilenameUtils.getExtension(sourceFile.getName());
+        if (nativeSourcecodeFileEndings.contains(fileExtension)) {
             insertPos = text.length();
             applyChangeAt(context, text, insertPos);
         } else {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutatorTest.groovy
@@ -70,4 +70,13 @@ class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
         sourceFileH.text == "#ifndef ABC\n\nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7();\n#endif"
     }
 
+    def "complains when a file with not-allowed file extension is specified"() {
+        def file = tmpDir.newFile("Thing.png")
+
+        when:
+        new ApplyChangeToNativeSourceFileMutator(file)
+
+        then:
+        thrown(IllegalArgumentException)
+    }
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutatorTest.groovy
@@ -2,6 +2,18 @@ package org.gradle.profiler.mutations
 
 class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
 
+    def "adds and replaces method to end of c source file"() {
+        def sourceFile = tmpDir.newFile("Thing.c")
+        sourceFile.text = " "
+        def mutator = new ApplyChangeToNativeSourceFileMutator(sourceFile)
+
+        when:
+        mutator.beforeBuild(buildContext)
+
+        then:
+        sourceFile.text == " \nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7 () { }"
+    }
+
     def "adds and replaces method to end of cpp source file"() {
         def sourceFile = tmpDir.newFile("Thing.cpp")
         sourceFile.text = " "
@@ -27,14 +39,23 @@ class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
         sourceFile.text == "#ifndef ABC\n\nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7();\n#endif"
     }
 
-    def "uses same name for method in CPP and H files"() {
+    def "uses same name for method in C, CPP and H files"() {
+        def sourceFileC = tmpDir.newFile("Thing.c")
         def sourceFileCPP = tmpDir.newFile("Thing.cpp")
         def sourceFileH = tmpDir.newFile("Thing.h")
+        sourceFileC.text = " "
         sourceFileCPP.text = " "
         sourceFileH.text = "#ifndef ABC\n\n#endif"
 
+        def mutatorC = new ApplyChangeToNativeSourceFileMutator(sourceFileC)
         def mutatorCPP = new ApplyChangeToNativeSourceFileMutator(sourceFileCPP)
         def mutatorH = new ApplyChangeToNativeSourceFileMutator(sourceFileH)
+
+        when:
+        mutatorC.beforeBuild(buildContext)
+
+        then:
+        sourceFileC.text == " \nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7 () { }"
 
         when:
         mutatorCPP.beforeBuild(buildContext)


### PR DESCRIPTION
Fixes #304 
Use list of valid c/c++ source and header files instead of few hardcoded values 🥇 
Also added further tests.