### PR TITLE
add lib/util_rt.jar to work with AS electric eel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "gradle-profiler",
+  "name": "gradle-profiler-fork",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/main/java/org/gradle/profiler/studio/launcher/StudioConfigurationProvider.java
+++ b/src/main/java/org/gradle/profiler/studio/launcher/StudioConfigurationProvider.java
@@ -35,7 +35,7 @@ public class StudioConfigurationProvider {
 
     private static StudioConfiguration getWindowsOrLinuxConfiguration(Path studioInstallDir) {
         String mainClass = "com.intellij.idea.Main";
-        List<Path> classPath = Stream.of("lib/bootstrap.jar", "lib/util.jar", "lib/jdom.jar", "lib/log4j.jar", "lib/jna.jar")
+        List<Path> classPath = Stream.of("lib/bootstrap.jar", "lib/util.jar", "lib/util_rt.jar", "lib/jdom.jar", "lib/log4j.jar", "lib/jna.jar")
             .map(studioInstallDir::resolve)
             .collect(Collectors.toList());
         Path javaPath = getJavaPath(studioInstallDir);

--- a/subprojects/studio-plugin/build.gradle.kts
+++ b/subprojects/studio-plugin/build.gradle.kts
@@ -18,6 +18,7 @@ repositories {
 dependencies {
     implementation(project(":client-protocol"))
     testFixturesImplementation(project(":client-protocol"))
+    implementation(files("libstudio.proto.jar"))
 }
 
 // Applied configurations by gradle-intellij-plugin can be found here:
@@ -41,7 +42,7 @@ java {
 
 intellij {
     pluginName.set("gradle-profiler-studio-plugin")
-    version.set("2021.1.1")
+    version.set("2022.1.3")
     // Don't override "since-build" and "until-build" properties in plugin.xml,
     // so we don't need to update plugin to use it also on future IntelliJ versions.
     updateSinceUntilBuild.set(false)

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/AndroidStudioSystemHelper.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/AndroidStudioSystemHelper.java
@@ -2,6 +2,7 @@ package org.gradle.profiler.studio.plugin.system;
 
 import com.android.tools.idea.gradle.project.sync.GradleSyncInvoker;
 import com.android.tools.idea.gradle.project.sync.GradleSyncState;
+import com.android.tools.idea.gradle.project.sync.GradleSyncStateImpl;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
@@ -23,7 +24,7 @@ public class AndroidStudioSystemHelper {
     public static GradleSyncResult doGradleSync(Project project) {
         GradleProfilerGradleSyncListener syncListener = new GradleProfilerGradleSyncListener();
         try {
-            GradleSyncInvoker.getInstance().requestProjectSync(project, TRIGGER_USER_SYNC_ACTION, syncListener);
+            GradleSyncInvoker.getInstance().requestProjectSync(project, new GradleSyncInvoker.Request(TRIGGER_USER_SYNC_ACTION), syncListener);
         } catch (Exception e) {
             e.printStackTrace();
             syncListener.syncFailed(project, e.getMessage());
@@ -36,7 +37,7 @@ public class AndroidStudioSystemHelper {
      */
     public static void waitOnPreviousGradleSyncFinish(Project project) {
         GradleProfilerGradleSyncListener syncListener = new GradleProfilerGradleSyncListener();
-        MessageBusConnection connection = GradleSyncState.subscribe(project, syncListener);
+        MessageBusConnection connection = GradleSyncStateImpl.Companion.subscribe(project, syncListener);
         if (!GradleSyncState.getInstance(project).isSyncInProgress()) {
             // Sync was actually not in progress,
             // just acknowledge the listener, so it won't wait forever.


### PR DESCRIPTION
fixing this issue: 
```
Running command /usr/local/android-studio-2022.1.1.8/jbr/bin/java -cp /usr/local/android-studio-2022.1.1.8/lib/bootstrap.jar:/usr/local/android-studio-2022.1.1.8/lib/util.jar:/usr/local/android-studio-2022.1.1.8/lib/jdom.jar:/usr/local/android-studio-2022.1.1.8/lib/log4j.jar:/usr/local/android-studio-2022.1.1.8/lib/jna.jar -Dgradle.profiler.startup.port=40383 -Dgradle.profiler.port=34771 -Didea.plugins.path=/home/acceptance-matrix/acceptance-matrix/2022-07-28-21-28/spos_gradle-7.5_agp-7.1.3_kotlin-1.6.21_studio-[AI-221](https://jira.sqprod.co/browse/AI-221).5921.22.2211.8786657/studio-sandbox/plugins -Didea.config.path=/home/acceptance-matrix/acceptance-matrix/2022-07-28-21-28/spos_gradle-7.5_agp-7.1.3_kotlin-1.6.21_studio-[AI-221](https://jira.sqprod.co/browse/AI-221).5921.22.2211.8786657/studio-sandbox/config -Didea.log.path=/home/acceptance-matrix/acceptance-matrix/2022-07-28-21-28/spos_gradle-7.5_agp-7.1.3_kotlin-1.6.21_studio-[AI-221](https://jira.sqprod.co/browse/AI-221).5921.22.2211.8786657/studio-sandbox/logs -Djava.awt.headless=true -Didea.trust.all.projects=true -Didea.system.path=/home/acceptance-matrix/acceptance-matrix/2022-07-28-21-28/spos_gradle-7.5_agp-7.1.3_kotlin-1.6.21_studio-[AI-221](https://jira.sqprod.co/browse/AI-221).5921.22.2211.8786657/studio-sandbox/system -Didea.vendor.name=Google -Didea.executable=studio -Didea.platform.prefix=AndroidStudio -javaagent:/tmp/studio-agent11737027762759105054.jar=46351,/tmp/instrumentation-support8830245079449839644.jar --add-exports java.base/jdk.internal.misc=ALL-UNNAMED -Xbootclasspath/a:/tmp/asm12706662800720597114.jar:/tmp/client-protocol8692386342783049662.jar -Xmx16g -XX:ReservedCodeCacheSize=2G -XX:G1HeapRegionSize=8M -XX:MinHeapFreeRatio=10 -XX:MaxHeapFreeRatio=20 com.intellij.idea.Main headless-starter /home/acceptance-matrix/Development/android-register
PROFILER AGENT RUNNING
* Connected to controller process

!bootstrap.error.title.start.failed!
!bootstrap.error.message.internal.error.please.refer.to.0!https://code.google.com/p/android/issues!

java.lang.NoClassDefFoundError: com/intellij/openapi/util/SystemInfoRt
        at com.intellij.openapi.application.PathManager.getHomePathFor(PathManager.java:153)
        at com.intellij.openapi.application.PathManager.getHomePath(PathManager.java:94)
        at com.intellij.openapi.application.PathManager.loadProperties(PathManager.java:532)
        at com.intellij.idea.Main.bootstrap(Main.java:90)
        at com.intellij.idea.Main.main(Main.java:80)
Caused by: java.lang.ClassNotFoundException: com.intellij.openapi.util.SystemInfoRt
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        ... 5 more

-----
!bootstrap.error.message.jre.details!11.0.13+0-b1751.21-8125866 amd64 (JetBrains s.r.o.)
/usr/local/android-studio-2022.1.1.8/jbr!
```