### PR TITLE
Fix parsing classpath for Bumblebee, Chipmunk and Dolphin on Linux and Windows

### DIFF
--- a/src/main/java/org/gradle/profiler/studio/launcher/StudioConfigurationProvider.java
+++ b/src/main/java/org/gradle/profiler/studio/launcher/StudioConfigurationProvider.java
@@ -31,6 +31,10 @@ public class StudioConfigurationProvider {
     private static final List<String> DEFAULT_MACOS_JAVA_PATHS = ImmutableList.of("Contents/jre/Contents/Home/bin/java", "Contents/jbr/Contents/Home/bin/java");
     private static final List<String> DEFAULT_WINDOWS_JAVA_PATHS = ImmutableList.of("jre/bin/java.exe", "jbr/bin/java.exe");
     private static final List<String> DEFAULT_LINUX_JAVA_PATHS = ImmutableList.of("jre/bin/java", "jbr/bin/java");
+
+    /**
+     * Android Studio Dolphin (2021.3) and older versions use "CLASSPATH", while Electric Eel (2022.1) and newer versions use CLASS_PATH
+     */
     private static final Pattern LINUX_CLASSPATH_LIB_PATTERN = Pattern.compile(".*(CLASS_PATH|CLASSPATH)=.*(?<lib>lib/.+\\.jar).*");
     private static final Pattern WINDOWS_CLASSPATH_LIB_PATTERN = Pattern.compile(".*(CLASS_PATH|CLASSPATH)=.*(?<lib>lib\\\\.+\\.jar).*");
 

--- a/src/main/java/org/gradle/profiler/studio/launcher/StudioConfigurationProvider.java
+++ b/src/main/java/org/gradle/profiler/studio/launcher/StudioConfigurationProvider.java
@@ -35,8 +35,8 @@ public class StudioConfigurationProvider {
     /**
      * Android Studio Dolphin (2021.3) and older versions use "CLASSPATH", while Electric Eel (2022.1) and newer versions use CLASS_PATH
      */
-    private static final Pattern LINUX_CLASSPATH_LIB_PATTERN = Pattern.compile(".*(CLASS_PATH|CLASSPATH)=.*(?<lib>lib/.+\\.jar).*");
-    private static final Pattern WINDOWS_CLASSPATH_LIB_PATTERN = Pattern.compile(".*(CLASS_PATH|CLASSPATH)=.*(?<lib>lib\\\\.+\\.jar).*");
+    private static final Pattern LINUX_CLASSPATH_LIB_PATTERN = Pattern.compile(".*(?:CLASS_PATH|CLASSPATH)=.*(?<lib>lib/.+\\.jar).*");
+    private static final Pattern WINDOWS_CLASSPATH_LIB_PATTERN = Pattern.compile(".*(?:CLASS_PATH|CLASSPATH)=.*(?<lib>lib\\\\.+\\.jar).*");
 
     public static StudioConfiguration getLaunchConfiguration(Path studioInstallDir) {
         if (OperatingSystem.isMacOS()) {

--- a/src/main/java/org/gradle/profiler/studio/launcher/StudioConfigurationProvider.java
+++ b/src/main/java/org/gradle/profiler/studio/launcher/StudioConfigurationProvider.java
@@ -31,8 +31,8 @@ public class StudioConfigurationProvider {
     private static final List<String> DEFAULT_MACOS_JAVA_PATHS = ImmutableList.of("Contents/jre/Contents/Home/bin/java", "Contents/jbr/Contents/Home/bin/java");
     private static final List<String> DEFAULT_WINDOWS_JAVA_PATHS = ImmutableList.of("jre/bin/java.exe", "jbr/bin/java.exe");
     private static final List<String> DEFAULT_LINUX_JAVA_PATHS = ImmutableList.of("jre/bin/java", "jbr/bin/java");
-    private static final Pattern LINUX_CLASSPATH_LIB_PATTERN = Pattern.compile(".*CLASS_PATH=.*(?<lib>lib/.+\\.jar).*");
-    private static final Pattern WINDOWS_CLASSPATH_LIB_PATTERN = Pattern.compile(".*CLASS_PATH=.*(?<lib>lib\\\\.+\\.jar).*");
+    private static final Pattern LINUX_CLASSPATH_LIB_PATTERN = Pattern.compile(".*(CLASS_PATH|CLASSPATH)=.*(?<lib>lib/.+\\.jar).*");
+    private static final Pattern WINDOWS_CLASSPATH_LIB_PATTERN = Pattern.compile(".*(CLASS_PATH|CLASSPATH)=.*(?<lib>lib\\\\.+\\.jar).*");
 
     public static StudioConfiguration getLaunchConfiguration(Path studioInstallDir) {
         if (OperatingSystem.isMacOS()) {

--- a/src/test/groovy/org/gradle/profiler/studio/launcher/StudioConfigurationProviderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/studio/launcher/StudioConfigurationProviderTest.groovy
@@ -20,14 +20,14 @@ class StudioConfigurationProviderTest extends Specification {
         new File(studioInstallDir, "jre/bin/java").createNewFile()
     }
 
-    def "should parse linux classpath correctly from studio sh file"() {
+    def "should parse linux classpath correctly from studio sh file with #classpathKeyword"() {
         given:
         new File(studioInstallDir, "bin/studio.sh") << """
 some text
 
-CLASS_PATH="\$IDE_HOME/lib/lib1.jar"
-CLASS_PATH="\$CLASS_PATH:\$IDE_HOME/lib/lib2.jar"
-CLASS_PATH="\$CLASS_PATH:\$IDE_HOME/lib/lib1/lib1.jar"
+$classpathKeyword="\$IDE_HOME/lib/lib1.jar"
+$classpathKeyword="\$$classpathKeyword:\$IDE_HOME/lib/lib2.jar"
+$classpathKeyword="\$$classpathKeyword:\$IDE_HOME/lib/lib1/lib1.jar"
 
 some other text
 """
@@ -41,16 +41,19 @@ some other text
             studioInstallDir.toPath().resolve("lib/lib2.jar"),
             studioInstallDir.toPath().resolve("lib/lib1/lib1.jar")
         ]
+
+        where:
+        classpathKeyword << ["CLASS_PATH", "CLASSPATH"]
     }
 
-    def "should parse windows classpath correctly from studio bat file"() {
+    def "should parse windows classpath correctly from studio bat file with #classpathKeyword"() {
         given:
         new File(studioInstallDir, "bin/studio.bat") << """
 some text
 
-SET "CLASS_PATH=%IDE_HOME%\\lib\\lib1.jar"
-SET "CLASS_PATH=%CLASS_PATH%;%IDE_HOME%\\lib\\lib2.jar"
-SET "CLASS_PATH=%CLASS_PATH%;%IDE_HOME%\\lib\\lib1\\lib1.jar"
+SET "$classpathKeyword=%IDE_HOME%\\lib\\lib1.jar"
+SET "$classpathKeyword=%$classpathKeyword%;%IDE_HOME%\\lib\\lib2.jar"
+SET "$classpathKeyword=%$classpathKeyword%;%IDE_HOME%\\lib\\lib1\\lib1.jar"
 
 some other text
 """
@@ -64,6 +67,8 @@ some other text
             studioInstallDir.toPath().resolve("lib\\lib2.jar"),
             studioInstallDir.toPath().resolve("lib\\lib1\\lib1.jar")
         ]
-    }
 
+        where:
+        classpathKeyword << ["CLASS_PATH", "CLASSPATH"]
+    }
 }


### PR DESCRIPTION
If this will be still require adjustments with new versions in the future, we could run `start.sh` or `start.bat` directly, but we would need to check what env. variables we need to set for custom AS args.

We don't have AS multi version tests, but I ran a tests with Bumblebee and all pass, here is the build:
https://builds.gradle.org/buildConfiguration/GradleProfiler_GradleProfilerTestTrigger/55190392?buildTab=overview&hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true