### PR TITLE
Add support for Android Studio Chipmunk (2021.2), Dolphin (2021.3) and Electric Eel (2022.1)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,8 +129,9 @@ androidStudioTests {
     val autoDownloadAndRunInHeadless = providers.gradleProperty("autoDownloadAndRunInHeadless").orNull == "true"
     runAndroidStudioInHeadlessMode.set(autoDownloadAndRunInHeadless)
     autoDownloadAndroidStudio.set(autoDownloadAndRunInHeadless)
-    testAndroidStudioVersion.set("2021.1.1.16")
-    testAndroidSdkVersion.set("7.1.0-beta04")
+    // Electric Eel (2022.1.1) Canary 8
+    testAndroidStudioVersion.set("2022.1.1.8")
+    testAndroidSdkVersion.set("7.3.0-beta04")
     // For local development it's easier to setup Android SDK with Android Studio, since auto download needs ANDROID_SDK_ROOT to be set with
     // an accepted license in it. See https://developer.android.com/studio/intro/update.html#download-with-gradle.
     autoDownloadAndroidSdk.set(autoDownloadAndRunInHeadless)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 groovy = "3.0.8"
-spock = "2.0-groovy-3.0"
+spock = "2.1-groovy-3.0"
 
 [libraries]
 toolingApi = "org.gradle:gradle-tooling-api:7.2"

--- a/src/main/java/org/gradle/profiler/studio/launcher/LauncherConfigurationParser.java
+++ b/src/main/java/org/gradle/profiler/studio/launcher/LauncherConfigurationParser.java
@@ -1,6 +1,7 @@
 package org.gradle.profiler.studio.launcher;
 
 import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
 import org.gradle.profiler.instrument.GradleInstrumentation;
 import org.gradle.profiler.studio.tools.StudioSandboxCreator.StudioSandbox;
 
@@ -15,6 +16,46 @@ import java.util.Map;
 public class LauncherConfigurationParser {
 
     private static final boolean SHOULD_RUN_HEADLESS = Boolean.getBoolean("studio.tests.headless");
+    private static final List<String> JAVA17_ADD_OPENS = ImmutableList.of(
+        "--add-opens=java.base/java.io=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+        "--add-opens=java.base/java.net=ALL-UNNAMED",
+        "--add-opens=java.base/java.nio=ALL-UNNAMED",
+        "--add-opens=java.base/java.nio.charset=ALL-UNNAMED",
+        "--add-opens=java.base/java.text=ALL-UNNAMED",
+        "--add-opens=java.base/java.time=ALL-UNNAMED",
+        "--add-opens=java.base/java.util=ALL-UNNAMED",
+        "--add-opens=java.base/java.util.concurrent=ALL-UNNAMED",
+        "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
+        "--add-opens=java.base/jdk.internal.vm=ALL-UNNAMED",
+        "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+        "--add-opens=java.base/sun.security.ssl=ALL-UNNAMED",
+        "--add-opens=java.base/sun.security.util=ALL-UNNAMED",
+        "--add-opens=java.desktop/com.sun.java.swing.plaf.gtk=ALL-UNNAMED",
+        "--add-opens=java.desktop/java.awt=ALL-UNNAMED",
+        "--add-opens=java.desktop/java.awt.dnd.peer=ALL-UNNAMED",
+        "--add-opens=java.desktop/java.awt.event=ALL-UNNAMED",
+        "--add-opens=java.desktop/java.awt.image=ALL-UNNAMED",
+        "--add-opens=java.desktop/java.awt.peer=ALL-UNNAMED",
+        "--add-opens=java.desktop/javax.swing=ALL-UNNAMED",
+        "--add-opens=java.desktop/javax.swing.plaf.basic=ALL-UNNAMED",
+        "--add-opens=java.desktop/javax.swing.text.html=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.awt.X11=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.awt.datatransfer=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.awt=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.font=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.java2d=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.swing=ALL-UNNAMED",
+        "--add-opens=jdk.attach/sun.tools.attach=ALL-UNNAMED",
+        "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+        "--add-opens=jdk.internal.jvmstat/sun.jvmstat.monitor=ALL-UNNAMED",
+        "--add-opens=jdk.jdi/com.sun.tools.jdi=ALL-UNNAMED",
+        "--add-exports=java.desktop/com.apple.eawt=ALL-UNNAMED",
+        "--add-exports=java.desktop/com.apple.laf=ALL-UNNAMED",
+        "--add-exports=java.desktop/com.apple.eawt.event=ALL-UNNAMED"
+    );
 
     private final Path studioInstallDir;
     private final StudioSandbox studioSandbox;
@@ -67,6 +108,8 @@ public class LauncherConfigurationParser {
         commandLine.add("-cp");
         commandLine.add(Joiner.on(File.pathSeparator).join(classpath));
         systemProperties.forEach((key, value) -> commandLine.add(String.format("-D%s=%s", key, value)));
+        // Support for IntelliJ with Java17 runtime
+        commandLine.addAll(JAVA17_ADD_OPENS);
         if (enableStudioAgentParameters) {
             commandLine.add(String.format("-javaagent:%s=%s,%s", agentJar, studioAgentPort, supportJar));
             commandLine.add("--add-exports");
@@ -97,6 +140,9 @@ public class LauncherConfigurationParser {
         systemProperties.put("idea.log.path", studioSandbox.getLogsDir().toString());
         // Newer IntelliJ versions require this property to avoid trust project popup
         systemProperties.put("idea.trust.all.projects", "true");
+        // Used so wrapper init script is not run by Android Studio.
+        // We anyway override installation in the org.gradle.profiler.studio.instrumented.Interceptor.
+        systemProperties.put("idea.gradle.distributionType", "BUNDLED");
         if (SHOULD_RUN_HEADLESS) {
             systemProperties.put("java.awt.headless", "true");
         }

--- a/src/test/groovy/org/gradle/profiler/studio/launcher/StudioConfigurationProviderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/studio/launcher/StudioConfigurationProviderTest.groovy
@@ -1,0 +1,69 @@
+package org.gradle.profiler.studio.launcher
+
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class StudioConfigurationProviderTest extends Specification {
+
+    @Rule
+    TemporaryFolder tmpDir = new TemporaryFolder()
+    File studioInstallDir
+
+    def setup() {
+        tmpDir.newFolder("Contents/jre/Contents/Home/bin").mkdirs()
+        tmpDir.newFolder("jre/bin").mkdirs()
+        tmpDir.newFolder("bin").mkdirs()
+        studioInstallDir = tmpDir.root
+        new File(studioInstallDir, "Contents/jre/Contents/Home/bin/java").createNewFile()
+        new File(studioInstallDir, "jre/bin/java.exe").createNewFile()
+        new File(studioInstallDir, "jre/bin/java").createNewFile()
+    }
+
+    def "should parse linux classpath correctly from studio sh file"() {
+        given:
+        new File(studioInstallDir, "bin/studio.sh") << """
+some text
+
+CLASS_PATH="\$IDE_HOME/lib/lib1.jar"
+CLASS_PATH="\$CLASS_PATH:\$IDE_HOME/lib/lib2.jar"
+CLASS_PATH="\$CLASS_PATH:\$IDE_HOME/lib/lib1/lib1.jar"
+
+some other text
+"""
+
+        when:
+        def configuration = StudioConfigurationProvider.getLinuxConfiguration(studioInstallDir.toPath())
+
+        then:
+        configuration.classpath == [
+            studioInstallDir.toPath().resolve("lib/lib1.jar"),
+            studioInstallDir.toPath().resolve("lib/lib2.jar"),
+            studioInstallDir.toPath().resolve("lib/lib1/lib1.jar")
+        ]
+    }
+
+    def "should parse windows classpath correctly from studio bat file"() {
+        given:
+        new File(studioInstallDir, "bin/studio.bat") << """
+some text
+
+SET "CLASS_PATH=%IDE_HOME%\\lib\\lib1.jar"
+SET "CLASS_PATH=%CLASS_PATH%;%IDE_HOME%\\lib\\lib2.jar"
+SET "CLASS_PATH=%CLASS_PATH%;%IDE_HOME%\\lib\\lib1\\lib1.jar"
+
+some other text
+"""
+
+        when:
+        def configuration = StudioConfigurationProvider.getWindowsConfiguration(studioInstallDir.toPath())
+
+        then:
+        configuration.classpath == [
+            studioInstallDir.toPath().resolve("lib\\lib1.jar"),
+            studioInstallDir.toPath().resolve("lib\\lib2.jar"),
+            studioInstallDir.toPath().resolve("lib\\lib1\\lib1.jar")
+        ]
+    }
+
+}

--- a/subprojects/studio-plugin/build.gradle.kts
+++ b/subprojects/studio-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     groovy
     `java-test-fixtures`
     id("profiler.allprojects")
-    id("org.jetbrains.intellij") version "1.2.1"
+    id("org.jetbrains.intellij") version "1.7.0"
 }
 
 description = "Contains logic for Android Studio plugin that communicates with profiler"
@@ -17,7 +17,9 @@ repositories {
 
 dependencies {
     implementation(project(":client-protocol"))
+    testImplementation(libs.groovy.core)
     testFixturesImplementation(project(":client-protocol"))
+    testFixturesImplementation(libs.groovy.core)
 }
 
 // Applied configurations by gradle-intellij-plugin can be found here:

--- a/subprojects/studio-plugin/build.gradle.kts
+++ b/subprojects/studio-plugin/build.gradle.kts
@@ -17,9 +17,9 @@ repositories {
 
 dependencies {
     implementation(project(":client-protocol"))
-    testImplementation(libs.groovy.core)
+    testImplementation(libs.bundles.testDependencies)
     testFixturesImplementation(project(":client-protocol"))
-    testFixturesImplementation(libs.groovy.core)
+    testFixturesImplementation(libs.bundles.testDependencies)
 }
 
 // Applied configurations by gradle-intellij-plugin can be found here:
@@ -39,6 +39,10 @@ java {
     toolchain {
         languageVersion.set(JavaLanguageVersion.of(11))
     }
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 intellij {

--- a/subprojects/studio-plugin/build.gradle.kts
+++ b/subprojects/studio-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     groovy
     `java-test-fixtures`
     id("profiler.allprojects")
-    id("org.jetbrains.intellij") version "1.7.0"
+    id("org.jetbrains.intellij") version "1.8.0"
 }
 
 description = "Contains logic for Android Studio plugin that communicates with profiler"

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/GradleProfilerProjectManagerListener.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/GradleProfilerProjectManagerListener.java
@@ -26,8 +26,10 @@ public class GradleProfilerProjectManagerListener implements ProjectManagerListe
     public void projectOpened(@NotNull com.intellij.openapi.project.Project project) {
         LOG.info("Project opened");
         if (System.getProperty(PROFILER_PORT_PROPERTY) != null) {
-            // Skip Android Studio Gradle automatic import on project open,
-            // interestingly this is an issue only with Android Studio but not IntelliJ
+            // This solves the issue where Android Studio would run the Gradle sync automatically on the first import.
+            // Unfortunately it seems we can't always detect it because it happens very late and due to that there might
+            // a case where two simultaneous syncs would be run: one from automatic sync trigger and one from our trigger.
+            // With this line we disable that automatic sync, but we still trigger our sync later in the code.
             GradleProjectInfo.getInstance(project).setSkipStartupActivity(true);
             TrustedProjects.setTrusted(project, true);
             ApplicationManager.getApplication().executeOnPooledThread(() -> {

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/GradleProfilerProjectManagerListener.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/GradleProfilerProjectManagerListener.java
@@ -1,5 +1,6 @@
 package org.gradle.profiler.studio.plugin;
 
+import com.android.tools.idea.gradle.project.GradleProjectInfo;
 import com.intellij.ide.impl.TrustedProjects;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -25,6 +26,9 @@ public class GradleProfilerProjectManagerListener implements ProjectManagerListe
     public void projectOpened(@NotNull com.intellij.openapi.project.Project project) {
         LOG.info("Project opened");
         if (System.getProperty(PROFILER_PORT_PROPERTY) != null) {
+            // Skip Android Studio Gradle automatic import on project open,
+            // interestingly this is an issue only with Android Studio but not IntelliJ
+            GradleProjectInfo.getInstance(project).setSkipStartupActivity(true);
             TrustedProjects.setTrusted(project, true);
             ApplicationManager.getApplication().executeOnPooledThread(() -> {
                 StudioRequest lastRequest = listenForSyncRequests(project);
@@ -43,5 +47,4 @@ public class GradleProfilerProjectManagerListener implements ProjectManagerListe
             throw new UncheckedIOException(e);
         }
     }
-
 }

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/client/GradleProfilerClient.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/client/GradleProfilerClient.java
@@ -1,5 +1,7 @@
 package org.gradle.profiler.studio.plugin.client;
 
+import com.android.tools.idea.projectsystem.ProjectSystemSyncManager;
+import com.android.tools.idea.projectsystem.ProjectSystemUtil;
 import com.google.common.base.Stopwatch;
 import com.intellij.ide.caches.CachesInvalidator;
 import com.intellij.openapi.diagnostic.Logger;
@@ -8,15 +10,21 @@ import org.gradle.profiler.client.protocol.Client;
 import org.gradle.profiler.client.protocol.messages.StudioCacheCleanupCompleted;
 import org.gradle.profiler.client.protocol.messages.StudioRequest;
 import org.gradle.profiler.client.protocol.messages.StudioSyncRequestCompleted;
+import org.gradle.profiler.client.protocol.messages.StudioSyncRequestCompleted.StudioSyncRequestResult;
 import org.gradle.profiler.studio.plugin.system.GradleProfilerGradleSyncListener.GradleSyncResult;
 
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.android.tools.idea.projectsystem.ProjectSystemSyncManager.SyncResult.SKIPPED;
+import static com.android.tools.idea.projectsystem.ProjectSystemSyncManager.SyncResult.SKIPPED_OUT_OF_DATE;
+import static com.android.tools.idea.projectsystem.ProjectSystemSyncManager.SyncResult.UNKNOWN;
 import static org.gradle.profiler.client.protocol.messages.StudioRequest.StudioRequestType.EXIT_IDE;
 import static org.gradle.profiler.client.protocol.messages.StudioRequest.StudioRequestType.STOP_RECEIVING_EVENTS;
 import static org.gradle.profiler.studio.plugin.system.AndroidStudioSystemHelper.doGradleSync;
 import static org.gradle.profiler.studio.plugin.system.AndroidStudioSystemHelper.waitOnBackgroundProcessesFinish;
+import static org.gradle.profiler.studio.plugin.system.AndroidStudioSystemHelper.waitOnPostStartupActivities;
 import static org.gradle.profiler.studio.plugin.system.AndroidStudioSystemHelper.waitOnPreviousGradleSyncFinish;
 
 public class GradleProfilerClient {
@@ -24,13 +32,18 @@ public class GradleProfilerClient {
     private static final Logger LOG = Logger.getInstance(GradleProfilerClient.class);
 
     private final Client client;
+    private final Stopwatch startupStopwatch;
+    private final AtomicInteger syncCount;
 
     public GradleProfilerClient(Client client) {
         this.client = client;
+        this.startupStopwatch = Stopwatch.createStarted();
+        this.syncCount = new AtomicInteger();
     }
 
     public StudioRequest listenForSyncRequests(Project project) {
         StudioRequest request = receiveNextEvent();
+        waitOnPostStartupActivities(project);
         while (shouldHandleNextEvent(request)) {
             handleGradleProfilerRequest(request, project);
             request = receiveNextEvent();
@@ -63,19 +76,44 @@ public class GradleProfilerClient {
 
     private void handleSyncRequest(StudioRequest request, Project project) {
         LOG.info("Received sync request with id: " + request.getId());
+        boolean isStartup = syncCount.getAndIncrement() == 0;
 
         // In some cases sync could happen before we trigger it,
         // for example when we open a project for the first time.
         waitOnPreviousGradleSyncFinish(project);
         waitOnBackgroundProcessesFinish(project);
 
-        Stopwatch stopwatch = Stopwatch.createStarted();
         LOG.info(String.format("[SYNC REQUEST %s] Sync has started%n", request.getId()));
+        Stopwatch stopwatch = isStartup ? startupStopwatch : Stopwatch.createStarted();
+        GradleSyncResult result = isStartup ? getStartupSyncResult(project) : startManualSync(project);
+        LOG.info(String.format("[SYNC REQUEST %s] '%s': '%s'%n", request.getId(), result.getResult(), result.getErrorMessage()));
+        client.send(new StudioSyncRequestCompleted(request.getId(), stopwatch.elapsed(TimeUnit.MILLISECONDS), result.getResult(), result.getErrorMessage()));
+    }
+
+    private GradleSyncResult startManualSync(Project project) {
         GradleSyncResult result = doGradleSync(project);
         waitOnBackgroundProcessesFinish(project);
-        String errorMessage = result.getErrorMessage().isEmpty() ? "no error message" : result.getErrorMessage();
-        LOG.info(String.format("[SYNC REQUEST %s] '%s': '%s'%n", request.getId(), result.getResult(), errorMessage));
-        client.send(new StudioSyncRequestCompleted(request.getId(), stopwatch.elapsed(TimeUnit.MILLISECONDS), result.getResult(), errorMessage));
+        return result;
+    }
+
+    /**
+     * Gets the result of startup sync by checking if there was already any sync done before. Otherwise, it starts a new sync.
+     */
+    private GradleSyncResult getStartupSyncResult(Project project) {
+        ProjectSystemSyncManager.SyncResult lastSyncResult = ProjectSystemUtil.getSyncManager(project).getLastSyncResult();
+        if (lastSyncResult == UNKNOWN) {
+            // Sync was not run before, we need to run it manually
+            return startManualSync(project);
+        }
+        GradleSyncResult result;
+        if (lastSyncResult.isSuccessful() && (lastSyncResult == SKIPPED || lastSyncResult == SKIPPED_OUT_OF_DATE)) {
+            result = new GradleSyncResult(StudioSyncRequestResult.SKIPPED, "");
+        } else if (lastSyncResult.isSuccessful()) {
+            result = new GradleSyncResult(StudioSyncRequestResult.SUCCEEDED, "");
+        } else  {
+            result = new GradleSyncResult(StudioSyncRequestResult.FAILED, "Startup failure");
+        }
+        return result;
     }
 
     /**
@@ -92,5 +130,4 @@ public class GradleProfilerClient {
         });
         client.send(new StudioCacheCleanupCompleted(request.getId()));
     }
-
 }

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/AndroidStudioSystemHelper.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/AndroidStudioSystemHelper.java
@@ -1,109 +1,96 @@
 package org.gradle.profiler.studio.plugin.system;
 
-import com.android.tools.idea.gradle.project.sync.GradleSyncInvoker;
-import com.android.tools.idea.gradle.project.sync.GradleSyncListener;
 import com.android.tools.idea.gradle.project.sync.GradleSyncState;
-import com.google.wireless.android.sdk.stats.GradleSyncStats;
+import com.android.tools.idea.projectsystem.ProjectSystemSyncManager;
+import com.android.tools.idea.projectsystem.ProjectSystemUtil;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.startup.StartupManager;
 import com.intellij.openapi.wm.IdeFrame;
 import com.intellij.openapi.wm.ex.StatusBarEx;
 import com.intellij.openapi.wm.ex.WindowManagerEx;
 import com.intellij.util.messages.MessageBusConnection;
 import org.gradle.profiler.studio.plugin.system.GradleProfilerGradleSyncListener.GradleSyncResult;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Supplier;
 
-import static com.google.wireless.android.sdk.stats.GradleSyncStats.Trigger.TRIGGER_USER_SYNC_ACTION;
+import static com.android.tools.idea.projectsystem.ProjectSystemSyncUtil.PROJECT_SYSTEM_SYNC_TOPIC;
 
 public class AndroidStudioSystemHelper {
 
     private static final long WAIT_ON_PROCESS_SLEEP_TIME = 10;
+    private static final long WAIT_ON_STARTUP_SLEEP_TIME = 100;
 
     /**
      * Does a Gradle sync.
      */
     public static GradleSyncResult doGradleSync(Project project) {
-        GradleProfilerGradleSyncListener syncListener = new GradleProfilerGradleSyncListener();
+        GradleProfilerGradleSyncListener syncListener = subscribeToGradleSync(project);
         try {
-            requestProjectSync(project, TRIGGER_USER_SYNC_ACTION, syncListener);
-        } catch (Exception e) {
-            e.printStackTrace();
-            syncListener.syncFailed(project, e.getMessage());
-        }
-        return syncListener.waitAndGetResult();
-    }
-
-    /**
-     * We use reflection since Android Studio Electric Eel adds a modified android plugin at runtime on classpath
-     */
-    private static void requestProjectSync(Project project, GradleSyncStats.Trigger trigger, GradleSyncListener listener) {
-        try {
-            Object syncInvoker = ApplicationManager.getApplication().getService(GradleSyncInvoker.class);
-            Method method = syncInvoker.getClass().getMethod(
-                "requestProjectSync",
-                Project.class,
-                GradleSyncInvoker.Request.class,
-                GradleSyncListener.class
-            );
-            method.invoke(syncInvoker, project, new GradleSyncInvoker.Request(trigger), listener);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            // We could get sync result from the `Future` returned by the syncProject(),
+            // but it doesn't return error message so we rather listen to GRADLE_SYNC_TOPIC to get the sync result
+            ProjectSystemUtil.getSyncManager(project).syncProject(ProjectSystemSyncManager.SyncReason.USER_REQUEST).get();
+        } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);
         }
+        return syncListener.waitAndGetResult();
     }
 
     /**
      * Registers a listener that waits on next gradle sync if it's in progress.
      */
     public static void waitOnPreviousGradleSyncFinish(Project project) {
-        GradleProfilerGradleSyncListener syncListener = new GradleProfilerGradleSyncListener();
-        MessageBusConnection connection = project.getMessageBus().connect(project);
-        connection.subscribe(GradleSyncState.GRADLE_SYNC_TOPIC, syncListener);
-        if (!isSyncInProgress(project)) {
+        MessageBusConnection connection = project.getMessageBus().connect();
+        CompletableFuture<String> future = new CompletableFuture<>();
+        connection.subscribe(PROJECT_SYSTEM_SYNC_TOPIC, syncResult -> future.complete("Done"));
+        if (!ProjectSystemUtil.getSyncManager(project).isSyncInProgress()) {
             // Sync was actually not in progress,
             // just acknowledge the listener, so it won't wait forever.
-            syncListener.syncSkipped(project);
+            future.complete("Done");
         }
         try {
-            syncListener.waitAndGetResult();
+            future.join();
         } finally {
             connection.disconnect();
         }
     }
 
-    /**
-     * We use reflection since Android Studio Electric Eel adds a modified android plugin at runtime on classpath
-     */
-    private static boolean isSyncInProgress(Project project) {
-        try {
-            Object syncState = project.getService(GradleSyncState.class);
-            Method method = syncState.getClass().getMethod("isSyncInProgress");
-            return (boolean) method.invoke(syncState);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e);
-        }
+    private static GradleProfilerGradleSyncListener subscribeToGradleSync(Project project) {
+        MessageBusConnection connection = project.getMessageBus().connect();
+        GradleProfilerGradleSyncListener syncListener = new GradleProfilerGradleSyncListener(connection);
+        connection.subscribe(GradleSyncState.GRADLE_SYNC_TOPIC, syncListener);
+        return syncListener;
     }
 
     /**
      * Wait on Android Studio indexing and similar background tasks to finish.
-     *
+     * <p>
      * It seems there is no better way to do it atm.
      */
     public static void waitOnBackgroundProcessesFinish(Project project) {
         IdeFrame frame = WindowManagerEx.getInstanceEx().findFrameFor(project);
         StatusBarEx statusBar = frame == null ? null : (StatusBarEx) frame.getStatusBar();
         if (statusBar != null) {
-            statusBar.getBackgroundProcesses().forEach(it -> waitOn(it.getSecond()));
+            statusBar.getBackgroundProcesses().forEach(it -> waitOnProgressIndicator(it.getSecond()));
         }
     }
 
+    private static void waitOnProgressIndicator(ProgressIndicator progressIndicator) {
+        wait(progressIndicator::isRunning, WAIT_ON_PROCESS_SLEEP_TIME);
+    }
+
+    public static void waitOnPostStartupActivities(Project project) {
+        wait(() -> !StartupManager.getInstance(project).postStartupActivityPassed(), WAIT_ON_STARTUP_SLEEP_TIME);
+    }
+
     @SuppressWarnings("BusyWait")
-    private static void waitOn(ProgressIndicator progressIndicator) {
-        while (progressIndicator.isRunning()) {
+    private static void wait(Supplier<Boolean> whileCondition, long sleepMillis) {
+        while (whileCondition.get()) {
             try {
-                Thread.sleep(WAIT_ON_PROCESS_SLEEP_TIME);
+                Thread.sleep(sleepMillis);
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/AndroidStudioSystemHelper.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/AndroidStudioSystemHelper.java
@@ -52,7 +52,6 @@ public class AndroidStudioSystemHelper {
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
-
     }
 
     /**
@@ -85,7 +84,6 @@ public class AndroidStudioSystemHelper {
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException(e);
         }
-
     }
 
     /**

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/AndroidStudioSystemHelper.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/AndroidStudioSystemHelper.java
@@ -1,7 +1,9 @@
 package org.gradle.profiler.studio.plugin.system;
 
 import com.android.tools.idea.gradle.project.sync.GradleSyncInvoker;
+import com.android.tools.idea.gradle.project.sync.GradleSyncListener;
 import com.android.tools.idea.gradle.project.sync.GradleSyncState;
+import com.google.wireless.android.sdk.stats.GradleSyncStats;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.progress.ProgressIndicator;
 import com.intellij.openapi.project.Project;
@@ -10,6 +12,9 @@ import com.intellij.openapi.wm.ex.StatusBarEx;
 import com.intellij.openapi.wm.ex.WindowManagerEx;
 import com.intellij.util.messages.MessageBusConnection;
 import org.gradle.profiler.studio.plugin.system.GradleProfilerGradleSyncListener.GradleSyncResult;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 import static com.google.wireless.android.sdk.stats.GradleSyncStats.Trigger.TRIGGER_USER_SYNC_ACTION;
 
@@ -23,7 +28,7 @@ public class AndroidStudioSystemHelper {
     public static GradleSyncResult doGradleSync(Project project) {
         GradleProfilerGradleSyncListener syncListener = new GradleProfilerGradleSyncListener();
         try {
-            GradleSyncInvoker.getInstance().requestProjectSync(project, TRIGGER_USER_SYNC_ACTION, syncListener);
+            requestProjectSync(project, TRIGGER_USER_SYNC_ACTION, syncListener);
         } catch (Exception e) {
             e.printStackTrace();
             syncListener.syncFailed(project, e.getMessage());
@@ -32,12 +37,32 @@ public class AndroidStudioSystemHelper {
     }
 
     /**
+     * We use reflection since Android Studio Electric Eel adds a modified android plugin at runtime on classpath
+     */
+    private static void requestProjectSync(Project project, GradleSyncStats.Trigger trigger, GradleSyncListener listener) {
+        try {
+            Object syncInvoker = ApplicationManager.getApplication().getService(GradleSyncInvoker.class);
+            Method method = syncInvoker.getClass().getMethod(
+                "requestProjectSync",
+                Project.class,
+                GradleSyncInvoker.Request.class,
+                GradleSyncListener.class
+            );
+            method.invoke(syncInvoker, project, new GradleSyncInvoker.Request(trigger), listener);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    /**
      * Registers a listener that waits on next gradle sync if it's in progress.
      */
     public static void waitOnPreviousGradleSyncFinish(Project project) {
         GradleProfilerGradleSyncListener syncListener = new GradleProfilerGradleSyncListener();
-        MessageBusConnection connection = GradleSyncState.subscribe(project, syncListener);
-        if (!GradleSyncState.getInstance(project).isSyncInProgress()) {
+        MessageBusConnection connection = project.getMessageBus().connect(project);
+        connection.subscribe(GradleSyncState.GRADLE_SYNC_TOPIC, syncListener);
+        if (!isSyncInProgress(project)) {
             // Sync was actually not in progress,
             // just acknowledge the listener, so it won't wait forever.
             syncListener.syncSkipped(project);
@@ -47,6 +72,20 @@ public class AndroidStudioSystemHelper {
         } finally {
             connection.disconnect();
         }
+    }
+
+    /**
+     * We use reflection since Android Studio Electric Eel adds a modified android plugin at runtime on classpath
+     */
+    private static boolean isSyncInProgress(Project project) {
+        try {
+            Object syncState = project.getService(GradleSyncState.class);
+            Method method = syncState.getClass().getMethod("isSyncInProgress");
+            return (boolean) method.invoke(syncState);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+
     }
 
     /**

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/GradleProfilerGradleSyncListener.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/GradleProfilerGradleSyncListener.java
@@ -2,7 +2,6 @@ package org.gradle.profiler.studio.plugin.system;
 
 import com.android.tools.idea.gradle.project.sync.GradleSyncListener;
 import com.intellij.openapi.project.Project;
-import com.intellij.util.messages.MessageBusConnection;
 import org.gradle.profiler.client.protocol.messages.StudioSyncRequestCompleted.StudioSyncRequestResult;
 import org.jetbrains.annotations.NotNull;
 
@@ -19,11 +18,9 @@ import static org.gradle.profiler.client.protocol.messages.StudioSyncRequestComp
 public class GradleProfilerGradleSyncListener implements GradleSyncListener {
 
     private final BlockingQueue<GradleSyncResult> results;
-    private final MessageBusConnection connection;
 
-    public GradleProfilerGradleSyncListener(MessageBusConnection connection) {
+    public GradleProfilerGradleSyncListener() {
         this.results = new ArrayBlockingQueue<>(1);
-        this.connection = connection;
     }
 
     @Override
@@ -53,8 +50,6 @@ public class GradleProfilerGradleSyncListener implements GradleSyncListener {
             return results.take();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
-        } finally {
-            connection.disconnect();
         }
     }
 

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/GradleProfilerGradleSyncListener.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/GradleProfilerGradleSyncListener.java
@@ -2,13 +2,16 @@ package org.gradle.profiler.studio.plugin.system;
 
 import com.android.tools.idea.gradle.project.sync.GradleSyncListener;
 import com.intellij.openapi.project.Project;
+import com.intellij.util.messages.MessageBusConnection;
 import org.gradle.profiler.client.protocol.messages.StudioSyncRequestCompleted.StudioSyncRequestResult;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 
-import static org.gradle.profiler.client.protocol.messages.StudioSyncRequestCompleted.StudioSyncRequestResult.*;
+import static org.gradle.profiler.client.protocol.messages.StudioSyncRequestCompleted.StudioSyncRequestResult.FAILED;
+import static org.gradle.profiler.client.protocol.messages.StudioSyncRequestCompleted.StudioSyncRequestResult.SKIPPED;
+import static org.gradle.profiler.client.protocol.messages.StudioSyncRequestCompleted.StudioSyncRequestResult.SUCCEEDED;
 
 /**
  * Listens to a SINGLE Gradle sync event and returns result of it.
@@ -16,9 +19,11 @@ import static org.gradle.profiler.client.protocol.messages.StudioSyncRequestComp
 public class GradleProfilerGradleSyncListener implements GradleSyncListener {
 
     private final BlockingQueue<GradleSyncResult> results;
+    private final MessageBusConnection connection;
 
-    public GradleProfilerGradleSyncListener() {
+    public GradleProfilerGradleSyncListener(MessageBusConnection connection) {
         this.results = new ArrayBlockingQueue<>(1);
+        this.connection = connection;
     }
 
     @Override
@@ -48,6 +53,8 @@ public class GradleProfilerGradleSyncListener implements GradleSyncListener {
             return results.take();
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
+        } finally {
+            connection.disconnect();
         }
     }
 

--- a/subprojects/studio-plugin/src/test/groovy/org/gradle/profiler/studio/plugin/StudioPluginIntegrationTest.groovy
+++ b/subprojects/studio-plugin/src/test/groovy/org/gradle/profiler/studio/plugin/StudioPluginIntegrationTest.groovy
@@ -1,6 +1,8 @@
 package org.gradle.profiler.studio.plugin
 
+import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.PathManager
+import com.intellij.openapi.project.ProjectUtil
 import org.gradle.profiler.client.protocol.ServerConnection
 import org.gradle.profiler.client.protocol.messages.StudioRequest
 import org.gradle.profiler.client.protocol.messages.StudioSyncRequestCompleted
@@ -57,7 +59,9 @@ class StudioPluginIntegrationTest extends StudioPluginTestCase {
         ServerConnection connection = server.waitForIncoming(Duration.ofSeconds(10))
 
         when:
-        def invalidateFile = Paths.get(PathManager.getSystemPath(), "projectModelCache", ".invalidate").toFile()
+        def invalidateFile = ApplicationInfo.instance.majorVersion == "2021" && ApplicationInfo.instance.minorVersionMainPart <= "1"
+            ? Paths.get(PathManager.getSystemPath(), "projectModelCache", ".invalidate").toFile()
+            : ProjectUtil.projectsDataDir.resolve(".invalidate").toFile()
         long beforeTimestamp = invalidateFile.exists() ? invalidateFile.text as Long : 0
         connection.send(new StudioRequest(CLEANUP_CACHE))
         connection.receiveCacheCleanupCompleted(Duration.ofSeconds(10))

--- a/subprojects/studio-plugin/src/test/groovy/org/gradle/profiler/studio/plugin/StudioPluginIntegrationTest.groovy
+++ b/subprojects/studio-plugin/src/test/groovy/org/gradle/profiler/studio/plugin/StudioPluginIntegrationTest.groovy
@@ -17,6 +17,10 @@ import static org.gradle.profiler.client.protocol.messages.StudioRequest.StudioR
 import static org.gradle.profiler.client.protocol.messages.StudioSyncRequestCompleted.StudioSyncRequestResult.FAILED
 import static org.gradle.profiler.client.protocol.messages.StudioSyncRequestCompleted.StudioSyncRequestResult.SUCCEEDED
 
+/**
+ * Note: This class doesn't extend Spock Specification, but it extends IntelliJ HeavyPlatformTestCase,
+ * so you should always use `assert` when asserting statements
+ */
 class StudioPluginIntegrationTest extends StudioPluginTestCase {
 
     @Test
@@ -29,7 +33,7 @@ class StudioPluginIntegrationTest extends StudioPluginTestCase {
 
         then:
         StudioSyncRequestCompleted requestCompleted = connection.receiveSyncRequestCompleted(Duration.ofSeconds(90))
-        requestCompleted.result == SUCCEEDED
+        assert requestCompleted.result == SUCCEEDED
 
         and:
         connection.send(new StudioRequest(STOP_RECEIVING_EVENTS))
@@ -39,8 +43,8 @@ class StudioPluginIntegrationTest extends StudioPluginTestCase {
     void "should report error if Gradle sync is not successful"() {
         given:
         ServerConnection connection = server.waitForIncoming(Duration.ofSeconds(10))
-        // Fail Gradle build by removing settings file
-        settingsFile << "garbage"
+        // Fail Gradle build by failing the build script compilation
+        settingsFile.text = "garbage"
 
         when:
         connection.send(new StudioRequest(SYNC))
@@ -59,7 +63,7 @@ class StudioPluginIntegrationTest extends StudioPluginTestCase {
         ServerConnection connection = server.waitForIncoming(Duration.ofSeconds(10))
 
         when:
-        def invalidateFile = ApplicationInfo.instance.majorVersion == "2021" && ApplicationInfo.instance.minorVersionMainPart <= "1"
+        def invalidateFile = ApplicationInfo.instance.majorVersion == "2021" && ApplicationInfo.instance.minorVersionMainPart in ["0", "1"]
             ? Paths.get(PathManager.getSystemPath(), "projectModelCache", ".invalidate").toFile()
             : ProjectUtil.projectsDataDir.resolve(".invalidate").toFile()
         long beforeTimestamp = invalidateFile.exists() ? invalidateFile.text as Long : 0

--- a/subprojects/studio-plugin/src/test/groovy/org/gradle/profiler/studio/plugin/StudioPluginIntegrationTest.groovy
+++ b/subprojects/studio-plugin/src/test/groovy/org/gradle/profiler/studio/plugin/StudioPluginIntegrationTest.groovy
@@ -40,14 +40,14 @@ class StudioPluginIntegrationTest extends StudioPluginTestCase {
         given:
         ServerConnection connection = server.waitForIncoming(Duration.ofSeconds(10))
         // Fail Gradle build by removing settings file
-        settingsFile.delete()
+        settingsFile << "garbage"
 
         when:
         connection.send(new StudioRequest(SYNC))
 
         then:
         StudioSyncRequestCompleted requestCompleted = connection.receiveSyncRequestCompleted(Duration.ofSeconds(90))
-        requestCompleted.result == FAILED
+        assert requestCompleted.result == FAILED
 
         and:
         connection.send(new StudioRequest(STOP_RECEIVING_EVENTS))

--- a/subprojects/studio-plugin/src/testFixtures/groovy/org/gradle/profiler/studio/plugin/IdeSetupHelper.groovy
+++ b/subprojects/studio-plugin/src/testFixtures/groovy/org/gradle/profiler/studio/plugin/IdeSetupHelper.groovy
@@ -14,6 +14,7 @@ import org.junit.runner.Description
 
 import java.nio.file.Path
 import java.util.function.Consumer
+
 /**
  * HeavyPlatformTestCase extends Junit TestCase, but we use it through composition so we can use Spock framework
  */

--- a/subprojects/studio-plugin/src/testFixtures/groovy/org/gradle/profiler/studio/plugin/StudioPluginSpecification.groovy
+++ b/subprojects/studio-plugin/src/testFixtures/groovy/org/gradle/profiler/studio/plugin/StudioPluginSpecification.groovy
@@ -1,0 +1,38 @@
+package org.gradle.profiler.studio.plugin
+
+import org.gradle.profiler.client.protocol.Server
+import org.junit.Rule
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import spock.lang.Specification
+
+class StudioPluginSpecification extends Specification {
+
+    /**
+     * Used so we can run integration tests as Spock tests and we use composition to setup the IDE.
+     */
+    @Rule
+    TestRule runBareTestRule = { Statement base, Description description ->
+        return new Statement() {
+            @Override
+            void evaluate() throws Throwable {
+                server = new Server("plugin")
+                System.setProperty("gradle.profiler.port", server.getPort() as String)
+                new IdeSetupHelper(description, StudioPluginSpecification.this::createProject).runBare(base::evaluate)
+            }
+        }
+    }
+
+    Server server
+    File buildFile
+    File settingsFile
+
+    def createProject(File projectDir) {
+        projectDir.mkdirs()
+        buildFile = new File(projectDir, "build.gradle")
+        buildFile.createNewFile()
+        settingsFile = new File(projectDir, "settings.gradle")
+        settingsFile.createNewFile()
+    }
+}


### PR DESCRIPTION
and IntelliJ with Java17 runtime. 

Fixes https://github.com/gradle/gradle-profiler/issues/437