### PR TITLE
Improve initial sync handling in headless mode

### DIFF
--- a/src/main/java/org/gradle/profiler/studio/launcher/StudioLauncherProvider.java
+++ b/src/main/java/org/gradle/profiler/studio/launcher/StudioLauncherProvider.java
@@ -93,6 +93,7 @@ public class StudioLauncherProvider {
         if (SHOULD_RUN_HEADLESS) {
             systemProperties.put("java.awt.headless", "true");
         }
+        systemProperties.put("external.system.auto.import.disabled", "true");
         systemProperties.forEach((k, v) -> jvmArgs.add(String.format("-D%s=%s", k, v)));
         return jvmArgs;
     }

--- a/subprojects/studio-plugin/build.gradle.kts
+++ b/subprojects/studio-plugin/build.gradle.kts
@@ -43,6 +43,9 @@ java {
 
 tasks.test {
     useJUnitPlatform()
+    // Disable IntelliJ file system access check for tests: having this check enabled can fail
+    // CI builds since Gradle user home can be mounted, e.g. it can be located in the /mnt/tcagent1/.gradle
+    systemProperty("NO_FS_ROOTS_ACCESS_CHECK", "true")
 }
 
 intellij {

--- a/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/client/GradleProfilerClient.java
+++ b/subprojects/studio-plugin/src/main/java/org/gradle/profiler/studio/plugin/client/GradleProfilerClient.java
@@ -55,9 +55,7 @@ public class GradleProfilerClient {
         GradleSettings gradleSettings = GradleSettings.getInstance(project);
         if (gradleSettings.getLinkedProjectsSettings().isEmpty()) {
             VirtualFile projectDir = ProjectUtil.guessProjectDir(project);
-            // We disable auto import, because we want to control when the import happens,
-            // here we re-enable it and we start the import when we are ready
-            Registry.get("external.system.auto.import.disabled").setValue(true);
+            // We disabled auto import with 'external.system.auto.import.disabled=true', so we need to link and refresh the project manually
             GradleProjectImportUtil.linkAndRefreshGradleProject(projectDir.getPath(), project);
         }
     }

--- a/subprojects/studio-plugin/src/test/groovy/org/gradle/profiler/studio/plugin/StudioPluginIntegrationTest.groovy
+++ b/subprojects/studio-plugin/src/test/groovy/org/gradle/profiler/studio/plugin/StudioPluginIntegrationTest.groovy
@@ -3,6 +3,7 @@ package org.gradle.profiler.studio.plugin
 import com.intellij.openapi.application.ApplicationInfo
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.project.ProjectUtil
+import com.intellij.openapi.util.registry.Registry
 import org.gradle.profiler.client.protocol.ServerConnection
 import org.gradle.profiler.client.protocol.messages.StudioRequest
 import org.gradle.profiler.client.protocol.messages.StudioSyncRequestCompleted
@@ -17,6 +18,11 @@ import static org.gradle.profiler.client.protocol.messages.StudioSyncRequestComp
 import static org.gradle.profiler.client.protocol.messages.StudioSyncRequestCompleted.StudioSyncRequestResult.SUCCEEDED
 
 class StudioPluginIntegrationTest extends StudioPluginSpecification {
+
+    def setup() {
+        // Our plugin expects auto-import is disabled
+        Registry.get("external.system.auto.import.disabled").setValue(true)
+    }
 
     def "should successfully sync Gradle project"() {
         given:


### PR DESCRIPTION
There were some problems with IntelliJ 2023.2 where we didn't detect initial import.