### PR TITLE
Consolidate file layout for profiles and flame graphs

### DIFF
--- a/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
+++ b/src/main/java/org/gradle/profiler/GradleScenarioDefinition.java
@@ -105,6 +105,13 @@ public class GradleScenarioDefinition extends ScenarioDefinition {
         return measuredBuildOperations;
     }
 
+    public boolean createsMultipleProcesses() {
+        if (getBuildCount() <= 1) {
+            return false;
+        }
+        return getInvoker().isDoesNotUseDaemon() || !getInvoker().isReuseDaemon();
+    }
+
     @Override
     public void visitProblems(InvocationSettings settings, Consumer<String> reporter) {
         if (getWarmUpCount() < 1) {

--- a/src/main/java/org/gradle/profiler/jfr/JFRControl.java
+++ b/src/main/java/org/gradle/profiler/jfr/JFRControl.java
@@ -37,8 +37,10 @@ public class JFRControl implements InstrumentingProfiler.SnapshotCapturingProfil
     }
 
     @Override
-    public void stopSession() throws IOException, InterruptedException {
-        new JfrFlameGraphGenerator().generateGraphs(jfrFile);
+    public void stopSession() {
+        String jfrFileName = jfrFile.getName();
+        String outputBaseName = jfrFileName.substring(0, jfrFileName.length() - 4);
+        new JfrFlameGraphGenerator().generateGraphs(jfrFile, outputBaseName);
         System.out.println("Wrote profiling data to " + jfrFile.getPath());
     }
 

--- a/src/main/java/org/gradle/profiler/jfr/JFRControl.java
+++ b/src/main/java/org/gradle/profiler/jfr/JFRControl.java
@@ -11,6 +11,7 @@ public class JFRControl implements InstrumentingProfiler.SnapshotCapturingProfil
     private final JcmdRunner jcmd;
     private final JFRArgs jfrArgs;
     private final File jfrFile;
+    private int counter;
 
     public JFRControl(JFRArgs args, File jfrFile) {
         this.jcmd = new JcmdRunner();
@@ -24,8 +25,11 @@ public class JFRControl implements InstrumentingProfiler.SnapshotCapturingProfil
     }
 
     @Override
-    public void stopRecording(String pid) throws IOException, InterruptedException {
-        jcmd.run(pid, "JFR.stop", "name=profile", "filename=" + jfrFile.getAbsolutePath());
+    public void stopRecording(String pid) {
+        File outputFile = jfrFile.isDirectory()
+            ? new File(jfrFile, "jfr-" + (counter++) + ".jfr")
+            : jfrFile;
+        jcmd.run(pid, "JFR.stop", "name=profile", "filename=" + outputFile.getAbsolutePath());
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/jfr/JFRJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/jfr/JFRJvmArgsCalculator.java
@@ -38,7 +38,7 @@ public class JFRJvmArgsCalculator implements JvmArgsCalculator {
         if (profileOnStart) {
             if (java11OrLater) {
                 String dumpOnExit = captureOnExit
-                    ? ",dumponexit=true,filename=" + outputFile.getParentFile().getAbsolutePath()
+                    ? ",dumponexit=true,filename=" + outputFile.getAbsolutePath()
                     : "";
                 jvmArgs.add("-XX:StartFlightRecording=name=profile,settings=" + args.getJfrSettings() + dumpOnExit);
             } else {
@@ -46,7 +46,7 @@ public class JFRJvmArgsCalculator implements JvmArgsCalculator {
                 if (captureOnExit) {
                     flightRecorderOptions.append(",defaultrecording=true,dumponexit=true")
                         .append(",dumponexitpath=")
-                        .append(outputFile.getParentFile().getAbsolutePath());
+                        .append(outputFile.getAbsolutePath());
                 }
             }
         }

--- a/src/main/java/org/gradle/profiler/jfr/JFRJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/jfr/JFRJvmArgsCalculator.java
@@ -22,7 +22,8 @@ public class JFRJvmArgsCalculator implements JvmArgsCalculator {
 
     @Override
     public void calculateJvmArgs(List<String> jvmArgs) {
-        if (!JavaVersion.current().isJava11Compatible()) {
+        boolean java11OrLater = JavaVersion.current().isJava11Compatible();
+        if (!java11OrLater) {
             if (!isOracleVm()) {
                 throw new IllegalArgumentException("JFR is only supported on OpenJDK since Java 11 and Oracle JDK since Java 7");
             }
@@ -35,11 +36,18 @@ public class JFRJvmArgsCalculator implements JvmArgsCalculator {
         StringBuilder flightRecorderOptions = new StringBuilder("-XX:FlightRecorderOptions=stackdepth=1024");
 
         if (profileOnStart) {
-            jvmArgs.add("-XX:StartFlightRecording=name=profile,settings=" + args.getJfrSettings());
-            if (captureOnExit) {
-                flightRecorderOptions.append(",defaultrecording=true,dumponexit=true")
-                    .append(",dumponexitpath=")
-                    .append(outputFile.getParentFile().getAbsolutePath());
+            if (java11OrLater) {
+                String dumpOnExit = captureOnExit
+                    ? ",dumponexit=true,filename=" + outputFile.getParentFile().getAbsolutePath()
+                    : "";
+                jvmArgs.add("-XX:StartFlightRecording=name=profile,settings=" + args.getJfrSettings() + dumpOnExit);
+            } else {
+                jvmArgs.add("-XX:StartFlightRecording=name=profile,settings=" + args.getJfrSettings());
+                if (captureOnExit) {
+                    flightRecorderOptions.append(",defaultrecording=true,dumponexit=true")
+                        .append(",dumponexitpath=")
+                        .append(outputFile.getParentFile().getAbsolutePath());
+                }
             }
         }
 

--- a/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
@@ -111,14 +111,14 @@ class JfrFlameGraphGenerator {
             true,
             Arrays.asList("--minwidth", "0.5"),
             Arrays.asList("--minwidth", "1"),
-            new FlameGraphSanitizer(FlameGraphSanitizer.COLLAPSE_BUILD_SCRIPTS, FlameGraphSanitizer.NORMALIZE_LAMBDA_NAMES)
+            FlameGraphSanitizer.raw()
         ),
         SIMPLIFIED(
             false,
             false,
             Arrays.asList("--minwidth", "1"),
             Arrays.asList("--minwidth", "2"),
-            new FlameGraphSanitizer(FlameGraphSanitizer.COLLAPSE_BUILD_SCRIPTS, FlameGraphSanitizer.COLLAPSE_GRADLE_INFRASTRUCTURE, FlameGraphSanitizer.SIMPLE_NAMES, FlameGraphSanitizer.NORMALIZE_LAMBDA_NAMES)
+            FlameGraphSanitizer.simplified()
         );
 
         private final boolean showArguments;

--- a/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
@@ -1,5 +1,6 @@
 package org.gradle.profiler.jfr;
 
+import com.google.common.base.Joiner;
 import org.gradle.profiler.flamegraph.FlameGraphSanitizer;
 import org.gradle.profiler.flamegraph.FlameGraphTool;
 import org.openjdk.jmc.common.item.IItemCollection;
@@ -12,6 +13,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -25,10 +27,10 @@ import static org.gradle.profiler.jfr.JfrToStacksConverter.Options;
  * TODO create flame graph diffs between profiled versions
  */
 class JfrFlameGraphGenerator {
-    private JfrToStacksConverter stacksConverter = new JfrToStacksConverter();
-    private FlameGraphTool flameGraphGenerator = new FlameGraphTool();
+    private final JfrToStacksConverter stacksConverter = new JfrToStacksConverter();
+    private final FlameGraphTool flameGraphGenerator = new FlameGraphTool();
 
-    public void generateGraphs(File jfrFile) {
+    public void generateGraphs(File jfrFile, String outputBaseName) {
         if (!flameGraphGenerator.checkInstallation()) {
             return;
         }
@@ -46,59 +48,57 @@ class JfrFlameGraphGenerator {
             }).collect(Collectors.toList());
 
         try {
-            generateGraphs(jfrFile, recordings);
+            generateGraphs(jfrFile.getParentFile(), outputBaseName, recordings);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private void generateGraphs(File jfrFile, List<IItemCollection> recordings) throws IOException {
-        File flamegraphDir = new File(jfrFile.getParentFile(), jfrFile.getName() + "-flamegraphs");
+    private void generateGraphs(File flameGraphDirectory, String outputBaseName, List<IItemCollection> recordings) throws IOException {
         for (EventType type : EventType.values()) {
             for (DetailLevel level : DetailLevel.values()) {
-                File stacks = generateStacks(flamegraphDir, recordings, type, level);
+                String eventFileBaseName = Joiner.on("-").join(outputBaseName, type.getId(), level.name().toLowerCase(Locale.ROOT));
+                File stacks = generateStacks(flameGraphDirectory, eventFileBaseName, recordings, type, level);
                 if (stacks != null) {
-                    generateFlameGraph(stacks, type, level);
-                    generateIcicleGraph(stacks, type, level);
+                    generateFlameGraph(stacks, new File(flameGraphDirectory, eventFileBaseName + "-flames.svg"), type, level);
+                    generateIcicleGraph(stacks, new File(flameGraphDirectory, eventFileBaseName + "-icicles.svg"), type, level);
                 }
             }
         }
     }
 
     @Nullable
-    private File generateStacks(File baseDir, List<IItemCollection> recordings, EventType type, DetailLevel level) throws IOException {
+    private File generateStacks(File baseDir, String eventFileBaseName, List<IItemCollection> recordings, EventType type, DetailLevel level) throws IOException {
         File stacks = File.createTempFile("stacks", ".txt");
         stacksConverter.convertToStacks(recordings, stacks, new Options(type, level.isShowArguments(), level.isShowLineNumbers()));
         if (stacks.length() == 0) {
             stacks.delete();
             return null;
         }
-        File sanitizedStacks = stacksFileName(baseDir, type, level);
+        File sanitizedStacks = stacksFileName(baseDir, eventFileBaseName);
         level.getSanitizer().sanitize(stacks, sanitizedStacks);
         stacks.delete();
         return sanitizedStacks;
     }
 
-    private File stacksFileName(File baseDir, final EventType type, final DetailLevel level) {
-        return new File(baseDir, type.getId() + "/" + level.name().toLowerCase() + "/stacks.txt");
+    private File stacksFileName(File baseDir, String eventFileBaseName) {
+        return new File(baseDir, eventFileBaseName + "-stacks.txt");
     }
 
-    private void generateFlameGraph(File stacks, EventType type, DetailLevel level) {
+    private void generateFlameGraph(File stacks, File flames, EventType type, DetailLevel level) {
         if (stacks.length() == 0) {
             return;
         }
-        File flames = new File(stacks.getParentFile(), "flames.svg");
         List<String> options = new ArrayList<>();
         options.addAll(level.getFlameGraphOptions());
         options.addAll(Arrays.asList("--title", type.getDisplayName() + " Flame Graph", "--countname", type.getUnitOfMeasure()));
         flameGraphGenerator.generateFlameGraph(stacks, flames, options);
     }
 
-    private void generateIcicleGraph(File stacks, EventType type, DetailLevel level) {
+    private void generateIcicleGraph(File stacks, File icicles, EventType type, DetailLevel level) {
         if (stacks.length() == 0) {
             return;
         }
-        File icicles = new File(stacks.getParentFile(), "icicles.svg");
         List<String> options = new ArrayList<>();
         options.addAll(level.getIcicleGraphOptions());
         options.addAll(Arrays.asList("--title", type.getDisplayName() + " Icicle Graph", "--countname", type.getUnitOfMeasure(), "--reverse", "--invert", "--colors", "aqua"));
@@ -123,9 +123,9 @@ class JfrFlameGraphGenerator {
 
         private final boolean showArguments;
         private final boolean showLineNumbers;
-        private List<String> flameGraphOptions;
-        private List<String> icicleGraphOptions;
-        private FlameGraphSanitizer sanitizer;
+        private final List<String> flameGraphOptions;
+        private final List<String> icicleGraphOptions;
+        private final FlameGraphSanitizer sanitizer;
 
         DetailLevel(boolean showArguments, boolean showLineNumbers, List<String> flameGraphOptions, List<String> icicleGraphOptions, FlameGraphSanitizer sanitizer) {
             this.showArguments = showArguments;

--- a/src/main/java/org/gradle/profiler/jfr/JfrProfiler.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrProfiler.java
@@ -1,5 +1,6 @@
 package org.gradle.profiler.jfr;
 
+import org.gradle.profiler.GradleScenarioDefinition;
 import org.gradle.profiler.InstrumentingProfiler;
 import org.gradle.profiler.JvmArgsCalculator;
 import org.gradle.profiler.ScenarioSettings;
@@ -9,6 +10,7 @@ import java.util.function.Consumer;
 
 public class JfrProfiler extends InstrumentingProfiler {
     private static final String PROFILE_JFR_SUFFIX = ".jfr";
+    private static final String PROFILE_JFR_DIRECTORY_SUFFIX = "-jfr";
 
     private final JFRArgs jfrArgs;
 
@@ -43,7 +45,14 @@ public class JfrProfiler extends InstrumentingProfiler {
     }
 
     private File getJfrFile(ScenarioSettings settings) {
-        return new File(settings.getScenario().getOutputDir(), settings.getScenario().getProfileName() + PROFILE_JFR_SUFFIX);
+        GradleScenarioDefinition scenario = settings.getScenario();
+        if (scenario.createsMultipleProcesses()) {
+            File jfrFilesDirectory = new File(scenario.getOutputDir(), scenario.getProfileName() + PROFILE_JFR_DIRECTORY_SUFFIX);
+            jfrFilesDirectory.mkdirs();
+            return jfrFilesDirectory;
+        } else {
+             return new File(scenario.getOutputDir(), scenario.getProfileName() + PROFILE_JFR_SUFFIX);
+        }
     }
 
     @Override

--- a/src/test/groovy/org/gradle/profiler/AsyncProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AsyncProfilerIntegrationTest.groovy
@@ -17,8 +17,15 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         logFile.containsOne("<invocations: 3>")
 
         and:
-        new File(outputDir, "${latestSupportedGradleVersion}-flames.svg").file
-        new File(outputDir, "${latestSupportedGradleVersion}-icicles.svg").file
+        assertGraphsGenerated()
+    }
+
+    void assertGraphsGenerated(String event = "cpu") {
+        ["raw", "simplified"].each { type ->
+            assert new File(outputDir, "${latestSupportedGradleVersion}-${event}-${type}-flames.svg").file
+            assert new File(outputDir, "${latestSupportedGradleVersion}-${event}-${type}-icicles.svg").file
+        }
+
     }
 
     @Requires({ !OperatingSystem.isWindows() })
@@ -34,8 +41,7 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         logFile.containsOne("<invocations: 3>")
 
         and:
-        new File(outputDir, "${latestSupportedGradleVersion}-flames.svg").file
-        new File(outputDir, "${latestSupportedGradleVersion}-icicles.svg").file
+        assertGraphsGenerated("alloc")
     }
 
     @Requires({ !OperatingSystem.isWindows() })
@@ -51,8 +57,7 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         logFile.containsOne("<invocations: 4>")
 
         and:
-        new File(outputDir, "${latestSupportedGradleVersion}-flames.svg").file
-        new File(outputDir, "${latestSupportedGradleVersion}-icicles.svg").file
+        assertGraphsGenerated()
     }
 
     @Requires({ !OperatingSystem.isWindows() })
@@ -68,8 +73,7 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         logFile.find("<invocations: 1>").size() == 3
 
         and:
-        new File(outputDir, "${latestSupportedGradleVersion}-flames.svg").file
-        new File(outputDir, "${latestSupportedGradleVersion}-icicles.svg").file
+        assertGraphsGenerated()
     }
 
     @Requires({ !OperatingSystem.isWindows() })
@@ -86,8 +90,7 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         logFile.find("<invocations: 1>").size() == 3
 
         and:
-        new File(outputDir, "${latestSupportedGradleVersion}-flames.svg").file
-        new File(outputDir, "${latestSupportedGradleVersion}-icicles.svg").file
+        assertGraphsGenerated()
     }
 
     @Requires({ !OperatingSystem.isWindows() })
@@ -138,7 +141,9 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         logFile.containsOne("<invocations: 3>")
 
         and:
-        new File(outputDir, "a-b/a-b-${latestSupportedGradleVersion}-flames.svg").file
-        new File(outputDir, "a-b/a-b-${latestSupportedGradleVersion}-icicles.svg").file
+        ["raw", "simplified"].each { type ->
+            assert new File(outputDir, "a-b/a-b-${latestSupportedGradleVersion}-cpu-${type}-flames.svg").file
+            assert new File(outputDir, "a-b/a-b-${latestSupportedGradleVersion}-cpu-${type}-icicles.svg").file
+        }
     }
 }

--- a/src/test/groovy/org/gradle/profiler/JFRProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/JFRProfilerIntegrationTest.groovy
@@ -1,10 +1,7 @@
 package org.gradle.profiler
 
-import org.gradle.api.JavaVersion
-import spock.lang.IgnoreIf
 import spock.lang.Unroll
 
-@IgnoreIf({ JavaVersion.current().isJava11Compatible() }) // JFR doesn't work on Java 11, yet
 class JFRProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
     @Unroll
     def "can profile Gradle #versionUnderTest using JFR, tooling API and warm daemon"() {

--- a/src/test/groovy/org/gradle/profiler/JFRProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/JFRProfilerIntegrationTest.groovy
@@ -139,6 +139,31 @@ class JFRProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
     }
 
     @Unroll
+    def "can profile Gradle #versionUnderTest using JFR with #iterations iterations"() {
+        given:
+        instrumentedBuildScript()
+
+        when:
+        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", versionUnderTest, "--profile", "jfr", "--iterations", iterations.toString(), "--cold-daemon", "--cli", "assemble")
+
+        def jfrFileDirectory = findJfrDirectory(iterations)
+
+        then:
+        // Probe version, 1 warm up, <iteration> builds
+        logFile.containsOne("* Running scenario using Gradle $versionUnderTest (scenario 1/1)")
+        logFile.find("* Running warm-up build").size() == 1
+        logFile.find("* Running measured build").size() == iterations
+        logFile.find("<invocations: 1>").size() == 2 + iterations
+
+        jfrFileDirectory.listFiles().findAll {it.name.endsWith(".jfr")}.size() == iterations
+
+        where:
+        versionUnderTest              | iterations
+        latestSupportedGradleVersion  | 1
+        latestSupportedGradleVersion  | 2
+    }
+
+    @Unroll
     def "can profile Gradle no daemon #versionUnderTest with #iterations iterations"(String versionUnderTest, int iterations) {
         given:
         instrumentedBuildScript()
@@ -154,6 +179,8 @@ class JFRProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
             "--no-daemon",
             "assemble")
 
+        def jfrFileDirectory = findJfrDirectory(iterations)
+
         then:
         // Probe version, 1 warm up, 2 build
         logFile.containsOne("* Running scenario using Gradle $versionUnderTest (scenario 1/1)")
@@ -165,7 +192,7 @@ class JFRProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         logFile.find("<tasks: [assemble]>").size() == 1 + iterations
         logFile.find("<invocations: 1>").size() == 2 + iterations
 
-        outputDir.listFiles().findAll { it.name.endsWith(".jfr") }.size() == iterations
+        jfrFileDirectory.listFiles().findAll { it.name.endsWith(".jfr") }.size() == iterations
         if (!OperatingSystem.isWindows()) {
             // No perl installed on Windows
             new File(outputDir, "${versionUnderTest}.jfr-flamegraphs").isDirectory()
@@ -200,7 +227,7 @@ class JFRProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--scenario-file", scenarioFile.absolutePath, "--gradle-version", minimalSupportedGradleVersion, "--profile", "jfr", "--iterations", "2", "--no-daemon", "assemble")
 
         then:
-        new File(outputDir, "assemble").listFiles().findAll { it.name.endsWith(".jfr") }.size() == 2
+        findJfrDirectory(2, new File(outputDir, "assemble")).listFiles().findAll { it.name.endsWith(".jfr") }.size() == 2
     }
 
     private File prepareBuild() {
@@ -213,5 +240,9 @@ class JFRProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
             }
         """
         return scenarioFile
+    }
+
+    private File findJfrDirectory(int iterations, File outputDir = this.outputDir) {
+        return iterations == 1 ? outputDir : outputDir.listFiles().find { it.name.endsWith("-jfr") }
     }
 }

--- a/src/test/groovy/org/gradle/profiler/JFRProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/JFRProfilerIntegrationTest.groovy
@@ -195,12 +195,12 @@ class JFRProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         jfrFileDirectory.listFiles().findAll { it.name.endsWith(".jfr") }.size() == iterations
         // No perl installed on Windows
         if (!OperatingSystem.isWindows()) {
-            // Events: alloc, cpu, monitor-locked / Type: raw, simplified
-            // Looks like no io stacks are in the JFR recording
-            int numberOfFlames = 3 * 2
-            assert outputDir.listFiles().findAll { it.name.endsWith("-flames.svg") }.size() == numberOfFlames
-            assert outputDir.listFiles().findAll { it.name.endsWith("-icicles.svg") }.size() == numberOfFlames
-            assert outputDir.listFiles().findAll { it.name.endsWith("-stacks.txt") }.size() == numberOfFlames
+            // Events: alloc, cpu / Type: raw, simplified
+            // Looks like monitor-locked and io mostly aren't captured
+            int numberOfFlames = 2 * 2
+            assert outputDir.listFiles().findAll { it.name.endsWith("-flames.svg") }.size() >= numberOfFlames
+            assert outputDir.listFiles().findAll { it.name.endsWith("-icicles.svg") }.size() >= numberOfFlames
+            assert outputDir.listFiles().findAll { it.name.endsWith("-stacks.txt") }.size() >= numberOfFlames
         }
         where:
         versionUnderTest              | iterations

--- a/src/test/groovy/org/gradle/profiler/JFRProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/JFRProfilerIntegrationTest.groovy
@@ -193,9 +193,14 @@ class JFRProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         logFile.find("<invocations: 1>").size() == 2 + iterations
 
         jfrFileDirectory.listFiles().findAll { it.name.endsWith(".jfr") }.size() == iterations
+        // No perl installed on Windows
         if (!OperatingSystem.isWindows()) {
-            // No perl installed on Windows
-            new File(outputDir, "${versionUnderTest}.jfr-flamegraphs").isDirectory()
+            // Events: alloc, cpu, monitor-locked / Type: raw, simplified
+            // Looks like no io stacks are in the JFR recording
+            int numberOfFlames = 3 * 2
+            assert outputDir.listFiles().findAll { it.name.endsWith("-flames.svg") }.size() == numberOfFlames
+            assert outputDir.listFiles().findAll { it.name.endsWith("-icicles.svg") }.size() == numberOfFlames
+            assert outputDir.listFiles().findAll { it.name.endsWith("-stacks.txt") }.size() == numberOfFlames
         }
         where:
         versionUnderTest              | iterations


### PR DESCRIPTION
Currently, the JFR profiler will generate a deeply nested structure of flame graphs, while async profiler puts all the flame graphs in one directory. We now consolidate this to end up with all the flame graphs in the scenario output directory:

```
├── 5.2.1-allocation-raw-flames.svg
├── 5.2.1-allocation-raw-icicles.svg
├── 5.2.1-allocation-raw-stacks.txt
├── 5.2.1-allocation-simplified-flames.svg
├── 5.2.1-allocation-simplified-icicles.svg
├── 5.2.1-allocation-simplified-stacks.txt
├── 5.2.1-cpu-raw-flames.svg
├── 5.2.1-cpu-raw-icicles.svg
├── 5.2.1-cpu-raw-stacks.txt
├── 5.2.1-cpu-simplified-flames.svg
├── 5.2.1-cpu-simplified-icicles.svg
├── 5.2.1-cpu-simplified-stacks.txt
├── 5.2.1-monitor-blocked-raw-flames.svg
├── 5.2.1-monitor-blocked-raw-icicles.svg
├── 5.2.1-monitor-blocked-raw-stacks.txt
├── 5.2.1-monitor-blocked-simplified-flames.svg
├── 5.2.1-monitor-blocked-simplified-icicles.svg
├── 5.2.1-monitor-blocked-simplified-stacks.txt
└── 5.2.1.jfr
```

We also include the event and the type in the file names for async profiler, so those will be the same as well.