### PR TITLE
Output chrome trace file for every invocation

### DIFF
--- a/src/main/java/org/gradle/profiler/BuildUnderTestInvoker.java
+++ b/src/main/java/org/gradle/profiler/BuildUnderTestInvoker.java
@@ -54,6 +54,7 @@ public class BuildUnderTestInvoker {
         public GradleBuildInvocationResult run(BuildContext buildContext, BuildStep buildStep) {
             List<String> jvmArgs = new ArrayList<>(BuildUnderTestInvoker.this.jvmArgs);
             jvmArgs.add("-Dorg.gradle.profiler.phase=" + buildContext.getPhase());
+            jvmArgs.add("-Dorg.gradle.profiler.phase.display.name=" + buildContext.getPhase().getDisplayName());
             jvmArgs.add("-Dorg.gradle.profiler.number=" + buildContext.getIteration());
             jvmArgs.add("-Dorg.gradle.profiler.step=" + buildStep);
 

--- a/src/main/java/org/gradle/profiler/Phase.java
+++ b/src/main/java/org/gradle/profiler/Phase.java
@@ -12,4 +12,8 @@ public enum Phase {
 	public String displayBuildNumber(int number) {
 		return name + " build #" + number;
 	}
+
+    public String getDisplayName() {
+        return name;
+    }
 }

--- a/src/main/java/org/gradle/profiler/chrometrace/ChromeTraceInstrumentation.java
+++ b/src/main/java/org/gradle/profiler/chrometrace/ChromeTraceInstrumentation.java
@@ -23,16 +23,16 @@ import java.io.PrintWriter;
 
 public class ChromeTraceInstrumentation extends GradleInstrumentation {
     private final File traceFolder;
-    private final String traceFilePattern;
+    private final String traceFileBaseName;
 
     public ChromeTraceInstrumentation(ScenarioSettings scenarioSettings) {
         traceFolder = scenarioSettings.profilerOutputLocationFor("-trace");
         traceFolder.mkdirs();
-        traceFilePattern = scenarioSettings.getProfilerOutputBaseName() + "-{phase}-build-{build}-invocation-{invocation}-trace.json";
+        traceFileBaseName = scenarioSettings.getProfilerOutputBaseName();
     }
 
     @Override
     protected void generateInitScriptBody(PrintWriter writer) {
-        writer.println("org.gradle.trace.GradleTracingPlugin.start(gradle, new File(new URI(\"" + traceFolder.toURI() + "\")), \"" + traceFilePattern + "\")");
+        writer.println("org.gradle.trace.GradleTracingPlugin.start(gradle, new File(new URI(\"" + traceFolder.toURI() + "\")), \"" + traceFileBaseName + "\")");
     }
 }

--- a/src/main/java/org/gradle/profiler/chrometrace/ChromeTraceInstrumentation.java
+++ b/src/main/java/org/gradle/profiler/chrometrace/ChromeTraceInstrumentation.java
@@ -22,14 +22,17 @@ import java.io.File;
 import java.io.PrintWriter;
 
 public class ChromeTraceInstrumentation extends GradleInstrumentation {
-    private final File traceFile;
+    private final File traceFolder;
+    private final String traceFilePattern;
 
     public ChromeTraceInstrumentation(ScenarioSettings scenarioSettings) {
-        traceFile = scenarioSettings.profilerOutputLocationFor("-trace.json");
+        traceFolder = scenarioSettings.profilerOutputLocationFor("-trace");
+        traceFolder.mkdirs();
+        traceFilePattern = scenarioSettings.getProfilerOutputBaseName() + "-{phase}-build-{build}-invocation-{invocation}-trace.json";
     }
 
     @Override
     protected void generateInitScriptBody(PrintWriter writer) {
-        writer.println("org.gradle.trace.GradleTracingPlugin.start(gradle, new File(new URI(\"" + traceFile.toURI() + "\")))");
+        writer.println("org.gradle.trace.GradleTracingPlugin.start(gradle, new File(new URI(\"" + traceFolder.toURI() + "\")), \"" + traceFilePattern + "\")");
     }
 }

--- a/src/test/groovy/org/gradle/profiler/ChromeTraceIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ChromeTraceIntegrationTest.groovy
@@ -1,9 +1,10 @@
 package org.gradle.profiler
 
+import org.gradle.profiler.studio.tools.StudioFinder
 import org.gradle.util.GradleVersion
+import spock.lang.Requires
 import spock.lang.Shared
 import spock.lang.Unroll
-
 
 class ChromeTraceIntegrationTest extends AbstractProfilerIntegrationTest {
     static final MINIMAL_SUPPORTED_VERSION_FOR_CHROME_TRACE = GradleVersion.version("3.5")
@@ -23,7 +24,9 @@ class ChromeTraceIntegrationTest extends AbstractProfilerIntegrationTest {
             run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", versionUnderTest, "--profile", "chrome-trace", "assemble")
 
         then:
-        new File(outputDir, "${versionUnderTest}-trace.json").isFile()
+        new File(outputDir, "${versionUnderTest}-trace/${versionUnderTest}-warm-up-build-1-invocation-1-trace.json").isFile()
+        new File(outputDir, "${versionUnderTest}-trace/${versionUnderTest}-warm-up-build-2-invocation-1-trace.json").isFile()
+        new File(outputDir, "${versionUnderTest}-trace/${versionUnderTest}-measured-build-1-invocation-1-trace.json").isFile()
 
         where:
         versionUnderTest << supportedGradleVersionsForChromeTrace
@@ -39,7 +42,8 @@ class ChromeTraceIntegrationTest extends AbstractProfilerIntegrationTest {
             run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", versionUnderTest, "--profile", "chrome-trace", "--cold-daemon", "assemble")
 
         then:
-        new File(outputDir, "${versionUnderTest}-trace.json").isFile()
+        new File(outputDir, "${versionUnderTest}-trace/${versionUnderTest}-warm-up-build-1-invocation-1-trace.json").isFile()
+        new File(outputDir, "${versionUnderTest}-trace/${versionUnderTest}-measured-build-1-invocation-1-trace.json").isFile()
 
         where:
         versionUnderTest << supportedGradleVersionsForChromeTrace
@@ -55,9 +59,38 @@ class ChromeTraceIntegrationTest extends AbstractProfilerIntegrationTest {
             run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", versionUnderTest, "--profile", "chrome-trace", "--no-daemon", "assemble")
 
         then:
-        new File(outputDir, "${versionUnderTest}-trace.json").isFile()
+        new File(outputDir, "${versionUnderTest}-trace/${versionUnderTest}-warm-up-build-1-invocation-1-trace.json").isFile()
+        new File(outputDir, "${versionUnderTest}-trace/${versionUnderTest}-measured-build-1-invocation-1-trace.json").isFile()
 
         where:
         versionUnderTest << supportedGradleVersionsForChromeTrace
+    }
+
+    @Requires({ StudioFinder.findStudioHome() })
+    def "profiles build to produce chrome trace output for builds with multiple gradle invocations"() {
+        given:
+        def studioHome = StudioFinder.findStudioHome()
+        new File(projectDir, "buildSrc").mkdirs()
+        new File(projectDir, "buildSrc/gradle.build").createNewFile()
+        def scenarioFile = file("performance.scenarios") << """
+            scenario {
+                android-studio-sync {}
+            }
+        """
+
+        when:
+        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath,
+            "--gradle-version", latestSupportedGradleVersion,
+            "--profile", "chrome-trace",
+            "--scenario-file", scenarioFile.absolutePath,
+            "--studio-install-dir", studioHome.absolutePath,
+            "--warmups", "1",
+            "--iterations", "1")
+
+        then:
+        new File(outputDir, "scenario-${latestSupportedGradleVersion}-trace/scenario-${latestSupportedGradleVersion}-warm-up-build-1-invocation-1-trace.json").isFile()
+        new File(outputDir, "scenario-${latestSupportedGradleVersion}-trace/scenario-${latestSupportedGradleVersion}-warm-up-build-1-invocation-2-trace.json").isFile()
+        new File(outputDir, "scenario-${latestSupportedGradleVersion}-trace/scenario-${latestSupportedGradleVersion}-measured-build-1-invocation-1-trace.json").isFile()
+        new File(outputDir, "scenario-${latestSupportedGradleVersion}-trace/scenario-${latestSupportedGradleVersion}-measured-build-1-invocation-2-trace.json").isFile()
     }
 }

--- a/subprojects/chrome-trace/src/main/java/org/gradle/trace/GradleTracingPlugin.java
+++ b/subprojects/chrome-trace/src/main/java/org/gradle/trace/GradleTracingPlugin.java
@@ -1,7 +1,5 @@
 package org.gradle.trace;
 
-import static org.gradle.trace.util.ReflectionUtil.invokerGetter;
-
 import org.gradle.BuildAdapter;
 import org.gradle.BuildResult;
 import org.gradle.api.internal.GradleInternal;
@@ -15,6 +13,8 @@ import org.gradle.trace.util.TimeUtil;
 import java.io.File;
 import java.util.HashMap;
 
+import static org.gradle.trace.util.ReflectionUtil.invokerGetter;
+
 public class GradleTracingPlugin {
     private static final String CATEGORY_PHASE = "BUILD_PHASE";
     private static final String PHASE_BUILD = "build duration";
@@ -25,18 +25,36 @@ public class GradleTracingPlugin {
     private final GCMonitoring gcMonitoring = new GCMonitoring();
     private final BuildOperationListenerAdapter buildOperationListener;
 
-    private GradleTracingPlugin(GradleInternal gradle, File traceFile) {
+    private GradleTracingPlugin(GradleInternal gradle, File traceFolder, String traceFilePattern) {
         this.buildRequestMetaData = gradle.getServices().get(BuildRequestMetaData.class);
-        traceResult = new TraceResult(traceFile);
+        traceResult = new TraceResult(getTraceFile(traceFolder, traceFilePattern));
         systemMonitoring.start(traceResult);
         gcMonitoring.start(traceResult);
         buildOperationListener = BuildOperationListenerAdapter.create(gradle, traceResult);
         gradle.addListener(new TraceFinalizerAdapter(gradle));
     }
 
+    private File getTraceFile(File traceFolder, String traceFilePatter) {
+        String phase = System.getProperty("org.gradle.profiler.phase.display.name");
+        String build = System.getProperty("org.gradle.profiler.number");
+        int invocation = 1;
+        File traceFile;
+        do {
+            String traceFileName = traceFilePatter.replace("{phase}", phase)
+                .replace("{build}", build)
+                .replace("{invocation}", String.valueOf(invocation));
+            traceFile = new File(traceFolder.getAbsoluteFile(), traceFileName);
+            invocation++;
+        } while (traceFile.exists());
+        return traceFile;
+    }
+
+    /**
+     * org.gradle.profiler.chrometrace.ChromeTraceInstrumentation writes a build init script that calls this
+     */
     @SuppressWarnings("unused")
-    public static void start(GradleInternal gradle, File traceFile) {
-        new GradleTracingPlugin(gradle, traceFile);
+    public static void start(GradleInternal gradle, File traceFile, String traceFilePattern) {
+        new GradleTracingPlugin(gradle, traceFile, traceFilePattern);
     }
 
     private class TraceFinalizerAdapter extends BuildAdapter {


### PR DESCRIPTION
So now chrome trace outputs file for every gradle invocation separately. 