### PR TITLE
Update hardcoded Android Studio embedded Java path

### DIFF
--- a/src/main/java/org/gradle/profiler/studio/LauncherConfigurationParser.java
+++ b/src/main/java/org/gradle/profiler/studio/LauncherConfigurationParser.java
@@ -30,7 +30,7 @@ public class LauncherConfigurationParser {
         List<Path> classPath = Arrays.stream(jvmOptions.string("ClassPath").split(":")).map(s -> FileSystems.getDefault().getPath(s.replace("$APP_PACKAGE", actualInstallDir.toString()))).collect(Collectors.toList());
         String mainClass = jvmOptions.string("MainClass");
         Map<String, String> systemProperties = mapValues(jvmOptions.dict("Properties").toMap(), v -> v.replace("$APP_PACKAGE", actualInstallDir.toString()));
-        Path javaCommand = actualInstallDir.resolve("Contents/jre/jdk/Contents/Home/bin/java");
+        Path javaCommand = actualInstallDir.resolve("Contents/jre/Contents/Home/bin/java");
         Path agentJar = GradleInstrumentation.unpackPlugin("studio-agent").toPath();
         Path asmJar = GradleInstrumentation.unpackPlugin("asm").toPath();
         Path supportJar = GradleInstrumentation.unpackPlugin("instrumentation-support").toPath();


### PR DESCRIPTION
- Remove 'jdk' folder from path as it was removed for a while now (unsure starting which AS version, but anything in the stable/beta/alpha channel does not contain it anymore)

Fixed #351