### PR TITLE
Replace reference to repo.gradle.org

### DIFF
--- a/buildSrc/src/main/kotlin/profiler.java-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.java-library.gradle.kts
@@ -5,10 +5,14 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
     maven {
-        url = uri("https://repo.gradle.org/gradle/repo")
+        name = "Gradle public repository"
+        url = uri("https://repo.gradle.org/gradle/public")
+        content {
+            includeModule("org.gradle", "gradle-tooling-api")
+        }
     }
+    mavenCentral()
 }
 
 java {


### PR DESCRIPTION
Instead of depending on /repo we now use /public with a content filter
that makes sure we only query the repository for content that's
available there.