### PR TITLE
Enable parallel builds for gradle-profiler

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 profiler.version=0.17.0-alpha09
 org.gradle.caching=true
+org.gradle.parallel=true


### PR DESCRIPTION
Speed up the builder of gradle-profiler that currently was all running on a single core.