### PR TITLE
Chrome traces: normalize file paths in build operation display names

### DIFF
--- a/buildSrc/src/main/kotlin/profiler.embedded-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.embedded-library.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("profiler.java-library")
+    id("groovy")
 }
 
 // These projects are packaged into the Gradle profiler Jar, so let's make them reproducible

--- a/subprojects/chrome-trace/build.gradle
+++ b/subprojects/chrome-trace/build.gradle
@@ -4,4 +4,6 @@ plugins {
 
 dependencies {
     implementation gradleApi()
+
+    testImplementation libs.bundles.testDependencies
 }

--- a/subprojects/chrome-trace/src/main/java/org/gradle/trace/listener/Gradle35BuildOperationListenerInvocationHandler.java
+++ b/subprojects/chrome-trace/src/main/java/org/gradle/trace/listener/Gradle35BuildOperationListenerInvocationHandler.java
@@ -3,6 +3,7 @@ package org.gradle.trace.listener;
 import org.gradle.api.internal.TaskInternal;
 import org.gradle.trace.TraceResult;
 
+import static org.gradle.trace.util.FilePathUtil.normalizePathInDisplayName;
 import static org.gradle.trace.util.ReflectionUtil.invokerGetter;
 
 public class Gradle35BuildOperationListenerInvocationHandler extends BuildOperationListenerInvocationHandler {
@@ -16,7 +17,7 @@ public class Gradle35BuildOperationListenerInvocationHandler extends BuildOperat
         if (details != null && details.getClass().getSimpleName().equals("TaskOperationDescriptor")) {
             return (String) invokerGetter(invokerGetter(details, "getTask"), "getPath");
         }
-        return invokerGetter(operation, "getDisplayName") + " (" + invokerGetter(operation, "getId") + ")";
+        return normalizePathInDisplayName(invokerGetter(operation, "getDisplayName").toString()) + " (" + invokerGetter(operation, "getId") + ")";
     }
 
     protected TaskInternal getTask(Object operation) {

--- a/subprojects/chrome-trace/src/main/java/org/gradle/trace/listener/Gradle40BuildOperationListenerInvocationHandler.java
+++ b/subprojects/chrome-trace/src/main/java/org/gradle/trace/listener/Gradle40BuildOperationListenerInvocationHandler.java
@@ -1,5 +1,6 @@
 package org.gradle.trace.listener;
 
+import static org.gradle.trace.util.FilePathUtil.normalizePathInDisplayName;
 import static org.gradle.trace.util.ReflectionUtil.invokerGetter;
 
 import org.gradle.api.internal.TaskInternal;
@@ -14,7 +15,7 @@ public class Gradle40BuildOperationListenerInvocationHandler extends BuildOperat
     protected String getName(Object operation) {
         TaskInternal task = getTask(operation);
         if (task == null) {
-            return invokerGetter(operation, "getDisplayName") + " (" + invokerGetter(operation, "getId") + ")";
+            return normalizePathInDisplayName(invokerGetter(operation, "getDisplayName").toString()) + " (" + invokerGetter(operation, "getId") + ")";
         } else {
             return task.getPath();
         }

--- a/subprojects/chrome-trace/src/main/java/org/gradle/trace/listener/Gradle47BuildOperationListenerInvocationHandler.java
+++ b/subprojects/chrome-trace/src/main/java/org/gradle/trace/listener/Gradle47BuildOperationListenerInvocationHandler.java
@@ -1,5 +1,6 @@
 package org.gradle.trace.listener;
 
+import static org.gradle.trace.util.FilePathUtil.normalizePathInDisplayName;
 import static org.gradle.trace.util.ReflectionUtil.invokerGetter;
 
 import org.gradle.api.internal.TaskInternal;
@@ -18,7 +19,7 @@ public class Gradle47BuildOperationListenerInvocationHandler extends BuildOperat
         BuildOperationDescriptor operationDescriptor = (BuildOperationDescriptor) operation;
         TaskInternal task = getTask(operation);
         if (task == null) {
-            return operationDescriptor.getDisplayName() + " (" + operationDescriptor.getId() + ")";
+            return normalizePathInDisplayName(operationDescriptor.getDisplayName()) + " (" + operationDescriptor.getId() + ")";
         } else {
             return task.getPath();
         }

--- a/subprojects/chrome-trace/src/main/java/org/gradle/trace/listener/Gradle50BuildOperationListenerInvocationHandler.java
+++ b/subprojects/chrome-trace/src/main/java/org/gradle/trace/listener/Gradle50BuildOperationListenerInvocationHandler.java
@@ -1,5 +1,6 @@
 package org.gradle.trace.listener;
 
+import static org.gradle.trace.util.FilePathUtil.normalizePathInDisplayName;
 import static org.gradle.trace.util.ReflectionUtil.invokerGetter;
 
 import org.gradle.api.internal.TaskInternal;
@@ -20,7 +21,7 @@ public class Gradle50BuildOperationListenerInvocationHandler extends BuildOperat
         BuildOperationDescriptor operationDescriptor = (BuildOperationDescriptor) operation;
         TaskInternal task = getTask(operation);
         if (task == null) {
-            return operationDescriptor.getDisplayName() + " (" + operationDescriptor.getId() + ")";
+            return normalizePathInDisplayName(operationDescriptor.getDisplayName()) + " (" + operationDescriptor.getId() + ")";
         } else {
             return task.getPath();
         }

--- a/subprojects/chrome-trace/src/main/java/org/gradle/trace/util/FilePathUtil.java
+++ b/subprojects/chrome-trace/src/main/java/org/gradle/trace/util/FilePathUtil.java
@@ -1,0 +1,12 @@
+package org.gradle.trace.util;
+
+public class FilePathUtil {
+
+    /**
+     * Replaces '\' in paths on windows with '/', because '\' is an escape character in JSON.
+     * Writing it into the JSON trace files leads to unreadable files.
+     */
+    public static String normalizePathInDisplayName(String displayName) {
+        return displayName.replace('\\', '/');
+    }
+}

--- a/subprojects/chrome-trace/src/test/groovy/org/gradle/trace/listener/GradleBuildOperationListenerTest.groovy
+++ b/subprojects/chrome-trace/src/test/groovy/org/gradle/trace/listener/GradleBuildOperationListenerTest.groovy
@@ -1,0 +1,24 @@
+package org.gradle.trace.listener
+
+import org.gradle.internal.operations.BuildOperationDescriptor
+import org.gradle.internal.operations.OperationIdentifier
+import spock.lang.Specification
+
+class GradleBuildOperationListenerTest extends Specification {
+    def "normalizes windows file paths in display names #gradleVersion"() {
+        given:
+        def displayName = "Apply initialization script 'C:\\some\\location\\init.gradle' to build"
+        def operation = BuildOperationDescriptor.displayName(displayName).build(
+            new OperationIdentifier(42), new OperationIdentifier(1))
+
+        expect:
+        invocationHandler.getName(operation) ==
+            "Apply initialization script 'C:/some/location/init.gradle' to build (42)"
+
+        where:
+        gradleVersion | invocationHandler
+        "5.0"         | new Gradle50BuildOperationListenerInvocationHandler(null)
+        "4.7"         | new Gradle47BuildOperationListenerInvocationHandler(null)
+        "4.0"         | new Gradle40BuildOperationListenerInvocationHandler(null)
+    }
+}


### PR DESCRIPTION
Fixes #293