### PR TITLE
Fix flakiness of AsyncProfilerIntegrationTest and DifferentialFlameGraphIntegrationTest

### DIFF
--- a/src/test/groovy/org/gradle/profiler/AsyncProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AsyncProfilerIntegrationTest.groovy
@@ -11,10 +11,13 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest imple
         instrumentedBuildScript()
 
         when:
-        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion, "--profile", "async-profiler", "assemble")
+        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath,
+            "--gradle-version", latestSupportedGradleVersion,
+            "--iterations", "3",
+            "--profile", "async-profiler", "assemble")
 
         then:
-        logFile.find("<daemon: true").size() == 4
+        logFile.find("<daemon: true").size() == 6
         logFile.containsOne("<invocations: 3>")
 
         and:
@@ -181,10 +184,14 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest imple
         """
 
         when:
-        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion, "--profile", profiler, "--scenario-file", scenarios.absolutePath, "a/b")
+        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath,
+            "--gradle-version", latestSupportedGradleVersion,
+            "--iterations", "3",
+            "--profile", profiler,
+            "--scenario-file", scenarios.absolutePath, "a/b")
 
         then:
-        logFile.find("<daemon: true").size() == 4
+        logFile.find("<daemon: true").size() == 6
         logFile.containsOne("<invocations: 3>")
 
         and:

--- a/src/test/groovy/org/gradle/profiler/AsyncProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AsyncProfilerIntegrationTest.groovy
@@ -28,13 +28,13 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest imple
         when:
         new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath,
             "--gradle-version", latestSupportedGradleVersion,
-            "--iterations", "2",
+            "--iterations", "3",
             "--profile", "async-profiler-all",
             "assemble"
         )
 
         then:
-        logFile.find("<daemon: true").size() == 5
+        logFile.find("<daemon: true").size() == 6
         logFile.containsOne("<invocations: 3>")
 
         and:
@@ -47,13 +47,14 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest imple
 
         when:
         new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion, "--profile", "async-profiler",
+            "--iterations", "3",
             "--async-profiler-event", "wall",
             "--async-profiler-event", "alloc",
             "assemble"
         )
 
         then:
-        logFile.find("<daemon: true").size() == 4
+        logFile.find("<daemon: true").size() == 6
         logFile.containsOne("<invocations: 3>")
 
         and:
@@ -65,10 +66,13 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest imple
         instrumentedBuildScript()
 
         when:
-        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion, "--profile", "async-profiler-heap", "assemble")
+        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath,
+            "--iterations", "3",
+            "--gradle-version", latestSupportedGradleVersion,
+            "--profile", "async-profiler-heap", "assemble")
 
         then:
-        logFile.find("<daemon: true").size() == 4
+        logFile.find("<daemon: true").size() == 6
         logFile.containsOne("<invocations: 3>")
 
         and:
@@ -80,10 +84,10 @@ class AsyncProfilerIntegrationTest extends AbstractProfilerIntegrationTest imple
         instrumentedBuildScript()
 
         when:
-        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion, "--profile", profiler, "--iterations", "2", "assemble")
+        new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion, "--profile", profiler, "--iterations", "3", "assemble")
 
         then:
-        logFile.find("<daemon: true").size() == 5
+        logFile.find("<daemon: true").size() == 6
         logFile.containsOne("<invocations: 4>")
 
         and:

--- a/src/test/groovy/org/gradle/profiler/DifferentialFlameGraphIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/DifferentialFlameGraphIntegrationTest.groovy
@@ -14,12 +14,12 @@ class DifferentialFlameGraphIntegrationTest extends AbstractProfilerIntegrationT
         new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath,
             "--gradle-version", latestSupportedGradleVersion,
             "--gradle-version", minimalSupportedGradleVersion,
-            "--iterations", "2",
+            "--iterations", "3",
             "--profile", profiler,
             "assemble")
 
         then:
-        logFile.find("<daemon: true").size() == 10
+        logFile.find("<daemon: true").size() == 12
         logFile.find("<invocations: 3>").size() == 2
 
         and:
@@ -43,13 +43,13 @@ class DifferentialFlameGraphIntegrationTest extends AbstractProfilerIntegrationT
         when:
         new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion, "--gradle-version", minimalSupportedGradleVersion,
             "--scenario-file", scenarioFile.absolutePath,
-            "--iterations", "2",
+            "--iterations", "3",
             "--profile", profiler,
             "upToDate"
         )
 
         then:
-        logFile.find("<daemon: true").size() == 10
+        logFile.find("<daemon: true").size() == 12
         logFile.find("<invocations: 3>").size() == 2
 
         and:
@@ -77,13 +77,13 @@ class DifferentialFlameGraphIntegrationTest extends AbstractProfilerIntegrationT
         when:
         new Main().run("--project-dir", projectDir.absolutePath, "--output-dir", outputDir.absolutePath, "--gradle-version", latestSupportedGradleVersion,
             "--scenario-file", scenarioFile.absolutePath,
-            "--iterations", "2",
+            "--iterations", "3",
             "--profile", profiler,
             "upToDate", "help"
         )
 
         then:
-        logFile.find("<daemon: true").size() == 9
+        logFile.find("<daemon: true").size() == 11
         logFile.find("<invocations: 3>").size() == 2
 
         and:
@@ -104,12 +104,12 @@ class DifferentialFlameGraphIntegrationTest extends AbstractProfilerIntegrationT
             "--gradle-version", latestSupportedGradleVersion,
             "--gradle-version", minimalSupportedGradleVersion,
             "--no-diffs",
-            "--iterations", "2",
+            "--iterations", "3",
             "--profile", "async-profiler",
             "assemble")
 
         then:
-        logFile.find("<daemon: true").size() == 10
+        logFile.find("<daemon: true").size() == 12
         logFile.find("<invocations: 3>").size() == 2
 
         and:


### PR DESCRIPTION
Additional iteration is added so the async profiler has more time to capture something. 

Fixes #388