### PR TITLE
Normalize stack frames with Lambda class names

### DIFF
--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerController.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerController.java
@@ -32,7 +32,7 @@ public class AsyncProfilerController implements InstrumentingProfiler.SnapshotCa
             sanitizers.add(new RemoveSystemThreads());
 
         }
-        sanitizers.add(COLLAPSE_BUILD_SCRIPTS, COLLAPSE_GRADLE_INFRASTRUCTURE, SIMPLE_NAMES);
+        sanitizers.add(COLLAPSE_BUILD_SCRIPTS, COLLAPSE_GRADLE_INFRASTRUCTURE, SIMPLE_NAMES, NORMALIZE_LAMBDA_NAMES);
         this.flamegraphSanitizer = new FlameGraphSanitizer(sanitizers.build().toArray(new SanitizeFunction[0]));
         this.flamegraphGenerator = new FlameGraphTool();
 

--- a/src/main/java/org/gradle/profiler/flamegraph/FlameGraphSanitizer.java
+++ b/src/main/java/org/gradle/profiler/flamegraph/FlameGraphSanitizer.java
@@ -52,6 +52,8 @@ public class FlameGraphSanitizer {
 
     public static final SanitizeFunction SIMPLE_NAMES = new ToSimpleName();
 
+    public static final SanitizeFunction NORMALIZE_LAMBDA_NAMES = new NormalizeLambda();
+
     private final SanitizeFunction sanitizeFunction;
 
     public FlameGraphSanitizer(SanitizeFunction... sanitizeFunctions) {
@@ -210,6 +212,15 @@ public class FlameGraphSanitizer {
                 }
             }
             return stack;
+        }
+    }
+
+    private static class NormalizeLambda extends FrameWiseSanitizeFunction {
+        @Override
+        protected String mapFrame(String frame) {
+            // Lambdas contain a name that's based on an index + timestamp at runtime and changes build-to-build.
+            // This makes comparing two builds very difficult when a lambda is in the stack
+            return frame.replaceFirst(Pattern.quote("$$Lambda$")+"[0-9/]+", "\\$\\$Lambda\\$");
         }
     }
 

--- a/src/main/java/org/gradle/profiler/flamegraph/FlameGraphSanitizer.java
+++ b/src/main/java/org/gradle/profiler/flamegraph/FlameGraphSanitizer.java
@@ -220,7 +220,7 @@ public class FlameGraphSanitizer {
         protected String mapFrame(String frame) {
             // Lambdas contain a name that's based on an index + timestamp at runtime and changes build-to-build.
             // This makes comparing two builds very difficult when a lambda is in the stack
-            return frame.replaceFirst(Pattern.quote("$$Lambda$")+"[0-9/]+", "\\$\\$Lambda\\$");
+            return frame.replaceFirst(Pattern.quote("$$Lambda$")+"[0-9]+[./][0-9]+", "\\$\\$Lambda\\$");
         }
     }
 

--- a/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
@@ -101,14 +101,14 @@ class JfrFlameGraphGenerator {
             true,
             Arrays.asList("--minwidth", "0.5"),
             Arrays.asList("--minwidth", "1"),
-            new FlameGraphSanitizer(FlameGraphSanitizer.COLLAPSE_BUILD_SCRIPTS)
+            new FlameGraphSanitizer(FlameGraphSanitizer.COLLAPSE_BUILD_SCRIPTS, FlameGraphSanitizer.NORMALIZE_LAMBDA_NAMES)
         ),
         SIMPLIFIED(
             false,
             false,
             Arrays.asList("--minwidth", "1"),
             Arrays.asList("--minwidth", "2"),
-            new FlameGraphSanitizer(FlameGraphSanitizer.COLLAPSE_BUILD_SCRIPTS, FlameGraphSanitizer.COLLAPSE_GRADLE_INFRASTRUCTURE, FlameGraphSanitizer.SIMPLE_NAMES)
+            new FlameGraphSanitizer(FlameGraphSanitizer.COLLAPSE_BUILD_SCRIPTS, FlameGraphSanitizer.COLLAPSE_GRADLE_INFRASTRUCTURE, FlameGraphSanitizer.SIMPLE_NAMES, FlameGraphSanitizer.NORMALIZE_LAMBDA_NAMES)
         );
 
         private final boolean showArguments;

--- a/src/test/groovy/org/gradle/profiler/flamegraph/FlameGraphSanitizerTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/flamegraph/FlameGraphSanitizerTest.groovy
@@ -6,6 +6,7 @@ class FlameGraphSanitizerTest extends Specification {
     def "normalizes lambda stack frames"() {
         def normalizer = FlameGraphSanitizer.NORMALIZE_LAMBDA_NAMES
         expect:
+        normalizer.map(['DefaultPlanExecutor$ExecutorWorker$$Lambda$887.1827771163.execute']) == ['DefaultPlanExecutor$ExecutorWorker$$Lambda$.execute']
         normalizer.map(['DefaultPlanExecutor$ExecutorWorker$$Lambda$887/1827771163.execute']) == ['DefaultPlanExecutor$ExecutorWorker$$Lambda$.execute']
     }
 }

--- a/src/test/groovy/org/gradle/profiler/flamegraph/FlameGraphSanitizerTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/flamegraph/FlameGraphSanitizerTest.groovy
@@ -1,0 +1,11 @@
+package org.gradle.profiler.flamegraph
+
+import spock.lang.Specification
+
+class FlameGraphSanitizerTest extends Specification {
+    def "normalizes lambda stack frames"() {
+        def normalizer = FlameGraphSanitizer.NORMALIZE_LAMBDA_NAMES
+        expect:
+        normalizer.map(['DefaultPlanExecutor$ExecutorWorker$$Lambda$887/1827771163.execute']) == ['DefaultPlanExecutor$ExecutorWorker$$Lambda$.execute']
+    }
+}


### PR DESCRIPTION
Lambda names are auto-generated and change from build to build. This
makes it difficult to compare flamegraphs since the stack may look very
different but ultimately be exactly the same