### PR TITLE
Query phase system property in background to avoid CC miss

### DIFF
--- a/src/main/java/org/gradle/profiler/buildscan/GradleEnterpriseAlreadyAppliedInitScript.java
+++ b/src/main/java/org/gradle/profiler/buildscan/GradleEnterpriseAlreadyAppliedInitScript.java
@@ -21,6 +21,9 @@ import java.io.PrintWriter;
 
 import static org.gradle.profiler.buildscan.GradleEnterpriseInitScript.PUBLISH_AND_TAG;
 
+/**
+ * An init script to apply Gradle Enterprise plugin that is already available, used for Gradle 6+.
+ */
 public class GradleEnterpriseAlreadyAppliedInitScript extends GeneratedInitScript {
 
     @Override

--- a/src/main/java/org/gradle/profiler/buildscan/GradleEnterpriseInitScript.java
+++ b/src/main/java/org/gradle/profiler/buildscan/GradleEnterpriseInitScript.java
@@ -19,13 +19,16 @@ import org.gradle.profiler.GeneratedInitScript;
 
 import java.io.PrintWriter;
 
+/**
+ * An init script to set up Gradle Enterprise plugin dependency and apply it, used for Gradle 6+.
+ */
 public class GradleEnterpriseInitScript extends GeneratedInitScript {
 
     static final String PUBLISH_AND_TAG = "" +
-        "        if (System.getProperty('org.gradle.profiler.phase') == 'MEASURE') {\n" +
-        "            publishAlways()\n" +
-        "        }\n" +
-        "        tag('GRADLE_PROFILER')\n";
+        "        background {\n" +
+        "            publishAlwaysIf(System.getProperty('org.gradle.profiler.phase') == 'MEASURE')\n" +
+        "            tag('GRADLE_PROFILER')\n" +
+        "        }\n";
 
     private final String version;
 


### PR DESCRIPTION
This way the property doesn't become a configuration input with the sufficiently recent version of Gradle and build scan plugin.