### PR TITLE
CI build now always uses Java11 as JAVA_HOME

### DIFF
--- a/.teamcity/settings/GradleProfilerTest.kt
+++ b/.teamcity/settings/GradleProfilerTest.kt
@@ -10,14 +10,20 @@ open class GradleProfilerTest(os: Os, javaVersion: JavaVersion) : BuildType({
     gradleProfilerVcs()
 
     params {
-        javaHome(os, javaVersion)
+        // Java home must always use Java11
+        // since intellij-gradle-plugin is not compatible with Java8
+        javaHome(os, JavaVersion.OPENJDK_11)
     }
 
     steps {
         gradle {
             tasks = "clean :test"
             buildFile = ""
-            gradleParams = "-s --build-cache ${toolchainConfiguration(os)}"
+            gradleParams = "-s" +
+                " --build-cache ${toolchainConfiguration(os)}" +
+                " -PtestJavaVersion=${javaVersion.majorVersion}" +
+                " -PtestJavaVendor=${javaVersion.vendor}"
+            param("org.jfrog.artifactory.selectedDeployableServer.defaultModuleVersionConfiguration", "GLOBAL")
             param("org.jfrog.artifactory.selectedDeployableServer.defaultModuleVersionConfiguration", "GLOBAL")
         }
     }

--- a/.teamcity/settings/GradleProfilerTest.kt
+++ b/.teamcity/settings/GradleProfilerTest.kt
@@ -24,7 +24,6 @@ open class GradleProfilerTest(os: Os, javaVersion: JavaVersion) : BuildType({
                 " -PtestJavaVersion=${javaVersion.majorVersion}" +
                 " -PtestJavaVendor=${javaVersion.vendor}"
             param("org.jfrog.artifactory.selectedDeployableServer.defaultModuleVersionConfiguration", "GLOBAL")
-            param("org.jfrog.artifactory.selectedDeployableServer.defaultModuleVersionConfiguration", "GLOBAL")
         }
     }
 

--- a/.teamcity/settings/extensions.kt
+++ b/.teamcity/settings/extensions.kt
@@ -17,9 +17,9 @@ fun ParametrizedWithType.javaHome(os: Os, javaVersion: JavaVersion) {
     param("env.JAVA_HOME", javaVersion.javaHome(os))
 }
 
-enum class JavaVersion(private val javaHomePostfix: String) {
-    ORACLE_JAVA_8("java8.oracle.64bit"),
-    OPENJDK_11("java11.openjdk.64bit");
+enum class JavaVersion(val majorVersion: String, val vendor: String, private val javaHomePostfix: String) {
+    ORACLE_JAVA_8("8", "oracle", "java8.oracle.64bit"),
+    OPENJDK_11("11", "openjdk", "java11.openjdk.64bit");
 
     fun javaHome(os: Os) = "%${os.name}.$javaHomePostfix%"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -115,6 +115,8 @@ tasks.test {
         }.getOrNull()
     }
     javaLauncher.set(launcher)
+    // So processes started from test also use same Java version
+    environment = mapOf("JAVA_HOME" to javaLauncher.get().metadata.installationPath)
 
     // We had some build failures on macOS, where it seems to be a Socket was already closed when trying to download the Gradle distribution.
     // The tests failing were consistenly in ProfilerIntegrationTest.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,7 +116,7 @@ tasks.test {
     }
     javaLauncher.set(launcher)
     // So processes started from test also use same Java version
-    environment = mapOf("JAVA_HOME" to javaLauncher.get().metadata.installationPath)
+    environment("JAVA_HOME" to javaLauncher.get().metadata.installationPath)
 
     // We had some build failures on macOS, where it seems to be a Socket was already closed when trying to download the Gradle distribution.
     // The tests failing were consistenly in ProfilerIntegrationTest.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,10 +99,22 @@ tasks.processResources {
 }
 
 tasks.test {
-    // Use the current JVM. Some tests require JFR, which is only available in some JVM implementations
-    // For now assume that the current JVM has JFR support and that CI will inject the correct implementation
-    javaLauncher.set(null as JavaLauncher?)
-    javaLauncher.convention(null as JavaLauncher?)
+    // If testJavaVersion is not set use the current JVM. Some tests require JFR, which is only available
+    // in some JVM implementations. For now assume that the current JVM has JFR support.
+    // CI will inject the correct implementation.
+    val launcher = project.javaToolchains.launcherFor {
+        val javaVersion = providers
+            .gradleProperty("testJavaVersion")
+            .getOrElse(JavaVersion.current().majorVersion)
+        languageVersion.set(JavaLanguageVersion.of(javaVersion))
+        providers.gradleProperty("testJavaVendor").map {
+            when (it.toLowerCase()) {
+                "oracle" -> vendor.set(JvmVendorSpec.ORACLE)
+                "openjdk" -> vendor.set(JvmVendorSpec.ADOPTOPENJDK)
+            }
+        }.getOrNull()
+    }
+    javaLauncher.set(launcher)
 
     // We had some build failures on macOS, where it seems to be a Socket was already closed when trying to download the Gradle distribution.
     // The tests failing were consistenly in ProfilerIntegrationTest.


### PR DESCRIPTION
… so it works with studio-plugin project