### PR TITLE
Use absolute paths for async-profiler output files

### DIFF
--- a/src/main/java/org/gradle/profiler/CommandLineParser.java
+++ b/src/main/java/org/gradle/profiler/CommandLineParser.java
@@ -97,7 +97,7 @@ class CommandLineParser {
             return null;
         }
 
-        File projectDir = parsedOptions.valueOf(projectOption);
+        File projectDir = toAbsoluteFileOrNull(parsedOptions.valueOf(projectOption));
         boolean hasProfiler = parsedOptions.has(profilerOption);
         ProfilerFactory profilerFactory = ProfilerFactory.NONE;
         if (hasProfiler) {
@@ -111,8 +111,8 @@ class CommandLineParser {
             return fail(parser, "Neither --profile or --benchmark specified.");
         }
 
-        File outputDir = parsedOptions.valueOf(outputDirOption);
-        File gradleUserHome = parsedOptions.valueOf(gradleUserHomeOption);
+        File outputDir = toAbsoluteFileOrNull(parsedOptions.valueOf(outputDirOption));
+        File gradleUserHome = toAbsoluteFileOrNull(parsedOptions.valueOf(gradleUserHomeOption));
         Integer warmups = parsedOptions.valueOf(warmupsOption);
         Integer iterations = parsedOptions.valueOf(iterationsOption);
         boolean measureGarbageCollection = parsedOptions.has(measureGarbageCollectionOption);
@@ -121,9 +121,9 @@ class CommandLineParser {
 
         List<String> targetNames = parsedOptions.nonOptionArguments().stream().map(Object::toString).collect(Collectors.toList());
         List<String> gradleVersions = parsedOptions.valuesOf(gradleVersionOption);
-        File scenarioFile = parsedOptions.valueOf(scenarioFileOption);
-        File studioInstallDir = parsedOptions.valueOf(studioHomeOption);
-        File studioSandboxDir = parsedOptions.valueOf(studioSandboxOption);
+        File scenarioFile = toAbsoluteFileOrNull(parsedOptions.valueOf(scenarioFileOption));
+        File studioInstallDir = toAbsoluteFileOrNull(parsedOptions.valueOf(studioHomeOption));
+        File studioSandboxDir = toAbsoluteFileOrNull(parsedOptions.valueOf(studioSandboxOption));
         if (parsedOptions.has(disableStudioSandbox)) {
             studioSandboxDir = null;
         } else if (studioSandboxDir == null) {
@@ -216,5 +216,9 @@ class CommandLineParser {
 
     private void showVersion() {
         System.out.printf("Gradle Profiler version %s%n", CommandLineParser.class.getPackage().getImplementationVersion());
+    }
+
+    private File toAbsoluteFileOrNull(@Nullable File file) {
+        return file == null ? null : file.getAbsoluteFile();
     }
 }

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
@@ -9,13 +9,13 @@ public enum AsyncProfilerOutputType {
     STACKS("collapsed") {
         @Override
         File outputFileFor(ScenarioSettings settings) {
-            return settings.profilerOutputLocationFor(".stacks.txt");
+            return settings.profilerOutputLocationFor(".stacks.txt").getAbsoluteFile();
         }
     },
     JFR("jfr") {
         @Override
         File outputFileFor(ScenarioSettings settings) {
-            return settings.computeJfrProfilerOutputLocation();
+            return settings.computeJfrProfilerOutputLocation().getAbsoluteFile();
         }
     };
 
@@ -34,7 +34,7 @@ public enum AsyncProfilerOutputType {
     abstract File outputFileFor(ScenarioSettings settings);
 
     File individualOutputFileFor(ScenarioSettings settings) {
-        File outputFile = outputFileFor(settings).getAbsoluteFile();
+        File outputFile = outputFileFor(settings);
         return settings.getScenario().createsMultipleProcesses()
             ? new File(outputFile, "profile-%t-%p.jfr")
             : outputFile;

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
@@ -34,7 +34,7 @@ public enum AsyncProfilerOutputType {
     abstract File outputFileFor(ScenarioSettings settings);
 
     File individualOutputFileFor(ScenarioSettings settings) {
-        File outputFile = outputFileFor(settings);
+        File outputFile = outputFileFor(settings).getAbsoluteFile();
         return settings.getScenario().createsMultipleProcesses()
             ? new File(outputFile, "profile-%t-%p.jfr")
             : outputFile;

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerOutputType.java
@@ -9,13 +9,13 @@ public enum AsyncProfilerOutputType {
     STACKS("collapsed") {
         @Override
         File outputFileFor(ScenarioSettings settings) {
-            return settings.profilerOutputLocationFor(".stacks.txt").getAbsoluteFile();
+            return settings.profilerOutputLocationFor(".stacks.txt");
         }
     },
     JFR("jfr") {
         @Override
         File outputFileFor(ScenarioSettings settings) {
-            return settings.computeJfrProfilerOutputLocation().getAbsoluteFile();
+            return settings.computeJfrProfilerOutputLocation();
         }
     };
 


### PR DESCRIPTION
When testing Android Studio sync with gradle-profiler I noticed after a long debugging session that profiler does not work if absolute --output-dir is not set. This fixes it so absolute paths are passed in JVM args.