### PR TITLE
Add support to run profiler with IntelliJ

### DIFF
--- a/src/main/java/org/gradle/profiler/studio/launcher/LauncherConfigurationParser.java
+++ b/src/main/java/org/gradle/profiler/studio/launcher/LauncherConfigurationParser.java
@@ -95,6 +95,8 @@ public class LauncherConfigurationParser {
         studioSandbox.getSystemDir().ifPresent(path -> systemProperties.put("idea.system.path", path.toString()));
         systemProperties.put("idea.plugins.path", studioSandbox.getPluginsDir().toString());
         systemProperties.put("idea.log.path", studioSandbox.getLogsDir().toString());
+        // Newer IntelliJ versions require this property to avoid trust project popup
+        systemProperties.put("idea.trust.all.projects", "true");
         if (SHOULD_RUN_HEADLESS) {
             systemProperties.put("java.awt.headless", "true");
         }

--- a/src/main/java/org/gradle/profiler/studio/launcher/StudioConfigurationProvider.java
+++ b/src/main/java/org/gradle/profiler/studio/launcher/StudioConfigurationProvider.java
@@ -34,6 +34,10 @@ public class StudioConfigurationProvider {
             .map(studioInstallDir::resolve)
             .collect(Collectors.toList());
         Path javaCommand = studioInstallDir.resolve("jre/bin/java");
+        if (!javaCommand.toFile().exists()) {
+            // Try IntelliJ location
+            javaCommand = studioInstallDir.resolve("jbr/bin/java");
+        }
         Map<String, String> systemProperties = ImmutableMap.<String, String>builder()
             .put("idea.vendor.name", "Google")
             .put("idea.executable", "studio")
@@ -59,6 +63,10 @@ public class StudioConfigurationProvider {
         Map<String, String> systemProperties = mapValues(jvmOptions.dict("Properties").toMap(), v -> v.replace("$APP_PACKAGE", actualInstallDir.toString()));
         String mainClass = jvmOptions.string("MainClass");
         Path javaCommand = actualInstallDir.resolve("Contents/jre/Contents/Home/bin/java");
+        if (!javaCommand.toFile().exists()) {
+            // Try IntelliJ location
+            javaCommand = actualInstallDir.resolve("Contents/jbr/Contents/Home/bin/java");
+        }
         return new StudioConfiguration(mainClass, actualInstallDir, javaCommand, classPath, systemProperties);
     }
 

--- a/src/main/java/org/gradle/profiler/studio/launcher/StudioConfigurationProvider.java
+++ b/src/main/java/org/gradle/profiler/studio/launcher/StudioConfigurationProvider.java
@@ -21,17 +21,9 @@ import java.util.stream.Stream;
 
 public class StudioConfigurationProvider {
 
-    private static final List<String> DEFAULT_JAVA_PATHS = ImmutableList.<String>builder()
-        // MacOS Studio and IntelliJ paths
-        .add("Contents/jre/Contents/Home/bin/java")
-        .add("Contents/jbr/Contents/Home/bin/java")
-        // Linux Studio and IntelliJ paths
-        .add("jre/bin/java")
-        .add("jbr/bin/java")
-        // Windows Studio and IntelliJ paths
-        .add("jre/bin/java.exe")
-        .add("jbr/bin/java.exe")
-        .build();
+    private static final List<String> DEFAULT_MACOS_JAVA_PATHS = ImmutableList.of("Contents/jre/Contents/Home/bin/java", "Contents/jbr/Contents/Home/bin/java");
+    private static final List<String> DEFAULT_WINDOWS_JAVA_PATHS = ImmutableList.of("jre/bin/java.exe", "jbr/bin/java.exe");
+    private static final List<String> DEFAULT_LINUX_JAVA_PATHS = ImmutableList.of("jre/bin/java", "jbr/bin/java");
 
     public static StudioConfiguration getLaunchConfiguration(Path studioInstallDir) {
         if (OperatingSystem.isMacOS()) {
@@ -76,11 +68,21 @@ public class StudioConfigurationProvider {
     }
 
     private static Path getJavaPath(Path studioInstallDir) {
-        return DEFAULT_JAVA_PATHS.stream()
+        return getDefaultJavaPathsForOs().stream()
             .map(studioInstallDir::resolve)
             .filter(path -> path.toFile().exists())
             .findFirst()
             .orElseThrow(() -> new RuntimeException("Could not find Java executable in " + studioInstallDir));
+    }
+
+    private static List<String> getDefaultJavaPathsForOs() {
+        if (OperatingSystem.isMacOS()) {
+            return DEFAULT_MACOS_JAVA_PATHS;
+        } else if (OperatingSystem.isWindows()) {
+            return DEFAULT_WINDOWS_JAVA_PATHS;
+        } else {
+            return DEFAULT_LINUX_JAVA_PATHS;
+        }
     }
 
     private static Dict parse(Path infoFile) {


### PR DESCRIPTION
Unofficial support for IntelliJ, tested on MacOS with 2021.3.2 and 2022.1 EAP locally.