### PR TITLE
Fix deadlock for Android Studio sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ Here is an example:
         title = "Android Studio Sync"
         # Measure an Android studio sync
         # Note: Android Studio Bumblebee (2021.1.1) or newer is required
+        # Note2: If you are testing with Android Studio Giraffe (2022.3) or later
+        # you need to have local.properties file in your project with sdk.dir set
         android-studio-sync {
             # Override default Android Studio jvm args
             # studio-jvm-args = ["-Xms256m", "-Xmx4096m"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -139,8 +139,8 @@ androidStudioTests {
     val autoDownloadAndRunInHeadless = providers.gradleProperty("autoDownloadAndRunInHeadless").orNull == "true"
     runAndroidStudioInHeadlessMode.set(autoDownloadAndRunInHeadless)
     autoDownloadAndroidStudio.set(autoDownloadAndRunInHeadless)
-    // Giraffe (2022.3.1.2) Canary 2
-    testAndroidStudioVersion.set("2022.3.1.2")
+    // Hedgehog (2023.1.1.6) Canary 6
+    testAndroidStudioVersion.set("2023.1.1.6")
     testAndroidSdkVersion.set("7.3.0")
     // For local development it's easier to setup Android SDK with Android Studio, since auto download needs ANDROID_HOME or ANDROID_SDK_ROOT
     // to be set with an accepted license in it. See https://developer.android.com/studio/intro/update.html#download-with-gradle.

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/AndroidStudioSystemHelper.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/system/AndroidStudioSystemHelper.java
@@ -89,13 +89,13 @@ public class AndroidStudioSystemHelper {
      * It seems there is no better way to do it atm.
      */
     public static void waitOnBackgroundProcessesFinish(Project project) {
-        DumbService.getInstance(project).runReadActionInSmartMode(() -> {
-            IdeFrame frame = WindowManagerEx.getInstanceEx().findFrameFor(project);
-            StatusBarEx statusBar = frame == null ? null : (StatusBarEx) frame.getStatusBar();
-            if (statusBar != null) {
-                statusBar.getBackgroundProcesses().forEach(it -> waitOnProgressIndicator(it.getSecond()));
-            }
-        });
+        // Run a dummy read action just so we wait on all indexing done
+        DumbService.getInstance(project).runReadActionInSmartMode(() -> {});
+        IdeFrame frame = WindowManagerEx.getInstanceEx().findFrameFor(project);
+        StatusBarEx statusBar = frame == null ? null : (StatusBarEx) frame.getStatusBar();
+        if (statusBar != null) {
+            statusBar.getBackgroundProcesses().forEach(it -> waitOnProgressIndicator(it.getSecond()));
+        }
     }
 
     private static void waitOnProgressIndicator(ProgressIndicator progressIndicator) {


### PR DESCRIPTION
Now we wait on background processes outside `runReadActionInSmartMode` and we just use `runReadActionInSmartMode` with a dummy read action to wait for indexing.

Tested with Giraffe and Hedgehog with  https://github.com/akerimsenol/giraffe.profiler.hang.repro, no issue there.

FIxes #496
Fixes #480