### PR TITLE
Update profiler.android-studio-setup.gradle.kts

### DIFF
--- a/buildSrc/src/main/kotlin/profiler.android-studio-setup.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.android-studio-setup.gradle.kts
@@ -17,8 +17,8 @@ repositories {
     }
 }
 
-val os = System.getProperty("os.name").toLowerCase()
-val architecture = System.getProperty("os.arch").toLowerCase()
+val os = System.getProperty("os.name").lowercase()
+val architecture = System.getProperty("os.arch").lowercase()
 fun isWindows(): Boolean = os.startsWith("windows")
 fun isMacOS(): Boolean = os.startsWith("mac")
 fun isLinux(): Boolean = os.startsWith("linux")


### PR DESCRIPTION
Fix buildSrc build warnings

> Task :buildSrc:compileKotlin
w: file:///ssd/ssd1/temp/gradle-profiler/buildSrc/src/main/kotlin/profiler.android-studio-setup.gradle.kts:20:40 'toLowerCase(): String' is deprecated. Use lowercase() instead. w: file:///ssd/ssd1/temp/gradle-profiler/buildSrc/src/main/kotlin/profiler.android-studio-setup.gradle.kts:21:50 'toLowerCase(): String' is deprecated. Use lowercase() instead.