### PR TITLE
Drop unused credentials

### DIFF
--- a/.teamcity/settings/GradleProfilerPublishing.kt
+++ b/.teamcity/settings/GradleProfilerPublishing.kt
@@ -12,15 +12,13 @@ object GradleProfilerPublishing : BuildType({
 
     params {
         javaHome(Os.linux, JavaVersion.ORACLE_JAVA_8)
-        text("ARTIFACTORY_USERNAME", "bot-build-tool", allowEmpty = true)
-        password("ARTIFACTORY_PASSWORD", "credentialsJSON:d94612fb-3291-41f5-b043-e2b3994aeeb4", display = ParameterDisplay.HIDDEN)
         password("pgpSigningKey", "credentialsJSON:ae6de222-f77d-4c71-b94e-fac6da485143", display = ParameterDisplay.HIDDEN)
         password("pgpSigningPassphrase", "credentialsJSON:f75db3bd-4f5b-4591-b5cb-2e76d91f57f5", display = ParameterDisplay.HIDDEN)
         password("mavenCentralStagingRepoUser", "credentialsJSON:ce6ff00a-dc06-4b9b-aa1f-7b01bea2eb2f", display = ParameterDisplay.HIDDEN)
         password("mavenCentralStagingRepoPassword", "credentialsJSON:f3c71885-0cec-49c9-adcf-d21536fcf1ca", display = ParameterDisplay.HIDDEN)
 
-        param("env.ORG_GRADLE_PROJECT_artifactoryUsername", "%ARTIFACTORY_USERNAME%")
-        param("env.ORG_GRADLE_PROJECT_artifactoryPassword", "%ARTIFACTORY_PASSWORD%")
+        param("env.ORG_GRADLE_PROJECT_artifactoryUsername", "%gradle.internal.repository.build-tool.publish.username%")
+        param("env.ORG_GRADLE_PROJECT_artifactoryPassword", "%gradle.internal.repository.build-tool.publish.password%")
         param("env.ORG_GRADLE_PROJECT_githubToken", "%github.bot-teamcity.token%")
         param("env.ORG_GRADLE_PROJECT_sdkmanKey", "%gradleprofiler.sdkman.key%")
         param("env.ORG_GRADLE_PROJECT_sdkmanToken", "%gradleprofiler.sdkman.token%")

--- a/.teamcity/settings/GradleProfilerPublishing.kt
+++ b/.teamcity/settings/GradleProfilerPublishing.kt
@@ -17,8 +17,6 @@ object GradleProfilerPublishing : BuildType({
         password("mavenCentralStagingRepoUser", "credentialsJSON:ce6ff00a-dc06-4b9b-aa1f-7b01bea2eb2f", display = ParameterDisplay.HIDDEN)
         password("mavenCentralStagingRepoPassword", "credentialsJSON:f3c71885-0cec-49c9-adcf-d21536fcf1ca", display = ParameterDisplay.HIDDEN)
 
-        param("env.ORG_GRADLE_PROJECT_artifactoryUsername", "%gradle.internal.repository.build-tool.publish.username%")
-        param("env.ORG_GRADLE_PROJECT_artifactoryPassword", "%gradle.internal.repository.build-tool.publish.password%")
         param("env.ORG_GRADLE_PROJECT_githubToken", "%github.bot-teamcity.token%")
         param("env.ORG_GRADLE_PROJECT_sdkmanKey", "%gradleprofiler.sdkman.key%")
         param("env.ORG_GRADLE_PROJECT_sdkmanToken", "%gradleprofiler.sdkman.token%")


### PR DESCRIPTION
The project is now only published to Maven Central so we don't need
these credentials anymore.