### PR TITLE
Check ANDROID_HOME first, ANDROID_SDK_ROOT is deprecated

### DIFF
--- a/.teamcity/settings/extensions.kt
+++ b/.teamcity/settings/extensions.kt
@@ -29,6 +29,7 @@ fun ParametrizedWithType.androidHome(os: Os) {
         Os.linux, Os.macos -> "/opt/android/sdk"
         Os.windows -> """C:\Program Files\android\sdk"""
     }
+    param("env.ANDROID_HOME", androidHome)
     param("env.ANDROID_SDK_ROOT", androidHome)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,8 +132,8 @@ androidStudioTests {
     // Giraffe (2022.3.1.2) Canary 2
     testAndroidStudioVersion.set("2022.3.1.2")
     testAndroidSdkVersion.set("7.3.0")
-    // For local development it's easier to setup Android SDK with Android Studio, since auto download needs ANDROID_HOME to be set with
-    // an accepted license in it. See https://developer.android.com/studio/intro/update.html#download-with-gradle.
+    // For local development it's easier to setup Android SDK with Android Studio, since auto download needs ANDROID_HOME or ANDROID_SDK_ROOT
+    // to be set with an accepted license in it. See https://developer.android.com/studio/intro/update.html#download-with-gradle.
     autoDownloadAndroidSdk.set(autoDownloadAndRunInHeadless)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -132,7 +132,7 @@ androidStudioTests {
     // Giraffe (2022.3.1.2) Canary 2
     testAndroidStudioVersion.set("2022.3.1.2")
     testAndroidSdkVersion.set("7.3.0")
-    // For local development it's easier to setup Android SDK with Android Studio, since auto download needs ANDROID_SDK_ROOT to be set with
+    // For local development it's easier to setup Android SDK with Android Studio, since auto download needs ANDROID_HOME to be set with
     // an accepted license in it. See https://developer.android.com/studio/intro/update.html#download-with-gradle.
     autoDownloadAndroidSdk.set(autoDownloadAndRunInHeadless)
 }

--- a/buildSrc/src/main/kotlin/tasks/InstallAndroidSdkTask.kt
+++ b/buildSrc/src/main/kotlin/tasks/InstallAndroidSdkTask.kt
@@ -12,7 +12,7 @@ import org.gradle.tooling.GradleConnector
 import java.io.File
 
 /**
- * Installs Android SDK. This task requires the ANDROID_SDK_ROOT env variable to be set.
+ * Installs Android SDK. This task requires the ANDROID_HOME env variable to be set.
  */
 @UntrackedTask(because = "Output directory can change when running other builds")
 abstract class InstallAndroidSdkTask : DefaultTask() {
@@ -25,9 +25,9 @@ abstract class InstallAndroidSdkTask : DefaultTask() {
 
     @TaskAction
     fun install() {
-        if (System.getenv("ANDROID_SDK_ROOT") == null) {
+        if (System.getenv("ANDROID_HOME") == null && System.getenv("ANDROID_SDK_ROOT") == null) {
             throw GradleException(
-                "ANDROID_SDK_ROOT env variable is not set but it should be with the installation directory path. " +
+                "ANDROID_HOME env variable is not set but it should be with the installation directory path. " +
                     "The installation directory should also contain the Android sdk license key. See https://developer.android.com/studio/intro/update.html#download-with-gradle."
             )
         }

--- a/buildSrc/src/main/kotlin/tasks/InstallAndroidSdkTask.kt
+++ b/buildSrc/src/main/kotlin/tasks/InstallAndroidSdkTask.kt
@@ -12,7 +12,7 @@ import org.gradle.tooling.GradleConnector
 import java.io.File
 
 /**
- * Installs Android SDK. This task requires the ANDROID_HOME env variable to be set.
+ * Installs Android SDK. This task requires the ANDROID_HOME or ANDROID_SDK_ROOT env variable to be set.
  */
 @UntrackedTask(because = "Output directory can change when running other builds")
 abstract class InstallAndroidSdkTask : DefaultTask() {
@@ -27,7 +27,7 @@ abstract class InstallAndroidSdkTask : DefaultTask() {
     fun install() {
         if (System.getenv("ANDROID_HOME") == null && System.getenv("ANDROID_SDK_ROOT") == null) {
             throw GradleException(
-                "ANDROID_HOME env variable is not set but it should be with the installation directory path. " +
+                "None of ANDROID_HOME or ANDROID_SDK_ROOT env variable is set, but one should be. " +
                     "The installation directory should also contain the Android sdk license key. See https://developer.android.com/studio/intro/update.html#download-with-gradle."
             )
         }

--- a/src/test/groovy/org/gradle/profiler/AndroidStudioIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AndroidStudioIntegrationTest.groovy
@@ -13,7 +13,7 @@ import spock.lang.Requires
 import static org.gradle.profiler.studio.AndroidStudioTestSupport.setupLocalProperties
 
 /**
- * If running this tests with Android Studio Giraffe (2022.3) or later you need ANDROID_SDK_ROOT set or
+ * If running this tests with Android Studio Giraffe (2022.3) or later you need ANDROID_HOME or ANDROID_SDK_ROOT set or
  * having Android sdk installed in <user.home>/Library/Android/sdk (e.g. on Mac /Users/<username>/Library/Android/sdk)
  */
 @ShowAndroidStudioLogsOnFailure

--- a/src/test/groovy/org/gradle/profiler/studio/AndroidStudioTestSupport.groovy
+++ b/src/test/groovy/org/gradle/profiler/studio/AndroidStudioTestSupport.groovy
@@ -9,6 +9,9 @@ class AndroidStudioTestSupport {
     }
 
     static String findAndroidSdkPath() {
+        if (System.getenv("ANDROID_HOME") != null) {
+            return FilenameUtils.separatorsToUnix(System.getenv("ANDROID_HOME"))
+        }
         if (System.getenv("ANDROID_SDK_ROOT") != null) {
             return FilenameUtils.separatorsToUnix(System.getenv("ANDROID_SDK_ROOT"))
         }


### PR DESCRIPTION
Currently debugging an issue with Giraffe beta 1 where it seems to fail to find the android sdk directory, tries to show the missing SDK modal, and crashes because studio is running in headless mode. During this, I found out that the `ANDROID_SDK_ROOT` env var is actually deprecated and thought it would be a good first PR to get familiar with the project source. 

https://developer.android.com/tools/variables#envar

Note that I am not able to test these changes, sync/builds fail because I have an M1 mac and theres no adoptium jdk8 available.

```
Failed to query the value of task ':compileGroovy' property 'javaLauncher'.
Unable to download toolchain matching these requirements: {languageVersion=8, vendor=any, implementation=vendor-specific}
Unable to download toolchain. This might indicate that the combination (version, architecture, release/early access, ...) for the requested JDK is not available.
Could not read 'https://api.adoptium.net/v3/binary/latest/8/ga/mac/aarch64/jdk/hotspot/normal/eclipse' as it does not exist.
```