### PR TITLE
Allow running tasks without "githubToken"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -173,7 +173,7 @@ tasks.register<Exec>("gitTag") {
 val gitPushTag = tasks.register<Exec>("gitPushTag") {
     mustRunAfter("publishAllPublicationsToGradleBuildInternalRepository")
     dependsOn("gitTag")
-    commandLine("git", "push", "https://bot-teamcity:${project.property("githubToken")}@github.com/gradle/gradle-profiler.git", releaseTagName)
+    commandLine("git", "push", "https://bot-teamcity:${project.findProperty("githubToken")}@github.com/gradle/gradle-profiler.git", releaseTagName)
 }
 
 sdkman {


### PR DESCRIPTION
Fixes #344.

When running `gradle tasks`, the `gitPushTag` task is realized, which fails when `githubToken` is not present.