### PR TITLE
Automatically install Android SDK on CI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+
 import com.moowork.gradle.node.npm.NpxTask
 import io.sdkman.vendors.tasks.SdkAnnounceVersionTask
 import io.sdkman.vendors.tasks.SdkDefaultVersionTask
@@ -134,6 +135,10 @@ androidStudioTests {
     runAndroidStudioInHeadlessMode.set(autoDownloadAndRunInHeadless)
     autoDownloadAndroidStudio.set(autoDownloadAndRunInHeadless)
     testAndroidStudioVersion.set("2021.1.1.16")
+    testAndroidSdkVersion.set("7.0.0")
+    // For local development it's easier to setup Android SDK with Android Studio, since auto download needs ANDROID_SDK_ROOT to be set with
+    // a accepted license in it. See https://developer.android.com/studio/intro/update.html#download-with-gradle.
+    autoDownloadAndroidSdk.set(autoDownloadAndRunInHeadless)
 }
 
 val testReports = mapOf(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import io.sdkman.vendors.tasks.SdkAnnounceVersionTask
 import io.sdkman.vendors.tasks.SdkDefaultVersionTask
 import io.sdkman.vendors.tasks.SdkReleaseVersionTask
 import io.sdkman.vendors.tasks.SdkmanVendorBaseTask
-import java.util.Locale
+import java.util.*
 
 plugins {
     id("profiler.java-library")
@@ -135,9 +135,9 @@ androidStudioTests {
     runAndroidStudioInHeadlessMode.set(autoDownloadAndRunInHeadless)
     autoDownloadAndroidStudio.set(autoDownloadAndRunInHeadless)
     testAndroidStudioVersion.set("2021.1.1.16")
-    testAndroidSdkVersion.set("7.0.0")
+    testAndroidSdkVersion.set("7.1.0-beta04")
     // For local development it's easier to setup Android SDK with Android Studio, since auto download needs ANDROID_SDK_ROOT to be set with
-    // a accepted license in it. See https://developer.android.com/studio/intro/update.html#download-with-gradle.
+    // an accepted license in it. See https://developer.android.com/studio/intro/update.html#download-with-gradle.
     autoDownloadAndroidSdk.set(autoDownloadAndRunInHeadless)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,9 @@
-
 import com.moowork.gradle.node.npm.NpxTask
 import io.sdkman.vendors.tasks.SdkAnnounceVersionTask
 import io.sdkman.vendors.tasks.SdkDefaultVersionTask
 import io.sdkman.vendors.tasks.SdkReleaseVersionTask
 import io.sdkman.vendors.tasks.SdkmanVendorBaseTask
-import java.util.*
+import java.util.Locale
 
 plugins {
     id("profiler.java-library")

--- a/buildSrc/src/main/kotlin/extensions/AndroidStudioTestExtension.kt
+++ b/buildSrc/src/main/kotlin/extensions/AndroidStudioTestExtension.kt
@@ -7,5 +7,7 @@ interface AndroidStudioTestExtension {
     val autoDownloadAndroidStudio: Property<Boolean>
     val testAndroidStudioVersion: Property<String>
     val runAndroidStudioInHeadlessMode: Property<Boolean>
+    val autoDownloadAndroidSdk: Property<Boolean>
+    val testAndroidSdkVersion: Property<String>
 
 }

--- a/buildSrc/src/main/kotlin/profiler.android-studio-setup.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.android-studio-setup.gradle.kts
@@ -60,7 +60,6 @@ val unpackAndroidStudio = tasks.register<Copy>("unpackAndroidStudio") {
 }
 
 val installAndroidSdk = tasks.register<InstallAndroidSdkTask>("installAndroidSdk") {
-    androidSdkRootEnvVariable.set(providers.environmentVariable("ANDROID_SDK_ROOT"))
     androidSdkVersion.set(extension.testAndroidSdkVersion)
     androidProjectDir.set(layout.buildDirectory.dir("installAndroidSdk/android-sdk-project"))
     onlyIf { extension.autoDownloadAndroidSdk.get() }

--- a/buildSrc/src/main/kotlin/tasks/InstallAndroidSdkTask.kt
+++ b/buildSrc/src/main/kotlin/tasks/InstallAndroidSdkTask.kt
@@ -40,15 +40,14 @@ abstract class InstallAndroidSdkTask : DefaultTask() {
     }
 
     private fun buildAndroidProject(projectDir: File) {
-        try {
-            val connector = GradleConnector.newConnector()
-                .forProjectDirectory(projectDir)
-            connector.connect().use {
-                it.newBuild().forTasks("build").run()
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
-            throw e
+        val connector = GradleConnector.newConnector()
+            .forProjectDirectory(projectDir)
+        connector.connect().use {
+            it.newBuild().forTasks("build")
+                .addArguments("--stacktrace")
+                .setStandardError(System.err)
+                .setStandardOutput(System.out)
+                .run()
         }
     }
 

--- a/buildSrc/src/main/kotlin/tasks/InstallAndroidSdkTask.kt
+++ b/buildSrc/src/main/kotlin/tasks/InstallAndroidSdkTask.kt
@@ -3,42 +3,36 @@ package tasks
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
-import org.gradle.api.file.ProjectLayout
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.*
 import org.gradle.tooling.GradleConnector
 import java.io.File
-import javax.inject.Inject
 
 /**
  * Installs Android SDK. This task requires the ANDROID_SDK_ROOT env variable to be set.
  */
+@UntrackedTask(because = "Output directory can change when running other builds")
 abstract class InstallAndroidSdkTask : DefaultTask() {
 
     @get:Input
     abstract val androidSdkVersion: Property<String>
 
-    @get:OutputDirectory
-    abstract val androidProjectDir: DirectoryProperty
-
     /**
      * Optional since we use manual error message
      */
+    @get:Input
     @get:Optional
-    @get:OutputDirectory
-    abstract val androidSdkInstallationDir: DirectoryProperty
+    abstract val androidSdkRootEnvVariable: Property<String>
 
-    @get:Inject
-    abstract val projectLayout: ProjectLayout
+    @get:OutputDirectory
+    abstract val androidProjectDir: DirectoryProperty
 
     @TaskAction
     fun install() {
-        if (!androidSdkInstallationDir.isPresent) {
-            throw GradleException("Output 'androidSdkInstallationDir' is not set, you should set ANDROID_SDK_ROOT env variable with Android Studio license in it.")
+        if (!androidSdkRootEnvVariable.isPresent) {
+            throw GradleException("ANDROID_SDK_ROOT env variable is not set but it should be.")
         }
+
         val androidSdkVersion = androidSdkVersion.get()
         val projectDir = androidProjectDir.get().asFile
 

--- a/buildSrc/src/main/kotlin/tasks/InstallAndroidSdkTask.kt
+++ b/buildSrc/src/main/kotlin/tasks/InstallAndroidSdkTask.kt
@@ -4,7 +4,11 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
 import org.gradle.tooling.GradleConnector
 import java.io.File
 

--- a/buildSrc/src/main/kotlin/tasks/InstallAndroidSdkTask.kt
+++ b/buildSrc/src/main/kotlin/tasks/InstallAndroidSdkTask.kt
@@ -40,10 +40,15 @@ abstract class InstallAndroidSdkTask : DefaultTask() {
     }
 
     private fun buildAndroidProject(projectDir: File) {
-        val connector = GradleConnector.newConnector()
-            .forProjectDirectory(projectDir)
-        connector.connect().use {
-            it.newBuild().forTasks("build").run()
+        try {
+            val connector = GradleConnector.newConnector()
+                .forProjectDirectory(projectDir)
+            connector.connect().use {
+                it.newBuild().forTasks("build").run()
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+            throw e
         }
     }
 

--- a/buildSrc/src/main/kotlin/tasks/InstallAndroidSdkTask.kt
+++ b/buildSrc/src/main/kotlin/tasks/InstallAndroidSdkTask.kt
@@ -5,7 +5,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.UntrackedTask
@@ -21,20 +20,16 @@ abstract class InstallAndroidSdkTask : DefaultTask() {
     @get:Input
     abstract val androidSdkVersion: Property<String>
 
-    /**
-     * Optional since we use manual error message
-     */
-    @get:Input
-    @get:Optional
-    abstract val androidSdkRootEnvVariable: Property<String>
-
     @get:OutputDirectory
     abstract val androidProjectDir: DirectoryProperty
 
     @TaskAction
     fun install() {
-        if (!androidSdkRootEnvVariable.isPresent) {
-            throw GradleException("ANDROID_SDK_ROOT env variable is not set but it should be.")
+        if (System.getenv("ANDROID_SDK_ROOT") == null) {
+            throw GradleException(
+                "ANDROID_SDK_ROOT env variable is not set but it should be with the installation directory path. " +
+                    "The installation directory should also contain the Android sdk license key. See https://developer.android.com/studio/intro/update.html#download-with-gradle."
+            )
         }
 
         val androidSdkVersion = androidSdkVersion.get()

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
To avoid test failures on fresh agents without Android SDK.