### PR TITLE
Run help on root project to speed up project probe

### DIFF
--- a/src/main/java/org/gradle/profiler/gradle/DefaultGradleBuildConfigurationReader.java
+++ b/src/main/java/org/gradle/profiler/gradle/DefaultGradleBuildConfigurationReader.java
@@ -126,7 +126,7 @@ public class DefaultGradleBuildConfigurationReader implements GradleBuildConfigu
         GradleBuildConfiguration version;
         try (ProjectConnection connection = connector.forProjectDirectory(projectDir).connect()) {
             BuildEnvironment buildEnvironment = connection.getModel(BuildEnvironment.class);
-            new ToolingApiGradleClient(connection).runTasks(ImmutableList.of("help"), ImmutableList.of("-I", initScript.getAbsolutePath()), ImmutableList.of());
+            new ToolingApiGradleClient(connection).runTasks(ImmutableList.of(":help"), ImmutableList.of("-I", initScript.getAbsolutePath()), ImmutableList.of());
             BuildDetails buildDetails = readBuildDetails();
             JavaEnvironment javaEnvironment = buildEnvironment.getJava();
             List<String> allJvmArgs = new ArrayList<>(javaEnvironment.getJvmArguments());

--- a/src/test/groovy/org/gradle/profiler/AbstractProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AbstractProfilerIntegrationTest.groovy
@@ -258,7 +258,7 @@ genrule(
             assert find("<gradle-version: $gradleVersion>").size() == 17
             assert find("<daemon: true").size() == 17
             assert find("<daemon: false").size() == 0
-            assert find("<tasks: [help]>").size() == 1
+            assert find("<tasks: [:help]>").size() == 1
             assert find("<tasks: [${tasks.join(", ")}]>").size() == 16
             assert containsOne("<invocations: 16>")
         }
@@ -274,7 +274,7 @@ genrule(
             assert find("<gradle-version: $gradleVersion>").size() == 12
             assert find("<daemon: true").size() == 12
             assert find("<daemon: false").size() == 0
-            assert find("<tasks: [help]>").size() == 1
+            assert find("<tasks: [:help]>").size() == 1
             assert find("<tasks: [${tasks.join(", ")}]>").size() == 11
             assert find("<invocations: 1>").size() == 12
         }
@@ -290,7 +290,7 @@ genrule(
             assert find("<gradle-version: $gradleVersion>").size() == 12
             assert find("<daemon: true").size() == 1
             assert find("<daemon: false").size() == 11
-            assert find("<tasks: [help]>").size() == 1
+            assert find("<tasks: [:help]>").size() == 1
             assert find("<tasks: [${tasks.join(", ")}]>").size() == 11
             assert find("<invocations: 1>").size() == 12
         }

--- a/src/test/groovy/org/gradle/profiler/BenchmarkIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/BenchmarkIntegrationTest.groovy
@@ -20,7 +20,7 @@ class BenchmarkIntegrationTest extends AbstractProfilerIntegrationTest {
         // Probe version, 6 warm up, 10 builds
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 10
         logFile.find("<gradle-version: 5.0>").size() == 17
-        logFile.find("<tasks: [help]>").size() == 2
+        logFile.find("<tasks: [:help]>").size() == 2
         logFile.find("<tasks: [assemble]>").size() == 9 + 16
 
         def lines = resultFile.lines
@@ -54,7 +54,7 @@ class BenchmarkIntegrationTest extends AbstractProfilerIntegrationTest {
         // Probe version, 6 warm up, 10 builds
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 5
         logFile.find("<gradle-version: 5.0>").size() == 17
-        logFile.find("<tasks: [help]>").size() == 2
+        logFile.find("<tasks: [:help]>").size() == 2
         logFile.find("<tasks: [assemble]>").size() == 4 + 16
 
         def lines = resultFile.lines
@@ -91,7 +91,7 @@ class BenchmarkIntegrationTest extends AbstractProfilerIntegrationTest {
         // Probe version, 6 warm up, 10 builds
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 2
         logFile.find("<gradle-version: 5.0>").size() == 17
-        logFile.find("<tasks: [help]>").size() == 2
+        logFile.find("<tasks: [:help]>").size() == 2
         logFile.find("<tasks: [assemble]>").size() == 1 + 16
 
         def lines = resultFile.lines

--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -396,7 +396,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
             }
             help {
                 versions = "$minimalSupportedGradleVersion"
-                tasks = [help]
+                tasks = [":help"]
                 daemon = none
             }
         """
@@ -418,7 +418,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         logFile.find("<gradle-version: $latestSupportedGradleVersion").size() == 17
         logFile.find("<daemon: true").size() == 2 + 16 * 2
         logFile.find("<daemon: false").size() == 11
-        logFile.find("<tasks: [help]>").size() == 2 + 11
+        logFile.find("<tasks: [:help]>").size() == 2 + 11
         logFile.find("<tasks: [assemble]>").size() == 16 * 2
 
         logFile.containsOne("* Running scenario assemble using Gradle $latestSupportedGradleVersion (scenario 1/3)")
@@ -461,7 +461,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         // Probe version, 6 warm up, 10 builds
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 17
         logFile.find("<daemon: true").size() == 17
-        logFile.find("<tasks: [help]>").size() == 1
+        logFile.find("<tasks: [:help]>").size() == 1
         logFile.find("<tasks: []>").size() == 16
 
         logFile.containsOne("* Running scenario xyz using Gradle $minimalSupportedGradleVersion (scenario 1/1)")
@@ -482,7 +482,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
                 tasks = assemble
             }
             help {
-                tasks = help
+                tasks = ":help"
             }
         """
 
@@ -498,7 +498,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
 
         then:
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 7
-        logFile.find("<tasks: [help]>").size() == 4
+        logFile.find("<tasks: [:help]>").size() == 4
         logFile.find("<tasks: [assemble]>").size() == 3
 
         logFile.containsOne("* Running scenario assemble using Gradle $minimalSupportedGradleVersion (scenario 1/2)")
@@ -516,7 +516,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
                 tasks = assemble
             }
             help {
-                tasks = help
+                tasks = ":help"
             }
         """
 
@@ -533,7 +533,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         then:
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 7
         logFile.find("<gradle-version: $latestSupportedGradleVersion>").size() == 7
-        logFile.find("<tasks: [help]>").size() == 8
+        logFile.find("<tasks: [:help]>").size() == 8
         logFile.find("<tasks: [assemble]>").size() == 6
 
         logFile.containsOne("* Running scenario assemble using Gradle $minimalSupportedGradleVersion (scenario 1/4)")
@@ -564,7 +564,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
                 tasks = assemble
             }
             help = \${defaults} {
-                tasks = help
+                tasks = ":help"
             }
         """
 
@@ -582,7 +582,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 7
         logFile.find("<gradle-version: $latestSupportedGradleVersion>").size() == 7
         logFile.find("<tasks: [assemble]>").size() == 6
-        logFile.find("<tasks: [help]>").size() == 8
+        logFile.find("<tasks: [:help]>").size() == 8
 
         logFile.containsOne("* Running scenario assemble using Gradle $minimalSupportedGradleVersion (scenario 1/4)")
         logFile.containsOne("* Running scenario assemble using Gradle $latestSupportedGradleVersion (scenario 2/4)")
@@ -600,7 +600,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
             help {
                 versions = "$minimalSupportedGradleVersion"
                 cleanup-tasks = clean
-                tasks = help
+                tasks = ":help"
             }
         """
 
@@ -618,13 +618,13 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         then:
         // Probe version, 6 warm up, 10 builds
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 33
-        logFile.find("<tasks: [help]>").size() == 17
+        logFile.find("<tasks: [:help]>").size() == 17
 
         def lines = resultFile.lines
         lines.size() == totalLinesForExecutions(16)
         lines.get(0) == "scenario,help"
         lines.get(1) == "version,Gradle ${minimalSupportedGradleVersion}"
-        lines.get(2) == "tasks,help"
+        lines.get(2) == "tasks,:help"
         lines.get(3) == "value,total execution time"
         lines.get(4).matches("warm-up build #1,$SAMPLE")
         lines.get(9).matches("warm-up build #6,$SAMPLE")
@@ -693,7 +693,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         logFile.find("<gradle-version: $latestSupportedGradleVersion").size() == 3
         logFile.find("<dry-run: false>").size() == 2
         logFile.find("<dry-run: true>").size() == 6
-        logFile.find("<tasks: [help]>").size() == 2
+        logFile.find("<tasks: [:help]>").size() == 2
         logFile.find("<tasks: [assemble]>").size() == 4
         logFile.find("<tasks: [clean, assemble]>").size() == 2
 

--- a/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ProfilerIntegrationTest.groovy
@@ -396,7 +396,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
             }
             help {
                 versions = "$minimalSupportedGradleVersion"
-                tasks = [":help"]
+                tasks = ["help"]
                 daemon = none
             }
         """
@@ -416,9 +416,10 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         // Probe version, 2 scenarios have 6 warm up, 10 builds, 1 scenario has 1 warm up, 10 builds
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 1 + 16 + 11
         logFile.find("<gradle-version: $latestSupportedGradleVersion").size() == 17
+        logFile.find("<tasks: [:help]>").size() == 2 // Probe version
         logFile.find("<daemon: true").size() == 2 + 16 * 2
         logFile.find("<daemon: false").size() == 11
-        logFile.find("<tasks: [:help]>").size() == 2 + 11
+        logFile.find("<tasks: [help]>").size() == 11
         logFile.find("<tasks: [assemble]>").size() == 16 * 2
 
         logFile.containsOne("* Running scenario assemble using Gradle $latestSupportedGradleVersion (scenario 1/3)")
@@ -460,8 +461,8 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         then:
         // Probe version, 6 warm up, 10 builds
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 17
+        logFile.find("<tasks: [:help]>").size() == 1 // Probe version
         logFile.find("<daemon: true").size() == 17
-        logFile.find("<tasks: [:help]>").size() == 1
         logFile.find("<tasks: []>").size() == 16
 
         logFile.containsOne("* Running scenario xyz using Gradle $minimalSupportedGradleVersion (scenario 1/1)")
@@ -482,7 +483,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
                 tasks = assemble
             }
             help {
-                tasks = ":help"
+                tasks = help
             }
         """
 
@@ -498,7 +499,8 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
 
         then:
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 7
-        logFile.find("<tasks: [:help]>").size() == 4
+        logFile.find("<tasks: [:help]>").size() == 1 // Probe version
+        logFile.find("<tasks: [help]>").size() == 3
         logFile.find("<tasks: [assemble]>").size() == 3
 
         logFile.containsOne("* Running scenario assemble using Gradle $minimalSupportedGradleVersion (scenario 1/2)")
@@ -516,7 +518,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
                 tasks = assemble
             }
             help {
-                tasks = ":help"
+                tasks = help
             }
         """
 
@@ -533,7 +535,8 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         then:
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 7
         logFile.find("<gradle-version: $latestSupportedGradleVersion>").size() == 7
-        logFile.find("<tasks: [:help]>").size() == 8
+        logFile.find("<tasks: [:help]>").size() == 2 // Probe version
+        logFile.find("<tasks: [help]>").size() == 6
         logFile.find("<tasks: [assemble]>").size() == 6
 
         logFile.containsOne("* Running scenario assemble using Gradle $minimalSupportedGradleVersion (scenario 1/4)")
@@ -564,7 +567,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
                 tasks = assemble
             }
             help = \${defaults} {
-                tasks = ":help"
+                tasks = help
             }
         """
 
@@ -581,8 +584,9 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         then:
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 7
         logFile.find("<gradle-version: $latestSupportedGradleVersion>").size() == 7
+        logFile.find("<tasks: [:help]>").size() == 2 // Probe version
         logFile.find("<tasks: [assemble]>").size() == 6
-        logFile.find("<tasks: [:help]>").size() == 8
+        logFile.find("<tasks: [help]>").size() == 6
 
         logFile.containsOne("* Running scenario assemble using Gradle $minimalSupportedGradleVersion (scenario 1/4)")
         logFile.containsOne("* Running scenario assemble using Gradle $latestSupportedGradleVersion (scenario 2/4)")
@@ -600,7 +604,7 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
             help {
                 versions = "$minimalSupportedGradleVersion"
                 cleanup-tasks = clean
-                tasks = ":help"
+                tasks = help
             }
         """
 
@@ -618,13 +622,14 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         then:
         // Probe version, 6 warm up, 10 builds
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 33
-        logFile.find("<tasks: [:help]>").size() == 17
+        logFile.find("<tasks: [:help]>").size() == 1
+        logFile.find("<tasks: [help]>").size() == 16
 
         def lines = resultFile.lines
         lines.size() == totalLinesForExecutions(16)
         lines.get(0) == "scenario,help"
         lines.get(1) == "version,Gradle ${minimalSupportedGradleVersion}"
-        lines.get(2) == "tasks,:help"
+        lines.get(2) == "tasks,help"
         lines.get(3) == "value,total execution time"
         lines.get(4).matches("warm-up build #1,$SAMPLE")
         lines.get(9).matches("warm-up build #6,$SAMPLE")
@@ -691,9 +696,9 @@ class ProfilerIntegrationTest extends AbstractProfilerIntegrationTest {
         // Probe version, 1 warm up, 1 build
         logFile.find("<gradle-version: $minimalSupportedGradleVersion>").size() == 5
         logFile.find("<gradle-version: $latestSupportedGradleVersion").size() == 3
+        logFile.find("<tasks: [:help]>").size() == 2
         logFile.find("<dry-run: false>").size() == 2
         logFile.find("<dry-run: true>").size() == 6
-        logFile.find("<tasks: [:help]>").size() == 2
         logFile.find("<tasks: [assemble]>").size() == 4
         logFile.find("<tasks: [clean, assemble]>").size() == 2
 


### PR DESCRIPTION
Related to #484, running `help` takes a significant amount of time in our build because it is so large and it configures the whole project just to find a few basic pieces of info. Using `:help` on the root project makes this considerably faster.

