### PR TITLE
Use Java 11 for building gradle profiler

### DIFF
--- a/buildSrc/src/main/kotlin/profiler.java-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.java-library.gradle.kts
@@ -18,7 +18,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(11))
     }
 }
 


### PR DESCRIPTION
Move to a less ancient version of Java. This matches existing subprojects too https://github.com/search?q=repo%3Agradle%2Fgradle-profiler%20JavaLanguageVersion&type=code