### PR TITLE
Remove .db files for build cache

### DIFF
--- a/src/main/java/org/gradle/profiler/mutations/ClearBuildCacheMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ClearBuildCacheMutator.java
@@ -16,7 +16,12 @@ public class ClearBuildCacheMutator extends AbstractCacheCleanupMutator {
 
     @Override
     protected void cleanupCacheDir(File cacheDir) {
-        Arrays.stream(Objects.requireNonNull(cacheDir.listFiles((file) -> file.getName().length() == 32))).forEach(AbstractCleanupMutator::delete);
+        Arrays.stream(Objects.requireNonNull(cacheDir.listFiles(ClearBuildCacheMutator::shouldRemoveFile))).forEach(AbstractCleanupMutator::delete);
+    }
+
+    private static boolean shouldRemoveFile(File file) {
+        // First generation Build-cache contains hashes of length 32 as names, second generation uses a H2 database
+        return file.getName().length() == 32 || file.getName().endsWith(".db");
     }
 
     public static class Configurator extends AbstractCleanupMutator.Configurator {

--- a/src/test/groovy/org/gradle/profiler/mutations/ClearBuildCacheMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ClearBuildCacheMutatorTest.groovy
@@ -13,7 +13,7 @@ class ClearBuildCacheMutatorTest extends AbstractMutatorTest {
     def setup() {
         gradleUserHome = tmpDir.newFolder()
         buildCache1Entry = new File(gradleUserHome, "caches/build-cache-1/12345678901234567890123456789012")
-        buildCache2Entry = new File(gradleUserHome, "caches/build-cache-2/12345678901234567890123456789012")
+        buildCache2Entry = new File(gradleUserHome, "caches/build-cache-2/filestore.mv.db")
     }
 
     private void remakeCacheEntries() {


### PR DESCRIPTION
To support new prototyped build cache format.