### PR TITLE
Support capturing multiple events with async profiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ You can use async profiler to profile a Gradle build using `--profile async-prof
 
 Alternatively, you can also use `--profile async-profiler-heap` to profile heap allocations, with some reasonable default settings.
 
+Finally, you can also use `--profile async-profiler-all` to profile cpu, heap allocations, and locks with some reasonable default settings.
+
 By default, an Async profiler release will be downloaded from [Github](https://github.com/jvm-profiling-tools/async-profiler/releases) and installed, if not already available.
 
 The output are flame and icicle graphs which show you the call tree and hotspots of your code.
@@ -105,8 +107,9 @@ The following options are supported and closely mimic the options of Async profi
 - `--async-profiler-event`: The event to sample, e.g. `cpu` or `alloc`. Defaults to `cpu`
 - `--async-profiler-count`: The count to use when aggregating event data. Either `samples` or `total`. `total` is especially useful for allocation profiling. Defaults to `samples`
 - `--async-profiler-interval`: The sampling interval in ns, defaults to 10_000_000 (10ms)
+- `--async-profiler-alloc-interval`: The sampling interval in bytes for allocation profiling, defaults to 10 bytes. Corresponds to the `--alloc` command line option for Async profiler.
+- `--async-profiler-lock-threshold`: lock profiling threshold in nanoseconds, defaults to 1ns.
 - `--async-profiler-stackdepth`: The maximum stack depth. Lower this if profiles with deep recursion get too large. Defaults to 2048.
-- `--async-profiler-framebuffer`: The size of the frame buffer in bytes. Defaults to 10_000_000 (~10MB)
 - `--async-profiler-system-threads`: Whether to show system threads like GC and JIT compilation in the profile. Usually makes them harder to read, but can be useful if you suspect problems in that area. Defaults to `false` 
 
 You can also use either the `ASYNC_PROFILER_HOME` environment variable or the `--async-profiler-home` command line option to point to the Async profiler install directory.

--- a/README.md
+++ b/README.md
@@ -104,13 +104,13 @@ The output are flame and icicle graphs which show you the call tree and hotspots
 
 The following options are supported and closely mimic the options of Async profiler. Have a look at its readme to find out more about each option:
 
-- `--async-profiler-event`: The event to sample, e.g. `cpu` or `alloc`. Defaults to `cpu`
-- `--async-profiler-count`: The count to use when aggregating event data. Either `samples` or `total`. `total` is especially useful for allocation profiling. Defaults to `samples`
-- `--async-profiler-interval`: The sampling interval in ns, defaults to 10_000_000 (10ms)
+- `--async-profiler-event`: The event to sample, e.g. `cpu`, `wall`, `lock` or `alloc`. Defaults to `cpu`. Multiple events can be profiled by using this parameter multiple times.
+- `--async-profiler-count`: The count to use when aggregating event data. Either `samples` or `total`. `total` is especially useful for allocation profiling. Defaults to `samples`. Corresponds to the `--samples` and `--total` command line options for Async profiler.
+- `--async-profiler-interval`: The sampling interval in ns, defaults to 10_000_000 (10 ms).
 - `--async-profiler-alloc-interval`: The sampling interval in bytes for allocation profiling, defaults to 10 bytes. Corresponds to the `--alloc` command line option for Async profiler.
-- `--async-profiler-lock-threshold`: lock profiling threshold in nanoseconds, defaults to 1ns.
+- `--async-profiler-lock-threshold`: lock profiling threshold in nanoseconds, defaults to 1 ns. Corresponds to the `--lock` command line option for Async profiler.
 - `--async-profiler-stackdepth`: The maximum stack depth. Lower this if profiles with deep recursion get too large. Defaults to 2048.
-- `--async-profiler-system-threads`: Whether to show system threads like GC and JIT compilation in the profile. Usually makes them harder to read, but can be useful if you suspect problems in that area. Defaults to `false` 
+- `--async-profiler-system-threads`: Whether to show system threads like GC and JIT compilation in the profile. Usually makes them harder to read, but can be useful if you suspect problems in that area. Defaults to `false`. 
 
 You can also use either the `ASYNC_PROFILER_HOME` environment variable or the `--async-profiler-home` command line option to point to the Async profiler install directory.
 

--- a/src/main/java/org/gradle/profiler/ProfilerFactory.java
+++ b/src/main/java/org/gradle/profiler/ProfilerFactory.java
@@ -2,6 +2,7 @@ package org.gradle.profiler;
 
 import joptsimple.OptionParser;
 import joptsimple.OptionSet;
+import org.gradle.profiler.asyncprofiler.AsyncProfilerAllEventsProfilerFactory;
 import org.gradle.profiler.asyncprofiler.AsyncProfilerFactory;
 import org.gradle.profiler.asyncprofiler.AsyncProfilerHeapAllocationProfilerFactory;
 import org.gradle.profiler.buildscan.BuildScanProfilerFactory;
@@ -13,7 +14,11 @@ import org.gradle.profiler.yourkit.YourKitHeapAllocationProfilerFactory;
 import org.gradle.profiler.yourkit.YourKitSamplingProfilerFactory;
 import org.gradle.profiler.yourkit.YourKitTracingProfilerFactory;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
@@ -37,6 +42,7 @@ public abstract class ProfilerFactory {
             put("yourkit-heap", new YourKitHeapAllocationProfilerFactory());
             put("async-profiler", AsyncProfilerFactory.INSTANCE);
             put("async-profiler-heap", AsyncProfilerHeapAllocationProfilerFactory.INSTANCE);
+            put("async-profiler-all", AsyncProfilerAllEventsProfilerFactory.INSTANCE);
             put("heap-dump", new HeapDumpProfilerFactory());
             put("chrome-trace", new ChromeTraceProfilerFactory());
         }}

--- a/src/main/java/org/gradle/profiler/ScenarioSettings.java
+++ b/src/main/java/org/gradle/profiler/ScenarioSettings.java
@@ -22,7 +22,7 @@ public class ScenarioSettings {
         return scenario;
     }
 
-    public File getJfrProfilerOutputLocation() {
+    public File computeJfrProfilerOutputLocation() {
         GradleScenarioDefinition scenario = getScenario();
         if (scenario.createsMultipleProcesses()) {
             File jfrFilesDirectory = getProfilerOutputLocation(PROFILE_JFR_DIRECTORY_SUFFIX);

--- a/src/main/java/org/gradle/profiler/ScenarioSettings.java
+++ b/src/main/java/org/gradle/profiler/ScenarioSettings.java
@@ -1,6 +1,11 @@
 package org.gradle.profiler;
 
+import java.io.File;
+
 public class ScenarioSettings {
+    private static final String PROFILE_JFR_SUFFIX = ".jfr";
+    private static final String PROFILE_JFR_DIRECTORY_SUFFIX = "-jfr";
+
     private final InvocationSettings invocationSettings;
     private final GradleScenarioDefinition scenario;
 
@@ -15,5 +20,28 @@ public class ScenarioSettings {
 
     public GradleScenarioDefinition getScenario() {
         return scenario;
+    }
+
+    public File getJfrProfilerOutputLocation() {
+        GradleScenarioDefinition scenario = getScenario();
+        if (scenario.createsMultipleProcesses()) {
+            File jfrFilesDirectory = getProfilerOutputLocation(PROFILE_JFR_DIRECTORY_SUFFIX);
+            jfrFilesDirectory.mkdirs();
+            return jfrFilesDirectory;
+        } else {
+            return getProfilerOutputLocation(PROFILE_JFR_SUFFIX);
+        }
+    }
+
+    public File getProfilerOutputLocation(String suffix) {
+        return new File(getProfilerOutputBaseDir(), getProfilerOutputBaseName() + suffix);
+    }
+
+    public File getProfilerOutputBaseDir() {
+        return scenario.getOutputDir();
+    }
+
+    public String getProfilerOutputBaseName() {
+        return scenario.getProfileName();
     }
 }

--- a/src/main/java/org/gradle/profiler/ScenarioSettings.java
+++ b/src/main/java/org/gradle/profiler/ScenarioSettings.java
@@ -25,15 +25,15 @@ public class ScenarioSettings {
     public File computeJfrProfilerOutputLocation() {
         GradleScenarioDefinition scenario = getScenario();
         if (scenario.createsMultipleProcesses()) {
-            File jfrFilesDirectory = getProfilerOutputLocation(PROFILE_JFR_DIRECTORY_SUFFIX);
+            File jfrFilesDirectory = profilerOutputLocationFor(PROFILE_JFR_DIRECTORY_SUFFIX);
             jfrFilesDirectory.mkdirs();
             return jfrFilesDirectory;
         } else {
-            return getProfilerOutputLocation(PROFILE_JFR_SUFFIX);
+            return profilerOutputLocationFor(PROFILE_JFR_SUFFIX);
         }
     }
 
-    public File getProfilerOutputLocation(String suffix) {
+    public File profilerOutputLocationFor(String suffix) {
         return new File(getProfilerOutputBaseDir(), getProfilerOutputBaseName() + suffix);
     }
 

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfiler.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfiler.java
@@ -36,6 +36,11 @@ public class AsyncProfiler extends InstrumentingProfiler {
     }
 
     @Override
+    public void validate(ScenarioSettings settings, Consumer<String> reporter) {
+        validateMultipleIterationsWithCleanupAction(settings, reporter);
+    }
+
+    @Override
     public String toString() {
         return "async profiler";
     }

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfiler.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfiler.java
@@ -1,6 +1,5 @@
 package org.gradle.profiler.asyncprofiler;
 
-import org.gradle.profiler.GradleScenarioDefinition;
 import org.gradle.profiler.InstrumentingProfiler;
 import org.gradle.profiler.JvmArgsCalculator;
 import org.gradle.profiler.ScenarioSettings;
@@ -39,13 +38,5 @@ public class AsyncProfiler extends InstrumentingProfiler {
     @Override
     public String toString() {
         return "async profiler";
-    }
-
-    static File stacksFileFor(GradleScenarioDefinition scenario) {
-        return new File(scenario.getOutputDir(), scenario.getProfileName() + ".stacks.txt");
-    }
-
-    static File jfrFileFor(GradleScenarioDefinition scenario) {
-        return new File(scenario.getOutputDir(), scenario.getProfileName() + ".jfr");
     }
 }

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfiler.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfiler.java
@@ -21,7 +21,7 @@ public class AsyncProfiler extends InstrumentingProfiler {
             // Can attach later instead
             return JvmArgsCalculator.DEFAULT;
         }
-        return new AsyncProfilerJvmArgsCalculator(config, settings, captureSnapshotOnProcessExit);
+        return new AsyncProfilerJvmArgsCalculator(config, settings);
     }
 
     @Override
@@ -43,5 +43,9 @@ public class AsyncProfiler extends InstrumentingProfiler {
 
     static File stacksFileFor(GradleScenarioDefinition scenario) {
         return new File(scenario.getOutputDir(), scenario.getProfileName() + ".stacks.txt");
+    }
+
+    static File jfrFileFor(GradleScenarioDefinition scenario) {
+        return new File(scenario.getOutputDir(), scenario.getProfileName() + ".jfr");
     }
 }

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerAllEventsProfilerFactory.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerAllEventsProfilerFactory.java
@@ -17,7 +17,7 @@ public class AsyncProfilerAllEventsProfilerFactory extends ProfilerFactory {
     @Override
     public Profiler createFromOptions(OptionSet parsedOptions) {
         AsyncProfilerConfig config = asyncProfilerFactory.createConfig(parsedOptions);
-        AsyncProfilerConfig overrides = new AsyncProfilerConfig(config.getProfilerHome(), ImmutableList.of("cpu", "alloc", "lock"), AsyncProfilerConfig.Counter.SAMPLES, config.getInterval(), config.getStackDepth(), config.isIncludeSystemThreads());
+        AsyncProfilerConfig overrides = new AsyncProfilerConfig(config.getProfilerHome(), ImmutableList.of("cpu", "alloc", "lock"), AsyncProfilerConfig.Counter.SAMPLES, config.getInterval(), config.getAllocSampleSize(), config.getLockThreshold(), config.getStackDepth(), config.isIncludeSystemThreads());
         return new AsyncProfiler(overrides);
     }
 }

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerAllEventsProfilerFactory.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerAllEventsProfilerFactory.java
@@ -17,7 +17,7 @@ public class AsyncProfilerAllEventsProfilerFactory extends ProfilerFactory {
     @Override
     public Profiler createFromOptions(OptionSet parsedOptions) {
         AsyncProfilerConfig config = asyncProfilerFactory.createConfig(parsedOptions);
-        AsyncProfilerConfig overrides = new AsyncProfilerConfig(config.getProfilerHome(), ImmutableList.of("cpu", "alloc", "lock"), AsyncProfilerConfig.Counter.SAMPLES, 10, config.getStackDepth(), config.isIncludeSystemThreads());
+        AsyncProfilerConfig overrides = new AsyncProfilerConfig(config.getProfilerHome(), ImmutableList.of("cpu", "alloc", "lock"), AsyncProfilerConfig.Counter.SAMPLES, config.getInterval(), config.getStackDepth(), config.isIncludeSystemThreads());
         return new AsyncProfiler(overrides);
     }
 }

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerAllEventsProfilerFactory.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerAllEventsProfilerFactory.java
@@ -1,0 +1,23 @@
+package org.gradle.profiler.asyncprofiler;
+
+import com.google.common.collect.ImmutableList;
+import joptsimple.OptionSet;
+import org.gradle.profiler.Profiler;
+import org.gradle.profiler.ProfilerFactory;
+
+public class AsyncProfilerAllEventsProfilerFactory extends ProfilerFactory {
+    public static final ProfilerFactory INSTANCE = new AsyncProfilerAllEventsProfilerFactory(AsyncProfilerFactory.INSTANCE);
+
+    private final AsyncProfilerFactory asyncProfilerFactory;
+
+    public AsyncProfilerAllEventsProfilerFactory(AsyncProfilerFactory asyncProfilerFactory) {
+        this.asyncProfilerFactory = asyncProfilerFactory;
+    }
+
+    @Override
+    public Profiler createFromOptions(OptionSet parsedOptions) {
+        AsyncProfilerConfig config = asyncProfilerFactory.createConfig(parsedOptions);
+        AsyncProfilerConfig overrides = new AsyncProfilerConfig(config.getProfilerHome(), ImmutableList.of("cpu", "alloc", "lock"), AsyncProfilerConfig.Counter.SAMPLES, 10, config.getStackDepth(), config.isIncludeSystemThreads());
+        return new AsyncProfiler(overrides);
+    }
+}

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerConfig.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerConfig.java
@@ -8,16 +8,14 @@ public class AsyncProfilerConfig {
     private final Counter counter;
     private final int interval;
     private final int stackDepth;
-    private final int frameBuffer;
     private final boolean includeSystemThreads;
 
-    public AsyncProfilerConfig(File profilerHome, String event, Counter counter, int interval, int stackDepth, int frameBuffer, boolean includeSystemThreads) {
+    public AsyncProfilerConfig(File profilerHome, String event, Counter counter, int interval, int stackDepth, boolean includeSystemThreads) {
         this.profilerHome = profilerHome;
         this.event = event;
         this.counter = counter;
         this.interval = interval;
         this.stackDepth = stackDepth;
-        this.frameBuffer = frameBuffer;
         this.includeSystemThreads = includeSystemThreads;
     }
 
@@ -39,10 +37,6 @@ public class AsyncProfilerConfig {
 
     public int getStackDepth() {
         return stackDepth;
-    }
-
-    public int getFrameBuffer() {
-        return frameBuffer;
     }
 
     public boolean isIncludeSystemThreads() {

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerConfig.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerConfig.java
@@ -1,18 +1,21 @@
 package org.gradle.profiler.asyncprofiler;
 
+import com.google.common.base.Joiner;
+
 import java.io.File;
+import java.util.List;
 
 public class AsyncProfilerConfig {
     private final File profilerHome;
-    private final String event;
+    private final List<String> events;
     private final Counter counter;
     private final int interval;
     private final int stackDepth;
     private final boolean includeSystemThreads;
 
-    public AsyncProfilerConfig(File profilerHome, String event, Counter counter, int interval, int stackDepth, boolean includeSystemThreads) {
+    public AsyncProfilerConfig(File profilerHome, List<String> events, Counter counter, int interval, int stackDepth, boolean includeSystemThreads) {
         this.profilerHome = profilerHome;
-        this.event = event;
+        this.events = events;
         this.counter = counter;
         this.interval = interval;
         this.stackDepth = stackDepth;
@@ -23,8 +26,12 @@ public class AsyncProfilerConfig {
         return profilerHome;
     }
 
-    public String getEvent() {
-        return event;
+    public String getJoinedEvents() {
+        return Joiner.on(",").join(events);
+    }
+
+    public List<String> getEvents() {
+        return events;
     }
 
     public Counter getCounter() {

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerConfig.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerConfig.java
@@ -6,18 +6,25 @@ import java.io.File;
 import java.util.List;
 
 public class AsyncProfilerConfig {
+    public static final String EVENT_ALLOC = "alloc";
+    public static final String EVENT_LOCK = "lock";
+
     private final File profilerHome;
     private final List<String> events;
     private final Counter counter;
     private final int interval;
+    private final int allocSampleSize;
+    private final int lockThreshold;
     private final int stackDepth;
     private final boolean includeSystemThreads;
 
-    public AsyncProfilerConfig(File profilerHome, List<String> events, Counter counter, int interval, int stackDepth, boolean includeSystemThreads) {
+    public AsyncProfilerConfig(File profilerHome, List<String> events, Counter counter, int interval, int allocSampleSize, int lockThreshold, int stackDepth, boolean includeSystemThreads) {
         this.profilerHome = profilerHome;
         this.events = events;
         this.counter = counter;
         this.interval = interval;
+        this.allocSampleSize = allocSampleSize;
+        this.lockThreshold = lockThreshold;
         this.stackDepth = stackDepth;
         this.includeSystemThreads = includeSystemThreads;
     }
@@ -40,6 +47,14 @@ public class AsyncProfilerConfig {
 
     public int getInterval() {
         return interval;
+    }
+
+    public int getAllocSampleSize() {
+        return allocSampleSize;
+    }
+
+    public int getLockThreshold() {
+        return lockThreshold;
     }
 
     public int getStackDepth() {

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerController.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerController.java
@@ -117,13 +117,13 @@ public class AsyncProfilerController implements InstrumentingProfiler.SnapshotCa
 
     private JfrFlameGraphGenerator.Stacks sanitizeStacks(File outputDir, String outputBaseName, File stacksFileToConvert, JfrToStacksConverter.EventType jfrEventType, JfrFlameGraphGenerator.DetailLevel level) {
         FlameGraphSanitizer flamegraphSanitizer = flameGraphSanitizers.get(level);
-        String eventFileBaseName = getEventFileBaseName(outputBaseName, jfrEventType, level);
+        String eventFileBaseName = eventFileBaseNameFor(outputBaseName, jfrEventType, level);
         File sanitizedStacksFile = new File(outputDir, eventFileBaseName + "-stacks.txt");
         flamegraphSanitizer.sanitize(stacksFileToConvert, sanitizedStacksFile);
         return new JfrFlameGraphGenerator.Stacks(sanitizedStacksFile, jfrEventType, level, eventFileBaseName);
     }
 
-    private String getEventFileBaseName(String outputBaseName, JfrToStacksConverter.EventType type, JfrFlameGraphGenerator.DetailLevel level) {
+    private String eventFileBaseNameFor(String outputBaseName, JfrToStacksConverter.EventType type, JfrFlameGraphGenerator.DetailLevel level) {
         return Joiner.on("-").join(outputBaseName, type.getId(), level.name().toLowerCase(Locale.ROOT));
     }
 

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerController.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerController.java
@@ -47,7 +47,6 @@ public class AsyncProfilerController implements InstrumentingProfiler.SnapshotCa
             "-e", profilerConfig.getEvent(),
             "-i", String.valueOf(profilerConfig.getInterval()),
             "-j", String.valueOf(profilerConfig.getStackDepth()),
-            "-b", String.valueOf(profilerConfig.getFrameBuffer()),
             pid
         );
     }

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerController.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerController.java
@@ -52,7 +52,7 @@ public class AsyncProfilerController implements InstrumentingProfiler.SnapshotCa
             "-i", String.valueOf(profilerConfig.getInterval()),
             "-j", String.valueOf(profilerConfig.getStackDepth()),
             "-o", outputType.getCommandLineOption(),
-            "-f", outputFile.getAbsolutePath(),
+            "-f", outputType.individualOutputFileFor(scenarioSettings).getAbsolutePath(),
             pid
         );
     }
@@ -63,7 +63,7 @@ public class AsyncProfilerController implements InstrumentingProfiler.SnapshotCa
             getProfilerScript().getAbsolutePath(),
             "stop",
             "-o", outputType.getCommandLineOption(),
-            "-f", outputFile.getAbsolutePath(),
+            "-f", outputType.individualOutputFileFor(scenarioSettings).getAbsolutePath(),
             "-a",
             pid
         );

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerController.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerController.java
@@ -4,7 +4,6 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import org.gradle.profiler.CommandExec;
-import org.gradle.profiler.GradleScenarioDefinition;
 import org.gradle.profiler.InstrumentingProfiler;
 import org.gradle.profiler.ScenarioSettings;
 import org.gradle.profiler.flamegraph.FlameGraphSanitizer;
@@ -90,9 +89,8 @@ public class AsyncProfilerController implements InstrumentingProfiler.SnapshotCa
 
     @Override
     public void stopSession() {
-        GradleScenarioDefinition scenario = scenarioSettings.getScenario();
-        List<JfrFlameGraphGenerator.Stacks> stacks = generateStacks(scenario.getOutputDir(), scenario.getProfileName());
-        flameGraphGenerator.generateGraphs(scenario.getOutputDir(), stacks);
+        List<JfrFlameGraphGenerator.Stacks> stacks = generateStacks(scenarioSettings.getProfilerOutputBaseDir(), scenarioSettings.getProfilerOutputBaseName());
+        flameGraphGenerator.generateGraphs(scenarioSettings.getProfilerOutputBaseDir(), stacks);
     }
 
     private List<JfrFlameGraphGenerator.Stacks> generateStacks(File outputDir, String outputBaseName) {

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerController.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerController.java
@@ -36,7 +36,7 @@ public class AsyncProfilerController implements InstrumentingProfiler.SnapshotCa
             : FlameGraphSanitizer.simplified(new RemoveSystemThreads());
         this.flameGraphGenerator = new JfrFlameGraphGenerator();
         this.outputType = AsyncProfilerOutputType.from(profilerConfig, scenarioSettings.getScenario());
-        this.outputFile = outputType.outputFileFor(scenarioSettings.getScenario());
+        this.outputFile = outputType.outputFileFor(scenarioSettings);
     }
 
     public String getName() {

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerDownload.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerDownload.java
@@ -25,7 +25,7 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
  * Downloads a version of async profiler and installs into ~/.gradle-profiler-dist.
  */
 public class AsyncProfilerDownload {
-    private static final String ASYNC_PROFILER_VERSION = "1.8.2";
+    private static final String ASYNC_PROFILER_VERSION = "2.0";
 
     /**
      * Attempts to locate a default install of async profiler. Uses a previously downloaded installation, or downloads if not available.

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerFactory.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerFactory.java
@@ -18,7 +18,6 @@ public class AsyncProfilerFactory extends ProfilerFactory {
     private ArgumentAcceptingOptionSpec<File> profilerHomeOption;
     private ArgumentAcceptingOptionSpec<String> eventOption;
     private ArgumentAcceptingOptionSpec<AsyncProfilerConfig.Counter> counterOption;
-    private ArgumentAcceptingOptionSpec<Integer> frameBufferOption;
     private ArgumentAcceptingOptionSpec<Integer> intervalOption;
     private ArgumentAcceptingOptionSpec<Integer> stackDepthOption;
     private ArgumentAcceptingOptionSpec<Boolean> systemThreadOption;
@@ -48,11 +47,6 @@ public class AsyncProfilerFactory extends ProfilerFactory {
             .withRequiredArg()
             .ofType(Integer.class)
             .defaultsTo(2048);
-        frameBufferOption = parser.accepts("async-profiler-framebuffer", "The size of the frame buffer in bytes.")
-            .availableIf("profile")
-            .withRequiredArg()
-            .ofType(Integer.class)
-            .defaultsTo(10_000_000);
         systemThreadOption = parser.accepts("async-profiler-system-threads", "Whether to show system threads like GC and JIT compiler.")
             .availableIf("profile")
             .withRequiredArg()
@@ -72,9 +66,8 @@ public class AsyncProfilerFactory extends ProfilerFactory {
         AsyncProfilerConfig.Counter counter = counterOption.value(parsedOptions);
         int interval = intervalOption.value(parsedOptions);
         int stackDepth = stackDepthOption.value(parsedOptions);
-        int frameBuffer = frameBufferOption.value(parsedOptions);
         Boolean showSystemThreads = systemThreadOption.value(parsedOptions);
-        return new AsyncProfilerConfig(profilerHome, event, counter, interval, stackDepth, frameBuffer, showSystemThreads);
+        return new AsyncProfilerConfig(profilerHome, event, counter, interval, stackDepth, showSystemThreads);
     }
 
     private File getProfilerHome(OptionSet parsedOptions) {

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerFactory.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerFactory.java
@@ -9,6 +9,7 @@ import org.gradle.profiler.Profiler;
 import org.gradle.profiler.ProfilerFactory;
 
 import java.io.File;
+import java.util.List;
 import java.util.Locale;
 
 public class AsyncProfilerFactory extends ProfilerFactory {
@@ -62,12 +63,12 @@ public class AsyncProfilerFactory extends ProfilerFactory {
 
     AsyncProfilerConfig createConfig(OptionSet parsedOptions) {
         File profilerHome = getProfilerHome(parsedOptions);
-        String event = eventOption.value(parsedOptions);
+        List<String> events = eventOption.values(parsedOptions);
         AsyncProfilerConfig.Counter counter = counterOption.value(parsedOptions);
         int interval = intervalOption.value(parsedOptions);
         int stackDepth = stackDepthOption.value(parsedOptions);
         Boolean showSystemThreads = systemThreadOption.value(parsedOptions);
-        return new AsyncProfilerConfig(profilerHome, event, counter, interval, stackDepth, showSystemThreads);
+        return new AsyncProfilerConfig(profilerHome, events, counter, interval, stackDepth, showSystemThreads);
     }
 
     private File getProfilerHome(OptionSet parsedOptions) {

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerFactory.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerFactory.java
@@ -20,6 +20,8 @@ public class AsyncProfilerFactory extends ProfilerFactory {
     private ArgumentAcceptingOptionSpec<String> eventOption;
     private ArgumentAcceptingOptionSpec<AsyncProfilerConfig.Counter> counterOption;
     private ArgumentAcceptingOptionSpec<Integer> intervalOption;
+    private ArgumentAcceptingOptionSpec<Integer> allocIntervalOption;
+    private ArgumentAcceptingOptionSpec<Integer> lockThresholdOption;
     private ArgumentAcceptingOptionSpec<Integer> stackDepthOption;
     private ArgumentAcceptingOptionSpec<Boolean> systemThreadOption;
 
@@ -43,6 +45,16 @@ public class AsyncProfilerFactory extends ProfilerFactory {
             .withRequiredArg()
             .ofType(Integer.class)
             .defaultsTo(10_000_000);
+        allocIntervalOption = parser.accepts("async-profiler-alloc-interval", "The sampling interval in bytes for allocation profiling.")
+            .availableIf("profile")
+            .withRequiredArg()
+            .ofType(Integer.class)
+            .defaultsTo(10);
+        lockThresholdOption = parser.accepts("async-profiler-lock-threshold", "lock profiling threshold in nanoseconds")
+            .availableIf("profile")
+            .withRequiredArg()
+            .ofType(Integer.class)
+            .defaultsTo(1);
         stackDepthOption = parser.accepts("async-profiler-stackdepth", "The maximum Java stack depth.")
             .availableIf("profile")
             .withRequiredArg()
@@ -66,9 +78,11 @@ public class AsyncProfilerFactory extends ProfilerFactory {
         List<String> events = eventOption.values(parsedOptions);
         AsyncProfilerConfig.Counter counter = counterOption.value(parsedOptions);
         int interval = intervalOption.value(parsedOptions);
+        int allocInterval = allocIntervalOption.value(parsedOptions);
+        int lockThreshold = lockThresholdOption.value(parsedOptions);
         int stackDepth = stackDepthOption.value(parsedOptions);
         Boolean showSystemThreads = systemThreadOption.value(parsedOptions);
-        return new AsyncProfilerConfig(profilerHome, events, counter, interval, stackDepth, showSystemThreads);
+        return new AsyncProfilerConfig(profilerHome, events, counter, interval, allocInterval, lockThreshold, stackDepth, showSystemThreads);
     }
 
     private File getProfilerHome(OptionSet parsedOptions) {

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerHeapAllocationProfilerFactory.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerHeapAllocationProfilerFactory.java
@@ -17,7 +17,7 @@ public class AsyncProfilerHeapAllocationProfilerFactory extends ProfilerFactory 
     @Override
     public Profiler createFromOptions(OptionSet parsedOptions) {
         AsyncProfilerConfig config = asyncProfilerFactory.createConfig(parsedOptions);
-        AsyncProfilerConfig overrides = new AsyncProfilerConfig(config.getProfilerHome(), ImmutableList.of("alloc"), AsyncProfilerConfig.Counter.TOTAL, 10, config.getStackDepth(), config.isIncludeSystemThreads());
+        AsyncProfilerConfig overrides = new AsyncProfilerConfig(config.getProfilerHome(), ImmutableList.of("alloc"), AsyncProfilerConfig.Counter.TOTAL, config.getInterval(), config.getAllocSampleSize(), config.getLockThreshold(), config.getStackDepth(), config.isIncludeSystemThreads());
         return new AsyncProfiler(overrides);
     }
 }

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerHeapAllocationProfilerFactory.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerHeapAllocationProfilerFactory.java
@@ -1,5 +1,6 @@
 package org.gradle.profiler.asyncprofiler;
 
+import com.google.common.collect.ImmutableList;
 import joptsimple.OptionSet;
 import org.gradle.profiler.Profiler;
 import org.gradle.profiler.ProfilerFactory;
@@ -16,7 +17,7 @@ public class AsyncProfilerHeapAllocationProfilerFactory extends ProfilerFactory 
     @Override
     public Profiler createFromOptions(OptionSet parsedOptions) {
         AsyncProfilerConfig config = asyncProfilerFactory.createConfig(parsedOptions);
-        AsyncProfilerConfig overrides = new AsyncProfilerConfig(config.getProfilerHome(), "alloc", AsyncProfilerConfig.Counter.TOTAL, 10, config.getStackDepth(), config.isIncludeSystemThreads());
+        AsyncProfilerConfig overrides = new AsyncProfilerConfig(config.getProfilerHome(), ImmutableList.of("alloc"), AsyncProfilerConfig.Counter.TOTAL, 10, config.getStackDepth(), config.isIncludeSystemThreads());
         return new AsyncProfiler(overrides);
     }
 }

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerHeapAllocationProfilerFactory.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerHeapAllocationProfilerFactory.java
@@ -16,7 +16,7 @@ public class AsyncProfilerHeapAllocationProfilerFactory extends ProfilerFactory 
     @Override
     public Profiler createFromOptions(OptionSet parsedOptions) {
         AsyncProfilerConfig config = asyncProfilerFactory.createConfig(parsedOptions);
-        AsyncProfilerConfig overrides = new AsyncProfilerConfig(config.getProfilerHome(), "alloc", AsyncProfilerConfig.Counter.TOTAL, 10, config.getStackDepth(), config.getFrameBuffer(), config.isIncludeSystemThreads());
+        AsyncProfilerConfig overrides = new AsyncProfilerConfig(config.getProfilerHome(), "alloc", AsyncProfilerConfig.Counter.TOTAL, 10, config.getStackDepth(), config.isIncludeSystemThreads());
         return new AsyncProfiler(overrides);
     }
 }

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerJvmArgsCalculator.java
@@ -26,7 +26,7 @@ class AsyncProfilerJvmArgsCalculator implements JvmArgsCalculator {
             .append(",jstackdepth=").append(profilerConfig.getStackDepth())
             .append(",").append(outputType.getCommandLineOption())
             .append(",").append(profilerConfig.getCounter().name().toLowerCase(Locale.ROOT))
-            .append(",file=").append(outputType.outputFileFor(scenarioSettings))
+            .append(",file=").append(outputType.individualOutputFileFor(scenarioSettings))
             .append(",ann");
 
         jvmArgs.add(agent.toString());

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerJvmArgsCalculator.java
@@ -26,7 +26,6 @@ class AsyncProfilerJvmArgsCalculator implements JvmArgsCalculator {
             .append(",event=").append(profilerConfig.getEvent())
             .append(",interval=").append(profilerConfig.getInterval())
             .append(",jstackdepth=").append(profilerConfig.getStackDepth())
-            .append(",buffer=").append(profilerConfig.getFrameBuffer())
             .append(",collapsed=").append(profilerConfig.getCounter().name().toLowerCase(Locale.ROOT))
             .append(",ann");
 

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerJvmArgsCalculator.java
@@ -29,6 +29,13 @@ class AsyncProfilerJvmArgsCalculator implements JvmArgsCalculator {
             .append(",file=").append(outputType.individualOutputFileFor(scenarioSettings))
             .append(",ann");
 
+        if (profilerConfig.getEvents().contains(AsyncProfilerConfig.EVENT_ALLOC)) {
+            agent.append(",alloc=").append(profilerConfig.getAllocSampleSize());
+        }
+        if (profilerConfig.getEvents().contains(AsyncProfilerConfig.EVENT_LOCK)) {
+            agent.append(",lock=").append(profilerConfig.getLockThreshold());
+        }
+
         jvmArgs.add(agent.toString());
     }
 }

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerJvmArgsCalculator.java
@@ -4,36 +4,32 @@ import org.gradle.profiler.GradleScenarioDefinition;
 import org.gradle.profiler.JvmArgsCalculator;
 import org.gradle.profiler.ScenarioSettings;
 
-import java.io.File;
 import java.util.List;
 import java.util.Locale;
 
 class AsyncProfilerJvmArgsCalculator implements JvmArgsCalculator {
     private final AsyncProfilerConfig profilerConfig;
     private final ScenarioSettings scenarioSettings;
-    private final boolean captureSnapshotOnProcessExit;
+    private final AsyncProfilerOutputType outputType;
 
-    AsyncProfilerJvmArgsCalculator(AsyncProfilerConfig profilerConfig, ScenarioSettings scenarioSettings, boolean captureSnapshotOnProcessExit) {
+    AsyncProfilerJvmArgsCalculator(AsyncProfilerConfig profilerConfig, ScenarioSettings scenarioSettings) {
         this.profilerConfig = profilerConfig;
         this.scenarioSettings = scenarioSettings;
-        this.captureSnapshotOnProcessExit = captureSnapshotOnProcessExit;
+        this.outputType = AsyncProfilerOutputType.from(profilerConfig, scenarioSettings.getScenario());
     }
 
     @Override
     public void calculateJvmArgs(List<String> jvmArgs) {
+        GradleScenarioDefinition scenario = scenarioSettings.getScenario();
         StringBuilder agent = new StringBuilder()
             .append("-agentpath:").append(profilerConfig.getProfilerHome()).append("/build/libasyncProfiler.so=start")
-            .append(",event=").append(profilerConfig.getEvent())
+            .append(",event=").append(profilerConfig.getJoinedEvents())
             .append(",interval=").append(profilerConfig.getInterval())
             .append(",jstackdepth=").append(profilerConfig.getStackDepth())
-            .append(",collapsed=").append(profilerConfig.getCounter().name().toLowerCase(Locale.ROOT))
+            .append(",").append(outputType.getCommandLineOption())
+            .append(",").append(profilerConfig.getCounter().name().toLowerCase(Locale.ROOT))
+            .append(",file=").append(outputType.outputFileFor(scenario))
             .append(",ann");
-
-        if (captureSnapshotOnProcessExit) {
-            GradleScenarioDefinition scenario = scenarioSettings.getScenario();
-            File stacks = AsyncProfiler.stacksFileFor(scenario);
-            agent.append(",file=").append(stacks.getAbsolutePath());
-        }
 
         jvmArgs.add(agent.toString());
     }

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerJvmArgsCalculator.java
@@ -1,6 +1,5 @@
 package org.gradle.profiler.asyncprofiler;
 
-import org.gradle.profiler.GradleScenarioDefinition;
 import org.gradle.profiler.JvmArgsCalculator;
 import org.gradle.profiler.ScenarioSettings;
 
@@ -20,7 +19,6 @@ class AsyncProfilerJvmArgsCalculator implements JvmArgsCalculator {
 
     @Override
     public void calculateJvmArgs(List<String> jvmArgs) {
-        GradleScenarioDefinition scenario = scenarioSettings.getScenario();
         StringBuilder agent = new StringBuilder()
             .append("-agentpath:").append(profilerConfig.getProfilerHome()).append("/build/libasyncProfiler.so=start")
             .append(",event=").append(profilerConfig.getJoinedEvents())
@@ -28,7 +26,7 @@ class AsyncProfilerJvmArgsCalculator implements JvmArgsCalculator {
             .append(",jstackdepth=").append(profilerConfig.getStackDepth())
             .append(",").append(outputType.getCommandLineOption())
             .append(",").append(profilerConfig.getCounter().name().toLowerCase(Locale.ROOT))
-            .append(",file=").append(outputType.outputFileFor(scenario))
+            .append(",file=").append(outputType.outputFileFor(scenarioSettings))
             .append(",ann");
 
         jvmArgs.add(agent.toString());

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
@@ -1,0 +1,38 @@
+package org.gradle.profiler.asyncprofiler;
+
+import org.gradle.profiler.GradleScenarioDefinition;
+
+import java.io.File;
+
+public enum AsyncProfilerOutputType {
+    STACKS("collapsed") {
+        @Override
+        File outputFileFor(GradleScenarioDefinition scenarioDefinition) {
+            return AsyncProfiler.stacksFileFor(scenarioDefinition);
+        }
+    },
+    JFR("jfr") {
+        @Override
+        File outputFileFor(GradleScenarioDefinition scenarioDefinition) {
+            return AsyncProfiler.jfrFileFor(scenarioDefinition);
+        }
+    };
+
+    public static AsyncProfilerOutputType from(AsyncProfilerConfig config, GradleScenarioDefinition scenarioDefinition) {
+        return (config.getEvents().size() > 1 || scenarioDefinition.createsMultipleProcesses())
+            ? AsyncProfilerOutputType.JFR
+            : AsyncProfilerOutputType.STACKS;
+    }
+
+    private final String commandLineOption;
+
+    AsyncProfilerOutputType(String commandLineOption) {
+        this.commandLineOption = commandLineOption;
+    }
+
+    abstract File outputFileFor(GradleScenarioDefinition scenarioDefinition);
+
+    public String getCommandLineOption() {
+        return commandLineOption;
+    }
+}

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
@@ -15,7 +15,7 @@ public enum AsyncProfilerOutputType {
     JFR("jfr") {
         @Override
         File outputFileFor(ScenarioSettings settings) {
-            return settings.getJfrProfilerOutputLocation();
+            return settings.computeJfrProfilerOutputLocation();
         }
     };
 

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
@@ -33,6 +33,13 @@ public enum AsyncProfilerOutputType {
 
     abstract File outputFileFor(ScenarioSettings settings);
 
+    File individualOutputFileFor(ScenarioSettings settings) {
+        File outputFile = outputFileFor(settings);
+        return settings.getScenario().createsMultipleProcesses()
+            ? new File(outputFile, "profile-%t-%p.jfr")
+            : outputFile;
+    }
+
     public String getCommandLineOption() {
         return commandLineOption;
     }

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
@@ -1,20 +1,21 @@
 package org.gradle.profiler.asyncprofiler;
 
 import org.gradle.profiler.GradleScenarioDefinition;
+import org.gradle.profiler.ScenarioSettings;
 
 import java.io.File;
 
 public enum AsyncProfilerOutputType {
     STACKS("collapsed") {
         @Override
-        File outputFileFor(GradleScenarioDefinition scenarioDefinition) {
-            return AsyncProfiler.stacksFileFor(scenarioDefinition);
+        File outputFileFor(ScenarioSettings settings) {
+            return settings.getProfilerOutputLocation(".stacks.txt");
         }
     },
     JFR("jfr") {
         @Override
-        File outputFileFor(GradleScenarioDefinition scenarioDefinition) {
-            return AsyncProfiler.jfrFileFor(scenarioDefinition);
+        File outputFileFor(ScenarioSettings settings) {
+            return settings.getJfrProfilerOutputLocation();
         }
     };
 
@@ -30,7 +31,7 @@ public enum AsyncProfilerOutputType {
         this.commandLineOption = commandLineOption;
     }
 
-    abstract File outputFileFor(GradleScenarioDefinition scenarioDefinition);
+    abstract File outputFileFor(ScenarioSettings settings);
 
     public String getCommandLineOption() {
         return commandLineOption;

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
@@ -9,7 +9,7 @@ public enum AsyncProfilerOutputType {
     STACKS("collapsed") {
         @Override
         File outputFileFor(ScenarioSettings settings) {
-            return settings.getProfilerOutputLocation(".stacks.txt");
+            return settings.profilerOutputLocationFor(".stacks.txt");
         }
     },
     JFR("jfr") {

--- a/src/main/java/org/gradle/profiler/chrometrace/ChromeTraceInstrumentation.java
+++ b/src/main/java/org/gradle/profiler/chrometrace/ChromeTraceInstrumentation.java
@@ -25,7 +25,7 @@ public class ChromeTraceInstrumentation extends GradleInstrumentation {
     private final File traceFile;
 
     public ChromeTraceInstrumentation(ScenarioSettings scenarioSettings) {
-        traceFile = scenarioSettings.getProfilerOutputLocation("-trace.html");
+        traceFile = scenarioSettings.profilerOutputLocationFor("-trace.html");
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/chrometrace/ChromeTraceInstrumentation.java
+++ b/src/main/java/org/gradle/profiler/chrometrace/ChromeTraceInstrumentation.java
@@ -15,9 +15,8 @@
  */
 package org.gradle.profiler.chrometrace;
 
-import org.gradle.profiler.instrument.GradleInstrumentation;
-import org.gradle.profiler.GradleScenarioDefinition;
 import org.gradle.profiler.ScenarioSettings;
+import org.gradle.profiler.instrument.GradleInstrumentation;
 
 import java.io.File;
 import java.io.PrintWriter;
@@ -26,8 +25,7 @@ public class ChromeTraceInstrumentation extends GradleInstrumentation {
     private final File traceFile;
 
     public ChromeTraceInstrumentation(ScenarioSettings scenarioSettings) {
-        GradleScenarioDefinition scenario = scenarioSettings.getScenario();
-        traceFile = new File(scenario.getOutputDir(), scenario.getProfileName() + "-trace.html");
+        traceFile = scenarioSettings.getProfilerOutputLocation("-trace.html");
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/flamegraph/FlameGraphTool.java
+++ b/src/main/java/org/gradle/profiler/flamegraph/FlameGraphTool.java
@@ -8,7 +8,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -54,10 +53,6 @@ public class FlameGraphTool {
         allArgs.add(stacks.getAbsolutePath());
         allArgs.addAll(args);
         new CommandExec().runAndCollectOutput(flames, allArgs);
-    }
-
-    public void generateFlameGraph(File stacks, File flames, String... args) {
-        generateFlameGraph(stacks, flames, Arrays.asList(args));
     }
 
 }

--- a/src/main/java/org/gradle/profiler/heapdump/HeapDumpProfiler.java
+++ b/src/main/java/org/gradle/profiler/heapdump/HeapDumpProfiler.java
@@ -15,7 +15,7 @@ public class HeapDumpProfiler extends Profiler {
         return new GradleInstrumentation() {
             @Override
             protected void generateInitScriptBody(PrintWriter writer) {
-                File baseName = settings.getProfilerOutputLocation("");
+                File baseName = settings.profilerOutputLocationFor("");
                 writer.println("new org.gradle.trace.heapdump.HeapDump(gradle, new File(new URI('" + baseName.toURI() + "')))");
             }
         };

--- a/src/main/java/org/gradle/profiler/heapdump/HeapDumpProfiler.java
+++ b/src/main/java/org/gradle/profiler/heapdump/HeapDumpProfiler.java
@@ -15,7 +15,7 @@ public class HeapDumpProfiler extends Profiler {
         return new GradleInstrumentation() {
             @Override
             protected void generateInitScriptBody(PrintWriter writer) {
-                File baseName = new File(settings.getScenario().getOutputDir(), settings.getScenario().getProfileName());
+                File baseName = settings.getProfilerOutputLocation("");
                 writer.println("new org.gradle.trace.heapdump.HeapDump(gradle, new File(new URI('" + baseName.toURI() + "')))");
             }
         };

--- a/src/main/java/org/gradle/profiler/jfr/JFRControl.java
+++ b/src/main/java/org/gradle/profiler/jfr/JFRControl.java
@@ -40,7 +40,7 @@ public class JFRControl implements InstrumentingProfiler.SnapshotCapturingProfil
     public void stopSession() {
         String jfrFileName = jfrFile.getName();
         String outputBaseName = jfrFileName.substring(0, jfrFileName.length() - 4);
-        new JfrFlameGraphGenerator().generateGraphs(jfrFile, outputBaseName);
+        new JfrFlameGraphGenerator().generateStacksAndGraphs(jfrFile, outputBaseName);
         System.out.println("Wrote profiling data to " + jfrFile.getPath());
     }
 

--- a/src/main/java/org/gradle/profiler/jfr/JFRControl.java
+++ b/src/main/java/org/gradle/profiler/jfr/JFRControl.java
@@ -1,7 +1,9 @@
 package org.gradle.profiler.jfr;
 
+import com.google.common.collect.ImmutableMap;
 import org.gradle.profiler.CommandExec;
 import org.gradle.profiler.InstrumentingProfiler;
+import org.gradle.profiler.flamegraph.FlameGraphSanitizer;
 
 import java.io.File;
 import java.io.IOException;
@@ -11,6 +13,10 @@ public class JFRControl implements InstrumentingProfiler.SnapshotCapturingProfil
     private final JcmdRunner jcmd;
     private final JFRArgs jfrArgs;
     private final File jfrFile;
+    private final JfrFlameGraphGenerator jfrFlameGraphGenerator = new JfrFlameGraphGenerator(ImmutableMap.of(
+        JfrFlameGraphGenerator.DetailLevel.RAW, FlameGraphSanitizer.raw(),
+        JfrFlameGraphGenerator.DetailLevel.SIMPLIFIED, FlameGraphSanitizer.simplified()
+    ));
     private int counter;
 
     public JFRControl(JFRArgs args, File jfrFile) {
@@ -40,7 +46,7 @@ public class JFRControl implements InstrumentingProfiler.SnapshotCapturingProfil
     public void stopSession() {
         String jfrFileName = jfrFile.getName();
         String outputBaseName = jfrFileName.substring(0, jfrFileName.length() - 4);
-        new JfrFlameGraphGenerator().generateStacksAndGraphs(jfrFile, outputBaseName);
+        jfrFlameGraphGenerator.generateStacksAndGraphs(jfrFile, outputBaseName);
         System.out.println("Wrote profiling data to " + jfrFile.getPath());
     }
 

--- a/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
@@ -26,15 +26,50 @@ import static org.gradle.profiler.jfr.JfrToStacksConverter.Options;
  * <p>
  * TODO create flame graph diffs between profiled versions
  */
-class JfrFlameGraphGenerator {
+public class JfrFlameGraphGenerator {
     private final JfrToStacksConverter stacksConverter = new JfrToStacksConverter();
     private final FlameGraphTool flameGraphGenerator = new FlameGraphTool();
 
-    public void generateGraphs(File jfrFile, String outputBaseName) {
-        if (!flameGraphGenerator.checkInstallation()) {
-            return;
+    public static class Stacks {
+        private final File file;
+        private final EventType type;
+        private final DetailLevel level;
+        private final String fileBaseName;
+
+        public Stacks(File file, EventType type, DetailLevel level, String fileBaseName) {
+            this.file = file;
+            this.type = type;
+            this.level = level;
+            this.fileBaseName = fileBaseName;
         }
 
+        public File getFile() {
+            return file;
+        }
+
+        public EventType getType() {
+            return type;
+        }
+
+        public DetailLevel getLevel() {
+            return level;
+        }
+
+        public boolean isEmpty() {
+            return file.length() == 0;
+        }
+
+        public String getFileBaseName() {
+            return fileBaseName;
+        }
+    }
+
+    public void generateStacksAndGraphs(File jfrFile, String outputBaseName) {
+        List<Stacks> stackFiles = generateStacks(jfrFile, outputBaseName);
+        generateGraphs(jfrFile.getParentFile(), stackFiles);
+    }
+
+    public List<Stacks> generateStacks(File jfrFile, String outputBaseName) {
         Stream<File> jfrFiles = jfrFile.isDirectory()
             ? Stream.of(requireNonNull(jfrFile.listFiles((dir, name) -> name.endsWith(".jfr"))))
             : Stream.of(jfrFile);
@@ -47,23 +82,30 @@ class JfrFlameGraphGenerator {
                 }
             }).collect(Collectors.toList());
 
+        List<Stacks> stacks = new ArrayList<>();
         try {
-            generateGraphs(jfrFile.getParentFile(), outputBaseName, recordings);
+            for (EventType type : EventType.values()) {
+                for (DetailLevel level : DetailLevel.values()) {
+                    String eventFileBaseName = Joiner.on("-").join(outputBaseName, type.getId(), level.name().toLowerCase(Locale.ROOT));
+                    File stacksFile = generateStacks(jfrFile.getParentFile(), eventFileBaseName, recordings, type, level);
+                    if (stacksFile != null) {
+                        stacks.add(new Stacks(stacksFile, type, level, eventFileBaseName));
+                    }
+                }
+            }
+            return stacks;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
     }
 
-    private void generateGraphs(File flameGraphDirectory, String outputBaseName, List<IItemCollection> recordings) throws IOException {
-        for (EventType type : EventType.values()) {
-            for (DetailLevel level : DetailLevel.values()) {
-                String eventFileBaseName = Joiner.on("-").join(outputBaseName, type.getId(), level.name().toLowerCase(Locale.ROOT));
-                File stacks = generateStacks(flameGraphDirectory, eventFileBaseName, recordings, type, level);
-                if (stacks != null) {
-                    generateFlameGraph(stacks, new File(flameGraphDirectory, eventFileBaseName + "-flames.svg"), type, level);
-                    generateIcicleGraph(stacks, new File(flameGraphDirectory, eventFileBaseName + "-icicles.svg"), type, level);
-                }
-            }
+    public void generateGraphs(File flameGraphDirectory, List<Stacks> stackFiles) {
+        if (!flameGraphGenerator.checkInstallation()) {
+            return;
+        }
+        for (Stacks stacks : stackFiles) {
+            generateFlameGraph(flameGraphDirectory, stacks);
+            generateIcicleGraph(flameGraphDirectory, stacks);
         }
     }
 
@@ -75,37 +117,37 @@ class JfrFlameGraphGenerator {
             stacks.delete();
             return null;
         }
-        File sanitizedStacks = stacksFileName(baseDir, eventFileBaseName);
+        File sanitizedStacks = new File(baseDir, eventFileBaseName + "-stacks.txt");
         level.getSanitizer().sanitize(stacks, sanitizedStacks);
         stacks.delete();
         return sanitizedStacks;
     }
 
-    private File stacksFileName(File baseDir, String eventFileBaseName) {
-        return new File(baseDir, eventFileBaseName + "-stacks.txt");
-    }
-
-    private void generateFlameGraph(File stacks, File flames, EventType type, DetailLevel level) {
-        if (stacks.length() == 0) {
+    private void generateFlameGraph(File flameGraphDirectory, Stacks stacks) {
+        if (stacks.isEmpty()) {
             return;
         }
+        DetailLevel level = stacks.getLevel();
+        EventType type = stacks.getType();
         List<String> options = new ArrayList<>();
         options.addAll(level.getFlameGraphOptions());
         options.addAll(Arrays.asList("--title", type.getDisplayName() + " Flame Graph", "--countname", type.getUnitOfMeasure(), "--colors", "java"));
-        flameGraphGenerator.generateFlameGraph(stacks, flames, options);
+        flameGraphGenerator.generateFlameGraph(stacks.getFile(), new File(flameGraphDirectory, stacks.getFileBaseName() + "-flames.svg"), options);
     }
 
-    private void generateIcicleGraph(File stacks, File icicles, EventType type, DetailLevel level) {
-        if (stacks.length() == 0) {
+    private void generateIcicleGraph(File flameGraphDirectory, Stacks stacks) {
+        if (stacks.isEmpty()) {
             return;
         }
+        DetailLevel level = stacks.getLevel();
+        EventType type = stacks.getType();
         List<String> options = new ArrayList<>();
         options.addAll(level.getIcicleGraphOptions());
         options.addAll(Arrays.asList("--title", type.getDisplayName() + " Icicle Graph", "--countname", type.getUnitOfMeasure(), "--reverse", "--invert", "--colors", "java"));
-        flameGraphGenerator.generateFlameGraph(stacks, icicles, options);
+        flameGraphGenerator.generateFlameGraph(stacks.getFile(), new File(flameGraphDirectory, stacks.getFileBaseName() + "-icicles.svg"), options);
     }
 
-    private enum DetailLevel {
+    public enum DetailLevel {
         RAW(
             true,
             true,

--- a/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
@@ -1,6 +1,7 @@
 package org.gradle.profiler.jfr;
 
 import com.google.common.base.Joiner;
+import org.gradle.profiler.asyncprofiler.AsyncProfilerController;
 import org.gradle.profiler.flamegraph.FlameGraphSanitizer;
 import org.gradle.profiler.flamegraph.FlameGraphTool;
 import org.openjdk.jmc.common.item.IItemCollection;
@@ -160,7 +161,8 @@ public class JfrFlameGraphGenerator {
             false,
             Arrays.asList("--minwidth", "1"),
             Arrays.asList("--minwidth", "2"),
-            FlameGraphSanitizer.simplified()
+            // TODO: Use the value configured in the config.
+            FlameGraphSanitizer.simplified(new AsyncProfilerController.RemoveSystemThreads())
         );
 
         private final boolean showArguments;

--- a/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrFlameGraphGenerator.java
@@ -91,7 +91,7 @@ class JfrFlameGraphGenerator {
         }
         List<String> options = new ArrayList<>();
         options.addAll(level.getFlameGraphOptions());
-        options.addAll(Arrays.asList("--title", type.getDisplayName() + " Flame Graph", "--countname", type.getUnitOfMeasure()));
+        options.addAll(Arrays.asList("--title", type.getDisplayName() + " Flame Graph", "--countname", type.getUnitOfMeasure(), "--colors", "java"));
         flameGraphGenerator.generateFlameGraph(stacks, flames, options);
     }
 
@@ -101,7 +101,7 @@ class JfrFlameGraphGenerator {
         }
         List<String> options = new ArrayList<>();
         options.addAll(level.getIcicleGraphOptions());
-        options.addAll(Arrays.asList("--title", type.getDisplayName() + " Icicle Graph", "--countname", type.getUnitOfMeasure(), "--reverse", "--invert", "--colors", "aqua"));
+        options.addAll(Arrays.asList("--title", type.getDisplayName() + " Icicle Graph", "--countname", type.getUnitOfMeasure(), "--reverse", "--invert", "--colors", "java"));
         flameGraphGenerator.generateFlameGraph(stacks, icicles, options);
     }
 

--- a/src/main/java/org/gradle/profiler/jfr/JfrProfiler.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrProfiler.java
@@ -1,6 +1,5 @@
 package org.gradle.profiler.jfr;
 
-import org.gradle.profiler.GradleScenarioDefinition;
 import org.gradle.profiler.InstrumentingProfiler;
 import org.gradle.profiler.JvmArgsCalculator;
 import org.gradle.profiler.ScenarioSettings;
@@ -9,9 +8,6 @@ import java.io.File;
 import java.util.function.Consumer;
 
 public class JfrProfiler extends InstrumentingProfiler {
-    private static final String PROFILE_JFR_SUFFIX = ".jfr";
-    private static final String PROFILE_JFR_DIRECTORY_SUFFIX = "-jfr";
-
     private final JFRArgs jfrArgs;
 
     JfrProfiler(JFRArgs jfrArgs) {
@@ -34,25 +30,13 @@ public class JfrProfiler extends InstrumentingProfiler {
 
     @Override
     protected SnapshotCapturingProfilerController doNewController(ScenarioSettings settings) {
-        File jfrFile = getJfrFile(settings);
-        return new JFRControl(jfrArgs, jfrFile);
+        return new JFRControl(jfrArgs, settings.getJfrProfilerOutputLocation());
     }
 
     @Override
     protected JvmArgsCalculator jvmArgsWithInstrumentation(ScenarioSettings settings, boolean startRecordingOnProcessStart, boolean captureSnapshotOnProcessExit) {
-        File jfrFile = getJfrFile(settings);
+        File jfrFile = settings.getJfrProfilerOutputLocation();
         return new JFRJvmArgsCalculator(jfrArgs, startRecordingOnProcessStart, captureSnapshotOnProcessExit, jfrFile);
-    }
-
-    private File getJfrFile(ScenarioSettings settings) {
-        GradleScenarioDefinition scenario = settings.getScenario();
-        if (scenario.createsMultipleProcesses()) {
-            File jfrFilesDirectory = new File(scenario.getOutputDir(), scenario.getProfileName() + PROFILE_JFR_DIRECTORY_SUFFIX);
-            jfrFilesDirectory.mkdirs();
-            return jfrFilesDirectory;
-        } else {
-             return new File(scenario.getOutputDir(), scenario.getProfileName() + PROFILE_JFR_SUFFIX);
-        }
     }
 
     @Override

--- a/src/main/java/org/gradle/profiler/jfr/JfrProfiler.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrProfiler.java
@@ -30,12 +30,12 @@ public class JfrProfiler extends InstrumentingProfiler {
 
     @Override
     protected SnapshotCapturingProfilerController doNewController(ScenarioSettings settings) {
-        return new JFRControl(jfrArgs, settings.getJfrProfilerOutputLocation());
+        return new JFRControl(jfrArgs, settings.computeJfrProfilerOutputLocation());
     }
 
     @Override
     protected JvmArgsCalculator jvmArgsWithInstrumentation(ScenarioSettings settings, boolean startRecordingOnProcessStart, boolean captureSnapshotOnProcessExit) {
-        File jfrFile = settings.getJfrProfilerOutputLocation();
+        File jfrFile = settings.computeJfrProfilerOutputLocation();
         return new JFRJvmArgsCalculator(jfrArgs, startRecordingOnProcessStart, captureSnapshotOnProcessExit, jfrFile);
     }
 

--- a/src/main/java/org/gradle/profiler/jfr/JfrToStacksConverter.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrToStacksConverter.java
@@ -36,7 +36,7 @@ import java.util.stream.StreamSupport;
 /**
  * Converts JFR recordings to the collapsed stacks format used by the FlameGraph tool.
  */
-class JfrToStacksConverter {
+public class JfrToStacksConverter {
     public void convertToStacks(List<IItemCollection> recordings, File targetFile, Options options) {
         Map<String, Long> foldedStacks = foldStacks(recordings, options);
         writeFoldedStacks(foldedStacks, targetFile);

--- a/src/main/java/org/gradle/profiler/jfr/JfrToStacksConverter.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrToStacksConverter.java
@@ -99,7 +99,7 @@ public class JfrToStacksConverter {
         }
 
         private String frameName(IMCFrame frame) {
-            return StacktraceFormatToolkit.formatFrame(
+            String frameName = StacktraceFormatToolkit.formatFrame(
                 frame,
                 new FrameSeparator(options.isShowLineNumbers() ? FrameCategorization.LINE : FrameCategorization.METHOD, false),
                 false,
@@ -109,6 +109,9 @@ public class JfrToStacksConverter {
                 options.isShowArguments(),
                 true
             );
+            return frame.getType() == IMCFrame.Type.UNKNOWN
+                ? frameName
+                : frameName + "_[j]";
         }
 
         private long getValue(IItem event) {

--- a/src/main/java/org/gradle/profiler/jfr/JfrToStacksConverter.java
+++ b/src/main/java/org/gradle/profiler/jfr/JfrToStacksConverter.java
@@ -148,8 +148,8 @@ public class JfrToStacksConverter {
 
         CPU("cpu", "CPU", "samples", ValueField.COUNT, "Method Profiling Sample", "Method Profiling Sample Native"),
         ALLOCATION("allocation", "Allocation size", "kB", ValueField.ALLOCATION_SIZE, "Allocation in new TLAB", "Allocation outside TLAB"),
-        MONITOR_BLOCKED("monitor-blocked", "Java Monitor Blocked", "ms", ValueField.DURATION, "Java Monitor Blocked"),
-        IO("io", "File and Socket IO", "ms", ValueField.DURATION, "File Read", "File Write", "Socket Read", "Socket Write");
+        MONITOR_BLOCKED("monitor-blocked", "Java Monitor Blocked", "ns", ValueField.DURATION, "Java Monitor Blocked", "Java Thread Park"),
+        IO("io", "File and Socket IO", "ns", ValueField.DURATION, "File Read", "File Write", "Socket Read", "Socket Write");
 
         private final String id;
         private final String displayName;
@@ -202,7 +202,7 @@ public class JfrToStacksConverter {
                         IMemberAccessor<IQuantity, IItem> endTime = itemType.getAccessor(JfrAttributes.END_TIME.getKey());
                         duration = MemberAccessorToolkit.difference(endTime, startTime);
                     }
-                    return duration.getMember(event).in(UnitLookup.MILLISECOND).longValue();
+                    return duration.getMember(event).in(UnitLookup.NANOSECOND).longValue();
                 }
             },
             ALLOCATION_SIZE {

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
@@ -20,13 +20,10 @@ public class JProfiler {
     }
 
     public static String getSnapshotPath(ScenarioSettings settings) {
-        File outputDir = settings.getScenario().getOutputDir();
-        String snapshotName = settings.getScenario().getProfileName();
-
         int i = 0;
         File snapshotFile;
         do {
-            snapshotFile = new File(outputDir, snapshotName  + ( i == 0 ? "" : ("_" + i)) + ".jps");
+            snapshotFile = settings.getProfilerOutputLocation(( i == 0 ? "" : ("_" + i)) + ".jps");
             ++i;
         } while (snapshotFile.exists());
         return snapshotFile.getAbsolutePath();

--- a/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
+++ b/src/main/java/org/gradle/profiler/jprofiler/JProfiler.java
@@ -23,7 +23,7 @@ public class JProfiler {
         int i = 0;
         File snapshotFile;
         do {
-            snapshotFile = settings.getProfilerOutputLocation(( i == 0 ? "" : ("_" + i)) + ".jps");
+            snapshotFile = settings.profilerOutputLocationFor(( i == 0 ? "" : ("_" + i)) + ".jps");
             ++i;
         } while (snapshotFile.exists());
         return snapshotFile.getAbsolutePath();

--- a/src/main/java/org/gradle/profiler/yourkit/YourKitJvmArgsCalculator.java
+++ b/src/main/java/org/gradle/profiler/yourkit/YourKitJvmArgsCalculator.java
@@ -36,8 +36,8 @@ public class YourKitJvmArgsCalculator implements JvmArgsCalculator {
         if (!jnilib.isFile()) {
             throw new IllegalArgumentException("Could not locate YourKit library in YourKit home directory " + yourKitHome);
         }
-        String agentOptions = "-agentpath:" + jnilib.getAbsolutePath() + "=dir=" + settings.getScenario().getOutputDir().getAbsolutePath()
-                + ",sessionname=" + settings.getScenario().getProfileName()
+        String agentOptions = "-agentpath:" + jnilib.getAbsolutePath() + "=dir=" + settings.getProfilerOutputBaseDir().getAbsolutePath()
+                + ",sessionname=" + settings.getProfilerOutputBaseName()
                 + ",port=" + PORT;
         if (yourKitConfig.isMemorySnapshot() || yourKitConfig.isUseSampling()) {
             agentOptions += ",disabletracing,probe_disable=*";

--- a/src/test/groovy/org/gradle/profiler/AsyncProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AsyncProfilerIntegrationTest.groovy
@@ -41,7 +41,7 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         logFile.containsOne("<invocations: 3>")
 
         and:
-        assertGraphsGenerated("alloc")
+        assertGraphsGenerated("allocation")
     }
 
     @Requires({ !OperatingSystem.isWindows() })

--- a/src/test/groovy/org/gradle/profiler/AsyncProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AsyncProfilerIntegrationTest.groovy
@@ -113,33 +113,42 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
     }
 
     @Requires({ !OperatingSystem.isWindows() })
-    def "cannot profile using async-profiler with multiple iterations and cold daemon"() {
+    def "profiles using #profiler with multiple iterations and cold daemon"() {
         given:
         instrumentedBuildScript()
 
         when:
-        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion, "--profile", "async-profiler", "--iterations", "2", "--cold-daemon", "assemble")
+        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion, "--profile", profiler, "--iterations", "2", "--cold-daemon", "assemble")
 
         then:
-        thrown(IllegalArgumentException)
+        logFile.find("<daemon: true").size() == 4
+        logFile.find("<invocations: 1>").size() == 4
 
         and:
-        output.contains("Scenario using Gradle ${latestSupportedGradleVersion}: Profiler async profiler does not support profiling multiple daemons.")
+        assertGraphsGenerated()
+
+        where:
+        profiler << ["async-profiler", "async-profiler-all"]
     }
 
     @Requires({ !OperatingSystem.isWindows() })
-    def "cannot profile using async-profiler with multiple iterations and no daemon"() {
+    def "profiles using #profiler with multiple iterations and no daemon"() {
         given:
         instrumentedBuildScript()
 
         when:
-        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion, "--profile", "async-profiler", "--iterations", "2", "--no-daemon", "assemble")
+        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion, "--profile", profiler, "--iterations", "2", "--no-daemon", "assemble")
 
         then:
-        thrown(IllegalArgumentException)
+        logFile.find("<daemon: true").size() == 1
+        logFile.find("<daemon: false").size() == 3
+        logFile.find("<invocations: 1>").size() == 4
 
         and:
-        output.contains("Scenario using Gradle ${latestSupportedGradleVersion}: Profiler async profiler does not support profiling multiple daemons.")
+        assertGraphsGenerated()
+
+        where:
+        profiler << ["async-profiler", "async-profiler-all"]
     }
 
     @Requires({ !OperatingSystem.isWindows() })

--- a/src/test/groovy/org/gradle/profiler/AsyncProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AsyncProfilerIntegrationTest.groovy
@@ -39,6 +39,26 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
     }
 
     @Requires({ !OperatingSystem.isWindows() })
+    def "profiles wall clock time using async-profiler with tooling API and warm daemon"() {
+        given:
+        instrumentedBuildScript()
+
+        when:
+        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion, "--profile", "async-profiler",
+            "--async-profiler-event", "wall",
+            "--async-profiler-event", "alloc",
+            "assemble"
+        )
+
+        then:
+        logFile.find("<daemon: true").size() == 4
+        logFile.containsOne("<invocations: 3>")
+
+        and:
+        assertGraphsGenerated("allocation", "cpu")
+    }
+
+    @Requires({ !OperatingSystem.isWindows() })
     def "profiles heap allocation using async-profiler with tooling API and warm daemon"() {
         given:
         instrumentedBuildScript()


### PR DESCRIPTION
Async profiler 2 allows capturing multiple events at once. It only support JFR files for multiple events. The change allows now capturing multiple events and adds a profiler `async-profiler-all` which captures cpu, alloc and lock samples at the same time.

When profiling multiple processes, we now use the infrastructure we use for the JFR profiler to capture multiple JFR files and then merge them into one flame graph for async profiler as well.