### PR TITLE
Add support for Android Studio Giraffe (2022.3)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -129,8 +129,8 @@ androidStudioTests {
     val autoDownloadAndRunInHeadless = providers.gradleProperty("autoDownloadAndRunInHeadless").orNull == "true"
     runAndroidStudioInHeadlessMode.set(autoDownloadAndRunInHeadless)
     autoDownloadAndroidStudio.set(autoDownloadAndRunInHeadless)
-    // Electric Eel (2022.1.1) Beta 1
-    testAndroidStudioVersion.set("2022.1.1.11")
+    // Giraffe (2022.3.1.2) Canary 2
+    testAndroidStudioVersion.set("2022.3.1.2")
     testAndroidSdkVersion.set("7.3.0")
     // For local development it's easier to setup Android SDK with Android Studio, since auto download needs ANDROID_SDK_ROOT to be set with
     // an accepted license in it. See https://developer.android.com/studio/intro/update.html#download-with-gradle.

--- a/buildSrc/src/main/kotlin/profiler.android-studio-setup.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.android-studio-setup.gradle.kts
@@ -52,8 +52,8 @@ val unpackAndroidStudio = tasks.register<Copy>("unpackAndroidStudio") {
         }
     }) {
         eachFile {
-            // Remove top folder when unzipping,
-            // that way we get rid of Android Studio.app folder that can cause issues on Mac
+            // Remove top folder when unzipping, that way we get rid of Android Studio.app folder that can cause issues on Mac
+            // where MacOS would kill the Android Studio process right after start, issue: https://github.com/gradle/gradle-profiler/issues/469
             relativePath = RelativePath(true, *relativePath.segments.drop(1).toTypedArray())
         }
     }

--- a/buildSrc/src/main/kotlin/profiler.android-studio-setup.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.android-studio-setup.gradle.kts
@@ -67,6 +67,7 @@ val androidStudioInstallation = objects.newInstance<AndroidStudioInstallation>()
 
 tasks.withType<Test>().configureEach {
     dependsOn(installAndroidSdk)
+    environment("ANDROID_SDK_ROOT", System.getenv("ANDROID_SDK_ROOT"))
     jvmArgumentProviders.add(
         AndroidStudioSystemProperties(
             androidStudioInstallation,

--- a/buildSrc/src/main/kotlin/profiler.android-studio-setup.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.android-studio-setup.gradle.kts
@@ -50,7 +50,13 @@ val unpackAndroidStudio = tasks.register<Copy>("unpackAndroidStudio") {
             singleFile.name.endsWith(".tar.gz") -> tarTree(singleFile)
             else -> zipTree(singleFile)
         }
-    })
+    }) {
+        eachFile {
+            // Remove top folder when unzipping,
+            // that way we get rid of Android Studio.app folder that can cause issues on Mac
+            relativePath = RelativePath(true, *relativePath.segments.drop(1).toTypedArray())
+        }
+    }
     into("$buildDir/android-studio")
 }
 
@@ -67,7 +73,6 @@ val androidStudioInstallation = objects.newInstance<AndroidStudioInstallation>()
 
 tasks.withType<Test>().configureEach {
     dependsOn(installAndroidSdk)
-    environment("ANDROID_SDK_ROOT", System.getenv("ANDROID_SDK_ROOT"))
     jvmArgumentProviders.add(
         AndroidStudioSystemProperties(
             androidStudioInstallation,

--- a/buildSrc/src/main/kotlin/providers/AndroidStudioSystemProperties.kt
+++ b/buildSrc/src/main/kotlin/providers/AndroidStudioSystemProperties.kt
@@ -37,16 +37,7 @@ class AndroidStudioSystemProperties(
         val systemProperties = mutableListOf<String>()
         if (autoDownloadAndroidStudio.get()) {
             val androidStudioPath = studioInstallation.studioInstallLocation.get().asFile.absolutePath
-            val isMacOS = System.getProperty("os.name").toLowerCase().startsWith("mac")
-            val macOsAndroidStudioPath = "$androidStudioPath/Android Studio.app"
-            val macOsAndroidStudioPathPreview = "$androidStudioPath/Android Studio Preview.app"
-            val windowsAndLinuxPath = "$androidStudioPath/android-studio"
-            val studioHome = when {
-                isMacOS && File(macOsAndroidStudioPath).exists() -> macOsAndroidStudioPath
-                isMacOS -> macOsAndroidStudioPathPreview
-                else -> windowsAndLinuxPath
-            }
-            systemProperties.add("-Dstudio.home=$studioHome")
+            systemProperties.add("-Dstudio.home=$androidStudioPath")
         }
         if (runInHeadlessMode.get()) {
             systemProperties.add("-Dstudio.tests.headless=true")

--- a/src/main/java/org/gradle/profiler/studio/launcher/LaunchConfiguration.java
+++ b/src/main/java/org/gradle/profiler/studio/launcher/LaunchConfiguration.java
@@ -115,6 +115,6 @@ public class LaunchConfiguration {
         getSystemProperties().forEach((key, value) -> System.out.printf("  %s -> %s%n", key, value));
         System.out.println("* Main class: " + getMainClass());
         System.out.println("* Android Studio logs can be found at: " + Paths.get(getStudioLogsDir().toString(), "idea.log"));
-        System.out.printf("* Using command line: %s%n%n", commandLine);
+        System.out.printf("* Using command line: %s%n%n", String.join(" ", commandLine));
     }
 }

--- a/src/main/java/org/gradle/profiler/studio/launcher/LauncherConfigurationParser.java
+++ b/src/main/java/org/gradle/profiler/studio/launcher/LauncherConfigurationParser.java
@@ -20,6 +20,7 @@ public class LauncherConfigurationParser {
         "--add-opens=java.base/java.io=ALL-UNNAMED",
         "--add-opens=java.base/java.lang=ALL-UNNAMED",
         "--add-opens=java.base/java.lang.reflect=ALL-UNNAMED",
+        "--add-opens=java.base/java.lang.ref=ALL-UNNAMED",
         "--add-opens=java.base/java.net=ALL-UNNAMED",
         "--add-opens=java.base/java.nio=ALL-UNNAMED",
         "--add-opens=java.base/java.nio.charset=ALL-UNNAMED",
@@ -30,10 +31,12 @@ public class LauncherConfigurationParser {
         "--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED",
         "--add-opens=java.base/jdk.internal.vm=ALL-UNNAMED",
         "--add-opens=java.base/sun.nio.ch=ALL-UNNAMED",
+        "--add-opens=java.base/sun.nio.fs=ALL-UNNAMED",
         "--add-opens=java.base/sun.security.ssl=ALL-UNNAMED",
         "--add-opens=java.base/sun.security.util=ALL-UNNAMED",
         "--add-opens=java.desktop/com.sun.java.swing.plaf.gtk=ALL-UNNAMED",
         "--add-opens=java.desktop/java.awt=ALL-UNNAMED",
+        "--add-opens=java.desktop/java.awt.font=ALL-UNNAMED",
         "--add-opens=java.desktop/java.awt.dnd.peer=ALL-UNNAMED",
         "--add-opens=java.desktop/java.awt.event=ALL-UNNAMED",
         "--add-opens=java.desktop/java.awt.image=ALL-UNNAMED",
@@ -45,6 +48,7 @@ public class LauncherConfigurationParser {
         "--add-opens=java.desktop/sun.awt.datatransfer=ALL-UNNAMED",
         "--add-opens=java.desktop/sun.awt.image=ALL-UNNAMED",
         "--add-opens=java.desktop/sun.awt=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.awt.windows=ALL-UNNAMED",
         "--add-opens=java.desktop/sun.font=ALL-UNNAMED",
         "--add-opens=java.desktop/sun.java2d=ALL-UNNAMED",
         "--add-opens=java.desktop/sun.swing=ALL-UNNAMED",
@@ -54,7 +58,12 @@ public class LauncherConfigurationParser {
         "--add-opens=jdk.jdi/com.sun.tools.jdi=ALL-UNNAMED",
         "--add-exports=java.desktop/com.apple.eawt=ALL-UNNAMED",
         "--add-exports=java.desktop/com.apple.laf=ALL-UNNAMED",
-        "--add-exports=java.desktop/com.apple.eawt.event=ALL-UNNAMED"
+        "--add-exports=java.desktop/com.apple.eawt.event=ALL-UNNAMED",
+        "--add-opens=java.desktop/com.apple.eawt=ALL-UNNAMED",
+        "--add-opens=java.desktop/com.apple.eawt.event=ALL-UNNAMED",
+        "--add-opens=java.desktop/com.apple.laf=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.lwawt=ALL-UNNAMED",
+        "--add-opens=java.desktop/sun.lwawt.macosx=ALL-UNNAMED"
     );
 
     private final Path studioInstallDir;
@@ -136,6 +145,7 @@ public class LauncherConfigurationParser {
         }
         studioSandbox.getConfigDir().ifPresent(path -> systemProperties.put("idea.config.path", path.toString()));
         studioSandbox.getSystemDir().ifPresent(path -> systemProperties.put("idea.system.path", path.toString()));
+        systemProperties.put("java.system.class.loader", "com.intellij.util.lang.PathClassLoader");
         systemProperties.put("idea.plugins.path", studioSandbox.getPluginsDir().toString());
         systemProperties.put("idea.log.path", studioSandbox.getLogsDir().toString());
         // Newer IntelliJ versions require this property to avoid trust project popup

--- a/src/test/groovy/org/gradle/profiler/AndroidStudioIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AndroidStudioIntegrationTest.groovy
@@ -325,14 +325,4 @@ class AndroidStudioIntegrationTest extends AbstractProfilerIntegrationTest {
         ]
         new Main().run(*args)
     }
-
-    private static Optional<String> findAndroidSdkPath() {
-        if (System.getenv("ANDROID_SDK_ROOT") != null) {
-            return Optional.of(System.getenv("ANDROID_SDK_ROOT").replace("\\", "/"))
-        }
-        String userDirAndroidSdkPath = "${System.getProperty("user.home").replace("\\", "/")}/Library/Android/sdk"
-        return new File(userDirAndroidSdkPath).exists()
-            ? Optional.<String>of(userDirAndroidSdkPath)
-            : Optional.<String>empty()
-    }
 }

--- a/src/test/groovy/org/gradle/profiler/AndroidStudioIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AndroidStudioIntegrationTest.groovy
@@ -8,8 +8,8 @@ import org.gradle.profiler.studio.tools.StudioSandboxCreator
 import spock.lang.Requires
 
 /**
- * If running this tests with Android Studio Giraffe (2023.1) or later you need ANDROID_SDK_ROOT set or
- * having Android sdk installed in <user.dir>/Library/Android/sdk (e.g. on Mac /Users/<username>/Library/Android/sdk)
+ * If running this tests with Android Studio Giraffe (2022.3) or later you need ANDROID_SDK_ROOT set or
+ * having Android sdk installed in <user.home>/Library/Android/sdk (e.g. on Mac /Users/<username>/Library/Android/sdk)
  */
 @Requires({ StudioFinder.findStudioHome() })
 class AndroidStudioIntegrationTest extends AbstractProfilerIntegrationTest {

--- a/src/test/groovy/org/gradle/profiler/AndroidStudioIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AndroidStudioIntegrationTest.groovy
@@ -1,5 +1,6 @@
 package org.gradle.profiler
 
+import org.gradle.profiler.spock.extensions.ShowAndroidStudioLogsOnFailure
 import org.gradle.profiler.studio.launcher.LaunchConfiguration
 import org.gradle.profiler.studio.launcher.LauncherConfigurationParser
 import org.gradle.profiler.studio.tools.StudioFinder
@@ -11,18 +12,18 @@ import spock.lang.Requires
  * If running this tests with Android Studio Giraffe (2022.3) or later you need ANDROID_SDK_ROOT set or
  * having Android sdk installed in <user.home>/Library/Android/sdk (e.g. on Mac /Users/<username>/Library/Android/sdk)
  */
+@ShowAndroidStudioLogsOnFailure
 @Requires({ StudioFinder.findStudioHome() })
 class AndroidStudioIntegrationTest extends AbstractProfilerIntegrationTest {
 
     File sandboxDir
     File studioHome
-    File localProperties
     String scenarioName
 
     def setup() {
         sandboxDir = tmpDir.newFolder('sandbox')
         studioHome = StudioFinder.findStudioHome()
-        localProperties = file("local.properties")
+        def localProperties = file("local.properties")
         scenarioName = "scenario"
         findAndroidSdkPath().ifPresent { path -> localProperties << "\nsdk.dir=$path\n" }
     }

--- a/src/test/groovy/org/gradle/profiler/spock/extensions/ShowAndroidStudioLogsOnFailure.groovy
+++ b/src/test/groovy/org/gradle/profiler/spock/extensions/ShowAndroidStudioLogsOnFailure.groovy
@@ -1,0 +1,25 @@
+package org.gradle.profiler.spock.extensions
+
+import org.spockframework.runtime.extension.ExtensionAnnotation
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Inherited
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * Instructs Spock to use {@link ShowAndroidStudioLogsOnFailureExtension} to show Android Studio logs on failure.
+ * Log file is retrieved from a sandbox dir set on a test class. A field to retrieve sandbox dir can be set via
+ * {@link ShowAndroidStudioLogsOnFailure#sandboxDirField()}.
+ */
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target([ElementType.TYPE, ElementType.METHOD])
+@ExtensionAnnotation(ShowAndroidStudioLogsOnFailureExtension)
+@interface ShowAndroidStudioLogsOnFailure {
+    /**
+     * A field name of the test class where Android Studio sandbox is set. Field has to be of type File.
+     */
+    String sandboxDirField() default "sandboxDir";
+}

--- a/src/test/groovy/org/gradle/profiler/spock/extensions/ShowAndroidStudioLogsOnFailureExtension.groovy
+++ b/src/test/groovy/org/gradle/profiler/spock/extensions/ShowAndroidStudioLogsOnFailureExtension.groovy
@@ -1,0 +1,55 @@
+package org.gradle.profiler.spock.extensions
+
+import org.spockframework.runtime.AbstractRunListener
+import org.spockframework.runtime.extension.IAnnotationDrivenExtension
+import org.spockframework.runtime.extension.IMethodInterceptor
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.ErrorInfo
+import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.runtime.model.SpecInfo
+
+class ShowAndroidStudioLogsOnFailureExtension implements IAnnotationDrivenExtension<ShowAndroidStudioLogsOnFailure> {
+    @Override
+    void visitSpecAnnotation(ShowAndroidStudioLogsOnFailure annotation, SpecInfo spec) {
+        spec.features.each { FeatureInfo feature ->
+            feature.addIterationInterceptor(new FailureShowLogsInterceptor(annotation.sandboxDirField()))
+        }
+    }
+
+    @Override
+    void visitFeatureAnnotations(List<ShowAndroidStudioLogsOnFailure> annotations, FeatureInfo feature) {
+        feature.addIterationInterceptor(new FailureShowLogsInterceptor(annotations[0].sandboxDirField()))
+    }
+
+    private static class FailureShowLogsInterceptor implements IMethodInterceptor {
+        final String fieldName
+
+        FailureShowLogsInterceptor(String fieldName) {
+            this.fieldName = fieldName
+        }
+
+        @Override
+        void intercept(IMethodInvocation invocation) throws Throwable {
+            def errorListener = new AbstractRunListener() {
+                @Override
+                void error(ErrorInfo error) {
+                    String message
+                    def sandboxDir = invocation.instance.getProperties().get(fieldName)
+                    if (sandboxDir == null) {
+                        message = "Cannot read logs, sandbox dir set in field '$fieldName' is null."
+                    } else if (!(sandboxDir instanceof File)) {
+                        message = "Cannot read logs, sandbox dir set in field '$fieldName' is not of type ${File.class.getName()}, but is ${sandboxDir.class.getName()}."
+                    } else {
+                        File logFile = new File(sandboxDir, "/logs/idea.log")
+                        message = logFile.exists()
+                            ? "\n${logFile.text}"
+                            : "Log file ${logFile} doesn't exist, nothing to print."
+                    }
+                    println("[ANDROID STUDIO LOGS] $message")
+                }
+            }
+            invocation.spec.bottomSpec.addListener(errorListener)
+            invocation.proceed()
+        }
+    }
+}

--- a/src/test/groovy/org/gradle/profiler/studio/AndroidStudioTestSupport.groovy
+++ b/src/test/groovy/org/gradle/profiler/studio/AndroidStudioTestSupport.groovy
@@ -1,0 +1,19 @@
+package org.gradle.profiler.studio
+
+class AndroidStudioTestSupport {
+
+    static setupLocalProperties(File localProperties) {
+        Optional.ofNullable(findAndroidSdkPath()).ifPresent { path -> localProperties << "\nsdk.dir=$path\n" }
+    }
+
+    static String findAndroidSdkPath() {
+        if (System.getenv("ANDROID_SDK_ROOT") != null) {
+            return System.getenv("ANDROID_SDK_ROOT").replace("\\", "/")
+        }
+        String userDirAndroidSdkPath = "${System.getProperty("user.home").replace("\\", "/")}/Library/Android/sdk"
+        if (!new File(userDirAndroidSdkPath).exists()) {
+            return null
+        }
+        return userDirAndroidSdkPath
+    }
+}

--- a/src/test/groovy/org/gradle/profiler/studio/AndroidStudioTestSupport.groovy
+++ b/src/test/groovy/org/gradle/profiler/studio/AndroidStudioTestSupport.groovy
@@ -1,5 +1,7 @@
 package org.gradle.profiler.studio
 
+import org.apache.commons.io.FilenameUtils
+
 class AndroidStudioTestSupport {
 
     static setupLocalProperties(File localProperties) {
@@ -8,9 +10,9 @@ class AndroidStudioTestSupport {
 
     static String findAndroidSdkPath() {
         if (System.getenv("ANDROID_SDK_ROOT") != null) {
-            return System.getenv("ANDROID_SDK_ROOT").replace("\\", "/")
+            return FilenameUtils.separatorsToUnix(System.getenv("ANDROID_SDK_ROOT"))
         }
-        String userDirAndroidSdkPath = "${System.getProperty("user.home").replace("\\", "/")}/Library/Android/sdk"
+        String userDirAndroidSdkPath = FilenameUtils.separatorsToUnix("${System.getProperty("user.home")}/Library/Android/sdk")
         if (!new File(userDirAndroidSdkPath).exists()) {
             return null
         }

--- a/subprojects/studio-plugin/build.gradle.kts
+++ b/subprojects/studio-plugin/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     groovy
     `java-test-fixtures`
     id("profiler.allprojects")
-    id("org.jetbrains.intellij") version "1.8.1"
+    id("org.jetbrains.intellij") version "1.12.0"
 }
 
 description = "Contains logic for Android Studio plugin that communicates with profiler"

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/GradleProfilerAppLifecycleListener.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/GradleProfilerAppLifecycleListener.java
@@ -1,25 +1,25 @@
 package org.gradle.profiler.studio.plugin;
 
-import com.intellij.openapi.application.PreloadingActivity;
+import com.intellij.ide.AppLifecycleListener;
 import com.intellij.openapi.diagnostic.Logger;
-import com.intellij.openapi.progress.ProgressIndicator;
 import org.gradle.profiler.client.protocol.Client;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.List;
 
-public class GradleProfilerPreloadingActivity extends PreloadingActivity {
+public class GradleProfilerAppLifecycleListener implements AppLifecycleListener {
 
-    private static final Logger LOG = Logger.getInstance(GradleProfilerProjectManagerListener.class);
+    private static final Logger LOG = Logger.getInstance(GradleProfilerStartupActivity.class);
 
     private static final String STARTUP_PORT_PROPERTY = "gradle.profiler.startup.port";
 
     /**
-     * Preload is started as soon as IDE starts. We use it, so we can detect fast if IDE was started or not.
+     * AppFrameCreated is called as soon as IDE starts. We use it, so we can detect fast if IDE was started or not.
      */
     @Override
-    public void preload(@NotNull ProgressIndicator indicator) {
+    public void appFrameCreated(@NotNull List<String> commandLineArgs) {
         LOG.info("Preloading...");
         if (System.getProperty(STARTUP_PORT_PROPERTY) != null) {
             int port = Integer.getInteger(STARTUP_PORT_PROPERTY);

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/GradleProfilerStartupActivity.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/GradleProfilerStartupActivity.java
@@ -7,7 +7,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.externalSystem.service.notification.ExternalSystemProgressNotificationManager;
 import com.intellij.openapi.externalSystem.settings.ExternalSystemSettingsListenerAdapter;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.project.ProjectManagerListener;
+import com.intellij.openapi.startup.StartupActivity;
 import org.gradle.profiler.client.protocol.Client;
 import org.gradle.profiler.client.protocol.messages.StudioRequest;
 import org.gradle.profiler.studio.plugin.client.GradleProfilerClient;
@@ -23,14 +23,14 @@ import java.util.Collection;
 
 import static org.gradle.profiler.client.protocol.messages.StudioRequest.StudioRequestType.EXIT_IDE;
 
-public class GradleProfilerProjectManagerListener implements ProjectManagerListener {
+public class GradleProfilerStartupActivity implements StartupActivity {
 
-    private static final Logger LOG = Logger.getInstance(GradleProfilerProjectManagerListener.class);
+    private static final Logger LOG = Logger.getInstance(GradleProfilerStartupActivity.class);
 
     public static final String PROFILER_PORT_PROPERTY = "gradle.profiler.port";
 
     @Override
-    public void projectOpened(@NotNull Project project) {
+    public void runActivity(@NotNull Project project) {
         LOG.info("Project opened");
         if (System.getProperty(PROFILER_PORT_PROPERTY) != null) {
             // This solves the issue where Android Studio would run the Gradle sync automatically on the first import.
@@ -62,7 +62,7 @@ public class GradleProfilerProjectManagerListener implements ProjectManagerListe
             public void onProjectsLinked(@NotNull Collection<GradleProjectSettings> linkedProjectsSettings) {
                 linkedProjectsSettings.forEach(settings -> settings.setResolveExternalAnnotations(false));
             }
-        });
+        }, gradleSettings);
     }
 
     private GradleSystemListener registerGradleSystemListener() {

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/GradleProfilerStartupActivity.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/GradleProfilerStartupActivity.java
@@ -23,7 +23,7 @@ import java.util.Collection;
 
 import static org.gradle.profiler.client.protocol.messages.StudioRequest.StudioRequestType.EXIT_IDE;
 
-public class GradleProfilerStartupActivity implements StartupActivity {
+public class GradleProfilerStartupActivity implements StartupActivity.DumbAware {
 
     private static final Logger LOG = Logger.getInstance(GradleProfilerStartupActivity.class);
 

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/AndroidStudioSystemHelper.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/AndroidStudioSystemHelper.java
@@ -6,6 +6,7 @@ import com.android.tools.idea.projectsystem.ProjectSystemUtil;
 import com.google.common.base.Strings;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.progress.ProgressIndicator;
+import com.intellij.openapi.project.DumbService;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.startup.StartupManager;
 import com.intellij.openapi.wm.IdeFrame;
@@ -88,11 +89,13 @@ public class AndroidStudioSystemHelper {
      * It seems there is no better way to do it atm.
      */
     public static void waitOnBackgroundProcessesFinish(Project project) {
-        IdeFrame frame = WindowManagerEx.getInstanceEx().findFrameFor(project);
-        StatusBarEx statusBar = frame == null ? null : (StatusBarEx) frame.getStatusBar();
-        if (statusBar != null) {
-            statusBar.getBackgroundProcesses().forEach(it -> waitOnProgressIndicator(it.getSecond()));
-        }
+        DumbService.getInstance(project).runReadActionInSmartMode(() -> {
+            IdeFrame frame = WindowManagerEx.getInstanceEx().findFrameFor(project);
+            StatusBarEx statusBar = frame == null ? null : (StatusBarEx) frame.getStatusBar();
+            if (statusBar != null) {
+                statusBar.getBackgroundProcesses().forEach(it -> waitOnProgressIndicator(it.getSecond()));
+            }
+        });
     }
 
     private static void waitOnProgressIndicator(ProgressIndicator progressIndicator) {

--- a/subprojects/studio-plugin/src/main/resources/META-INF/plugin.xml
+++ b/subprojects/studio-plugin/src/main/resources/META-INF/plugin.xml
@@ -16,13 +16,14 @@
     <depends>org.jetbrains.android</depends>
 
     <applicationListeners>
-        <listener class="org.gradle.profiler.studio.plugin.GradleProfilerProjectManagerListener"
-                  topic="com.intellij.openapi.project.ProjectManagerListener"/>
+        <listener class="org.gradle.profiler.studio.plugin.GradleProfilerAppLifecycleListener"
+                  topic="com.intellij.ide.AppLifecycleListener"/>
     </applicationListeners>
 
     <extensions defaultExtensionNs="com.intellij">
-        <appStarter implementation="org.gradle.profiler.studio.plugin.starter.HeadlessApplicationStarter" />
-        <preloadingActivity implementation="org.gradle.profiler.studio.plugin.GradleProfilerPreloadingActivity"/>
+        <appStarter id="headless-starter"
+                    implementation="org.gradle.profiler.studio.plugin.starter.HeadlessApplicationStarter"/>
+        <postStartupActivity implementation="org.gradle.profiler.studio.plugin.GradleProfilerStartupActivity"/>
     </extensions>
 
 </idea-plugin>


### PR DESCRIPTION
By using newer APIs. Good news is that all these APIs are also in other versions we support (Chipmunk and newer), so this also works with previous versions.

Fixes https://github.com/gradle/gradle-profiler/issues/469
Fixes https://github.com/gradle/gradle-profiler/issues/470