### PR TITLE
Support configuration client Gradle VM in CliGradleClient

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-profiler.version=0.17.0-SNAPSHOT
+profiler.version=0.17.0-alpha06
 org.gradle.caching=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-profiler.version=0.17.0-alpha06
+profiler.version=0.17.0-alpha07
 org.gradle.caching=true

--- a/src/main/java/org/gradle/profiler/CliGradleClient.java
+++ b/src/main/java/org/gradle/profiler/CliGradleClient.java
@@ -63,7 +63,7 @@ public class CliGradleClient implements GradleInvoker, GradleClient {
             String orgGradleJvmArgs = jvmArgs.isEmpty()
                 ? ""
                 : " \"-Dorg.gradle.jvmargs=" + daemonJvmArgs + "\"";
-            LinkedHashSet<String> gradleOptsSet = new LinkedHashSet<>(gradleBuildConfiguration.getGradleOpts());
+            LinkedHashSet<String> gradleOptsSet = new LinkedHashSet<>(gradleBuildConfiguration.getClientJvmArguments());
             gradleOptsSet.add("-XX:+HeapDumpOnOutOfMemoryError");
             builder.environment().put("GRADLE_OPTS", quoteJvmArguments(false, gradleOptsSet) + orgGradleJvmArgs);
         } else {

--- a/src/main/java/org/gradle/profiler/CliGradleClient.java
+++ b/src/main/java/org/gradle/profiler/CliGradleClient.java
@@ -63,8 +63,9 @@ public class CliGradleClient implements GradleInvoker, GradleClient {
             String orgGradleJvmArgs = jvmArgs.isEmpty()
                 ? ""
                 : " \"-Dorg.gradle.jvmargs=" + daemonJvmArgs + "\"";
-            LinkedHashSet<String> gradleOptsSet = new LinkedHashSet<>(gradleBuildConfiguration.getClientJvmArguments());
+            LinkedHashSet<String> gradleOptsSet = new LinkedHashSet<>();
             gradleOptsSet.add("-XX:+HeapDumpOnOutOfMemoryError");
+            gradleOptsSet.addAll(gradleBuildConfiguration.getClientJvmArguments());
             builder.environment().put("GRADLE_OPTS", quoteJvmArguments(false, gradleOptsSet) + orgGradleJvmArgs);
         } else {
             Logging.detailed().println("GRADLE_OPTS: " + daemonJvmArgs);

--- a/src/main/java/org/gradle/profiler/GradleBuildConfiguration.java
+++ b/src/main/java/org/gradle/profiler/GradleBuildConfiguration.java
@@ -5,6 +5,7 @@ import org.gradle.util.GradleVersion;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class GradleBuildConfiguration {
@@ -13,13 +14,38 @@ public class GradleBuildConfiguration {
     private final File javaHome;
     private final List<String> jvmArguments;
     private final boolean usesScanPlugin;
+    /**
+     * The GRADLE_OPTS environment variable passed to configure the client VM.
+     * See https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_environment_variables
+     * <p>
+     * This is used only for --daemon. Use jvmArguments for --no-daemon.
+     */
+    private final List<String> gradleOpts;
 
-    public GradleBuildConfiguration(GradleVersion gradleVersion, File gradleHome, File javaHome, List<String> jvmArguments, boolean usesScanPlugin) {
+    public GradleBuildConfiguration(
+        GradleVersion gradleVersion,
+        File gradleHome,
+        File javaHome,
+        List<String> jvmArguments,
+        boolean usesScanPlugin
+    ) {
+       this(gradleVersion, gradleHome, javaHome, jvmArguments, usesScanPlugin, Collections.emptyList());
+    }
+
+    public GradleBuildConfiguration(
+        GradleVersion gradleVersion,
+        File gradleHome,
+        File javaHome,
+        List<String> jvmArguments,
+        boolean usesScanPlugin,
+        List<String> gradleOpts
+    ) {
         this.gradleVersion = gradleVersion;
         this.gradleHome = gradleHome;
         this.javaHome = javaHome;
         this.usesScanPlugin = usesScanPlugin;
         this.jvmArguments = jvmArguments;
+        this.gradleOpts = gradleOpts;
     }
 
     public GradleVersion getGradleVersion() {
@@ -40,6 +66,10 @@ public class GradleBuildConfiguration {
 
     public boolean isUsesScanPlugin() {
         return usesScanPlugin;
+    }
+
+    public List<String> getGradleOpts() {
+        return gradleOpts;
     }
 
     public void printVersionInfo() {

--- a/src/main/java/org/gradle/profiler/GradleBuildConfiguration.java
+++ b/src/main/java/org/gradle/profiler/GradleBuildConfiguration.java
@@ -14,13 +14,7 @@ public class GradleBuildConfiguration {
     private final File javaHome;
     private final List<String> jvmArguments;
     private final boolean usesScanPlugin;
-    /**
-     * The GRADLE_OPTS environment variable passed to configure the client VM.
-     * See https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_environment_variables
-     * <p>
-     * This is used only for --daemon. Use jvmArguments for --no-daemon.
-     */
-    private final List<String> gradleOpts;
+    private final List<String> clientJvmArguments;
 
     public GradleBuildConfiguration(
         GradleVersion gradleVersion,
@@ -45,7 +39,7 @@ public class GradleBuildConfiguration {
         this.javaHome = javaHome;
         this.usesScanPlugin = usesScanPlugin;
         this.jvmArguments = jvmArguments;
-        this.gradleOpts = gradleOpts;
+        this.clientJvmArguments = gradleOpts;
     }
 
     public GradleVersion getGradleVersion() {
@@ -68,8 +62,16 @@ public class GradleBuildConfiguration {
         return usesScanPlugin;
     }
 
-    public List<String> getGradleOpts() {
-        return gradleOpts;
+    /**
+     * The JVM arguments passed to configure the client VM.
+     * See https://docs.gradle.org/current/userguide/build_environment.html#sec:gradle_environment_variables
+     * <p>
+     * Note:
+     * 1. This is only for {@link CliGradleClient}, not for TAPI clients.
+     * 2. This is used only for --daemon. Use jvmArguments for --no-daemon.
+     */
+    public List<String> getClientJvmArguments() {
+        return clientJvmArguments;
     }
 
     public void printVersionInfo() {


### PR DESCRIPTION
We found sometimes we have to configure Gradle client VM, which is unsupported now. For example, build scan performance generates a huge amount of output events, when they're not flushed in time, the buffer caused an OOM in client VM:

![image](https://user-images.githubusercontent.com/12689835/125376487-ae729100-e3bd-11eb-9805-d355530d20fe.png)


![image](https://user-images.githubusercontent.com/12689835/125376477-a6b2ec80-e3bd-11eb-88a0-e1fb70d3e74f.png)


![image](https://user-images.githubusercontent.com/12689835/125376419-8420d380-e3bd-11eb-81fb-bfa1bf87e761.png)


This PR adds the extra `gradleOpts` configuration to make it possible.