### PR TITLE
Fix non-ABI and android resources mutators

### DIFF
--- a/src/main/java/org/gradle/profiler/mutations/ApplyChangeToAndroidResourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyChangeToAndroidResourceFileMutator.java
@@ -15,6 +15,6 @@ public class ApplyChangeToAndroidResourceFileMutator extends AbstractFileChangeM
         if (insertPos < 0) {
             throw new IllegalArgumentException("Cannot parse source file " + sourceFile + " to apply changes");
         }
-        text.insert(insertPos, "<string name=\"new_resource\">" + context.getUniqueBuildId() + "</string>");
+        text.insert(insertPos, "<string name=\"new_resource"+ context.getUniqueBuildId() + "\">" + context.getUniqueBuildId() + "</string>");
     }
 }

--- a/src/main/java/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutator.java
@@ -15,7 +15,7 @@ public class ApplyNonAbiChangeToKotlinSourceFileMutator extends AbstractKotlinSo
         text.append('\n')
             .append("private fun _m")
             .append(context.getUniqueScenarioId())
-            .append("() {requireNotNull(\"")
+            .append("() {println(\"")
             .append(context.getUniqueBuildId())
             .append("\")}");
     }

--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -910,8 +910,8 @@ classes {
         then:
         // Probe version, 6 warm up, 10 builds
         logFile.find("<src-length: ${srcFile.length()}>").size() == 1
-        logFile.find("<src-length: ${srcFile.length() + 101}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
-        logFile.find("<src-length: ${srcFile.length() + 102}>").size() == 1 /* MEASURE #10 */
+        logFile.find("<src-length: ${srcFile.length() + 165}>").size() == 6 /* WARM_UP #1..6 */ + 9 /* MEASURE #1..9*/
+        logFile.find("<src-length: ${srcFile.length() + 167}>").size() == 1 /* MEASURE #10 */
         srcFile.text == originalText
     }
 

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidResourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToAndroidResourceFileMutatorTest.groovy
@@ -12,7 +12,7 @@ class ApplyChangeToAndroidResourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == '<resources><string name="new_resource">_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7</string></resources>'
+        sourceFile.text == '<resources><string name="new_resource_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7">_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7</string></resources>'
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyNonAbiChangeToKotlinSourceFileMutatorTest.groovy
@@ -9,7 +9,7 @@ class ApplyNonAbiChangeToKotlinSourceFileMutatorTest extends AbstractMutatorTest
     static Function<String, String> FUNCTION_TEXT = { qualifier ->
         "class Thing { fun existingMethod() { }}\n" +
             "private fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7() {" +
-            "requireNotNull(\"_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_$qualifier\")" +
+            "println(\"_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_$qualifier\")" +
             "}"
     }
 


### PR DESCRIPTION
Non-ABI: use println so it does not get removed by the compiler
Android resources: generated a new resource name every time

Fixes #378 