### PR TITLE
Add IDEA provisioning

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,6 +14,7 @@ include("client-protocol")
 include("instrumentation-support")
 include("studio-agent")
 include("studio-plugin")
+include("ide-provisioning")
 
 rootProject.children.forEach {
     it.projectDir = rootDir.resolve( "subprojects/${it.name}")

--- a/subprojects/ide-provisioning/build.gradle.kts
+++ b/subprojects/ide-provisioning/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id("profiler.embedded-library")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+repositories {
+    maven { url = uri("https://www.jetbrains.com/intellij-repository/releases") }
+    maven { url = uri("https://cache-redirector.jetbrains.com/intellij-dependencies") }
+
+    maven { url = uri("https://cache-redirector.jetbrains.com/maven-central") }
+    maven { url = uri("https://www.jetbrains.com/intellij-repository/snapshots") }
+    maven {
+        url = uri("https://cache-redirector.jetbrains.com/packages.jetbrains.team/maven/p/grazi/grazie-platform-public")
+    }
+}
+
+dependencies {
+    implementation("com.jetbrains.intellij.tools:ide-starter-squashed:233.13135.103") {
+        exclude(group = "io.ktor")
+        exclude(group = "com.jetbrains.infra")
+        exclude(group = "com.jetbrains.intellij.remoteDev")
+    }
+    testImplementation(libs.bundles.testDependencies)
+}

--- a/subprojects/ide-provisioning/src/main/java/org/gradle/profiler/ide/DefaultIdeProvider.java
+++ b/subprojects/ide-provisioning/src/main/java/org/gradle/profiler/ide/DefaultIdeProvider.java
@@ -1,0 +1,34 @@
+package org.gradle.profiler.ide;
+
+import kotlin.io.FilesKt;
+import org.gradle.profiler.ide.idea.IDEA;
+import org.gradle.profiler.ide.idea.IDEAProvider;
+
+import java.io.File;
+import java.nio.file.Path;
+
+public class DefaultIdeProvider implements IdeProvider<Ide> {
+
+    private final IDEAProvider ideaProvider;
+
+    public DefaultIdeProvider(IDEAProvider ideaProvider) {
+        this.ideaProvider = ideaProvider;
+    }
+
+    @Override
+    public File provideIde(Ide ide, Path homeDir, Path downloadsDir) {
+        File result;
+        if (ide instanceof IDEA) {
+            result = ideaProvider.provideIde((IDEA) ide, homeDir, downloadsDir);
+        } else {
+            throw new IllegalArgumentException("Unknown IDE to provide");
+        }
+
+        cleanup(homeDir, downloadsDir);
+        return result;
+    }
+
+    private void cleanup(Path homeDir, Path downloadsDir) {
+        FilesKt.deleteRecursively(downloadsDir.toFile());
+    }
+}

--- a/subprojects/ide-provisioning/src/main/java/org/gradle/profiler/ide/Ide.java
+++ b/subprojects/ide-provisioning/src/main/java/org/gradle/profiler/ide/Ide.java
@@ -1,0 +1,9 @@
+package org.gradle.profiler.ide;
+
+import org.jetbrains.annotations.NotNull;
+
+public interface Ide {
+    @NotNull
+    String getVersion();
+}
+

--- a/subprojects/ide-provisioning/src/main/java/org/gradle/profiler/ide/IdeProvider.java
+++ b/subprojects/ide-provisioning/src/main/java/org/gradle/profiler/ide/IdeProvider.java
@@ -1,0 +1,9 @@
+package org.gradle.profiler.ide;
+
+import java.io.File;
+import java.nio.file.Path;
+
+public interface IdeProvider<T extends Ide> {
+
+    File provideIde(T ide, Path homeDir, Path downloadsDir);
+}

--- a/subprojects/ide-provisioning/src/main/java/org/gradle/profiler/ide/idea/IDEA.java
+++ b/subprojects/ide-provisioning/src/main/java/org/gradle/profiler/ide/idea/IDEA.java
@@ -1,0 +1,18 @@
+package org.gradle.profiler.ide.idea;
+
+import org.gradle.profiler.ide.Ide;
+import org.jetbrains.annotations.NotNull;
+
+public class IDEA implements Ide {
+    public static IDEA LATEST = new IDEA("");
+    private final String version;
+    public IDEA(String version) {
+        this.version = version;
+    }
+
+    @NotNull
+    @Override
+    public String getVersion() {
+        return version;
+    }
+}

--- a/subprojects/ide-provisioning/src/main/java/org/gradle/profiler/ide/idea/IDEAProvider.java
+++ b/subprojects/ide-provisioning/src/main/java/org/gradle/profiler/ide/idea/IDEAProvider.java
@@ -1,0 +1,74 @@
+package org.gradle.profiler.ide.idea;
+
+import com.intellij.ide.starter.community.PublicIdeDownloader;
+import com.intellij.ide.starter.community.model.BuildType;
+import com.intellij.ide.starter.ide.IdeArchiveExtractor;
+import com.intellij.ide.starter.ide.IdeDownloader;
+import com.intellij.ide.starter.ide.installer.IdeInstallerFile;
+import com.intellij.ide.starter.models.IdeInfo;
+import org.gradle.profiler.ide.IdeProvider;
+import org.jetbrains.annotations.Nullable;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Collections;
+
+public class IDEAProvider implements IdeProvider<IDEA> {
+    private final IdeDownloader ideDownloader;
+    private final IdeArchiveExtractor ideArchiveExtractor;
+
+    public IDEAProvider() {
+        this.ideDownloader = PublicIdeDownloader.INSTANCE;
+        this.ideArchiveExtractor = IdeArchiveExtractor.INSTANCE;
+    }
+
+    @Override
+    public File provideIde(IDEA ide, Path homeDir, Path downloadsDir) {
+        IdeInfo ideInfo = new IdeInfo(
+            "IC",
+            "Idea",
+            "idea",
+            BuildType.EAP.getType(),
+            Collections.emptyList(),
+            "", // latest
+            ide.getVersion(),
+            null,
+            null,
+            "IDEA Community",
+            info -> null
+        );
+
+        String version = ideInfo.getVersion().isEmpty()
+            ? "latest"
+            : ideInfo.getVersion();
+
+        File unpackDir = homeDir
+            .resolve(ideInfo.getInstallerFilePrefix())
+            .resolve(version)
+            .toFile();
+
+        File unpackedIde = getUnpackedIde(unpackDir);
+
+        if (unpackedIde != null) {
+            System.out.println("Downloading is skipped, get " + ideInfo.getFullName() + " from cache");
+            return unpackedIde;
+        }
+
+        IdeInstallerFile installerFile = ideDownloader.downloadIdeInstaller(ideInfo, downloadsDir);
+        ideArchiveExtractor.unpackIdeIfNeeded(installerFile.getInstallerFile().toFile(), unpackDir);
+
+        return unpackDir.listFiles()[0];
+    }
+
+    @Nullable
+    private static File getUnpackedIde(File unpackDir) {
+        File[] unpackedFiles = unpackDir.listFiles();
+        if (unpackedFiles == null || unpackedFiles.length == 0) {
+            return null;
+        }
+        if (unpackedFiles.length == 1) {
+            return unpackedFiles[0];
+        }
+        throw new IllegalStateException("Unexpected content in " + unpackDir);
+    }
+}

--- a/subprojects/ide-provisioning/src/test/groovy/org/gradle/profiler/TeeOutputStream.java
+++ b/subprojects/ide-provisioning/src/test/groovy/org/gradle/profiler/TeeOutputStream.java
@@ -1,0 +1,52 @@
+package org.gradle.profiler;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Arrays;
+import java.util.List;
+
+public class TeeOutputStream extends OutputStream {
+    private final List<OutputStream> targets;
+
+    public TeeOutputStream(OutputStream... targets) {
+        this.targets = Arrays.asList(targets);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        withAll(stream -> stream.write(b));
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        withAll(stream -> stream.write(b, off, len));
+    }
+
+    @Override
+    public void flush() throws IOException {
+        withAll(stream -> stream.flush());
+    }
+
+    @Override
+    public void close() throws IOException {
+        withAll(stream -> stream.close());
+    }
+
+    private void withAll(IOAction action) throws IOException {
+        IOException failure = null;
+        for (OutputStream target : targets) {
+            try {
+                action.withStream(target);
+            } catch (IOException e) {
+                failure = e;
+            }
+        }
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private interface IOAction {
+        void withStream(OutputStream stream) throws IOException;
+    }
+}

--- a/subprojects/ide-provisioning/src/test/groovy/org/gradle/profiler/ide/AbstractIdeProvisioningTest.groovy
+++ b/subprojects/ide-provisioning/src/test/groovy/org/gradle/profiler/ide/AbstractIdeProvisioningTest.groovy
@@ -1,0 +1,28 @@
+package org.gradle.profiler.ide
+
+import org.gradle.profiler.TeeOutputStream
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class AbstractIdeProvisioningTest extends Specification {
+
+    private ByteArrayOutputStream outputBuffer
+
+    @Rule
+    protected TemporaryFolder tmpDir = new TemporaryFolder(new File("build/tmp/"))
+
+    def setup() {
+        outputBuffer = new ByteArrayOutputStream()
+        System.out = new PrintStream(new TeeOutputStream(System.out, outputBuffer))
+    }
+
+    protected void outputContains(String content) {
+        assert getOutput().contains(content.trim())
+    }
+
+    protected String getOutput() {
+        System.out.flush()
+        return new String(outputBuffer.toByteArray())
+    }
+}

--- a/subprojects/ide-provisioning/src/test/groovy/org/gradle/profiler/ide/IdeProviderTest.groovy
+++ b/subprojects/ide-provisioning/src/test/groovy/org/gradle/profiler/ide/IdeProviderTest.groovy
@@ -1,0 +1,33 @@
+package org.gradle.profiler.ide
+
+
+import org.gradle.profiler.ide.idea.IDEA
+import org.gradle.profiler.ide.idea.IDEAProvider
+
+class IdeProviderTest extends AbstractIdeProvisioningTest {
+
+    def "can provide IDEA"() {
+        given:
+        def workDir = tmpDir.newFolder().toPath().toAbsolutePath()
+        def downloadsDir = workDir.resolve("downloads")
+        def ideHomeDir = workDir.resolve("ide")
+        def ideProvider = new DefaultIdeProvider(new IDEAProvider())
+
+        when:
+        def ide = ideProvider.provideIde(IDEA.LATEST, ideHomeDir, downloadsDir)
+
+        then:
+        outputContains("Downloading https://")
+        assert ide.exists()
+
+        when:
+        def ide2 = ideProvider.provideIde(IDEA.LATEST, ideHomeDir, downloadsDir)
+
+        then:
+        outputContains("Downloading is skipped, get IDEA Community from cache")
+        assert ide == ide2
+
+        and:
+        assert !downloadsDir.toFile().exists()
+    }
+}


### PR DESCRIPTION
This PR integrates `ide-starter` to Gradle profiler and provide some wrappers around it. In particular, some abstraction for IDE provisioning is introduced alongside with an implementation of IDEA provisioning.

Provisioning does include downloading of an IDE of desired version to a desired directory.


