### PR TITLE
Add arch into agent requirements

### DIFF
--- a/.teamcity/settings/GradleProfilerTest.kt
+++ b/.teamcity/settings/GradleProfilerTest.kt
@@ -6,7 +6,7 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.BuildFailu
 import jetbrains.buildServer.configs.kotlin.v2019_2.failureConditions.failOnText
 import jetbrains.buildServer.configs.kotlin.v2019_2.ui.add
 
-open class GradleProfilerTest(os: Os, javaVersion: JavaVersion) : BuildType({
+open class GradleProfilerTest(os: Os, javaVersion: JavaVersion, arch: Arch = Arch.AMD64) : BuildType({
     gradleProfilerVcs()
 
     params {
@@ -53,7 +53,7 @@ open class GradleProfilerTest(os: Os, javaVersion: JavaVersion) : BuildType({
         }
     }
 
-    agentRequirement(os)
+    agentRequirement(os, arch)
 }) {
     constructor(os: Os, javaVersion: JavaVersion, init: GradleProfilerTest.() -> Unit) : this(os, javaVersion) {
         init()

--- a/.teamcity/settings/Os.kt
+++ b/.teamcity/settings/Os.kt
@@ -3,3 +3,8 @@ enum class Os(val requirementName: String) {
     macos("Mac OS X"),
     windows("Windows")
 }
+
+enum class Arch(val nameOnLinuxWindows: String, val nameOnMac: String) {
+    AMD64("amd64", "x86_64"),
+    AARCH64("aarch64", "aarch64");
+}

--- a/.teamcity/settings/extensions.kt
+++ b/.teamcity/settings/extensions.kt
@@ -3,15 +3,22 @@ import jetbrains.buildServer.configs.kotlin.v2019_2.CheckoutMode
 import jetbrains.buildServer.configs.kotlin.v2019_2.DslContext
 import jetbrains.buildServer.configs.kotlin.v2019_2.ParametrizedWithType
 
-fun BuildType.agentRequirement(os: Os) {
+fun BuildType.agentRequirement(os: Os, arch: Arch = Arch.AMD64) {
     requirements {
         contains("teamcity.agent.jvm.os.name", os.requirementName)
+        if (os == Os.macos) {
+            contains("teamcity.agent.jvm.os.arch", arch.nameOnMac)
+        } else {
+            contains("teamcity.agent.jvm.os.arch", arch.nameOnLinuxWindows)
+        }
     }
 }
 
-fun toolchainConfiguration(os: Os) = listOf("-Porg.gradle.java.installations.auto-detect=false",
+fun toolchainConfiguration(os: Os) = listOf(
+    "-Porg.gradle.java.installations.auto-detect=false",
     "-Porg.gradle.java.installations.auto-download=false",
-    """"-Porg.gradle.java.installations.paths=%${os.name}.java8.oracle.64bit%,%${os.name}.java11.openjdk.64bit%"""").joinToString(" ")
+    """"-Porg.gradle.java.installations.paths=%${os.name}.java8.oracle.64bit%,%${os.name}.java11.openjdk.64bit%""""
+).joinToString(" ")
 
 fun ParametrizedWithType.javaHome(os: Os, javaVersion: JavaVersion) {
     param("env.JAVA_HOME", javaVersion.javaHome(os))


### PR DESCRIPTION
Given that we now have m1 and intel Macs in the same agent pool.