### PR TITLE
Allow copy-file and delete-file to be scheduled

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,8 +312,8 @@ A scenario can define changes that should be applied to the source before each b
 - `clear-jars-cache-before`: Deletes the contents of the instrumented jars cache before the scenario is executed (`SCENARIO`), before cleanup (`CLEANUP`) or before the build is executed (`BUILD`).
 - `clear-project-cache-before`: Deletes the contents of the `.gradle` and `buildSrc/.gradle` project cache directories before the scenario is executed (`SCENARIO`), before cleanup (`CLEANUP`) or before the build is executed (`BUILD`).
 - `clear-transform-cache-before`: Deletes the contents of the transform cache before the scenario is executed (`SCENARIO`), before cleanup (`CLEANUP`) or before the build is executed (`BUILD`).
-- `copy-file`: Copies a file or a directory from one location to another. Has to specify a `source` and a `target` path; relative paths are resolved against the project directory. Can take an array of operations.
-- `delete-file`: Deletes a file or a directory. Has to specify a `target` path; when relative it is resolved against the project directory. Can take an array of operations.
+- `copy-file`: Copies a file or a directory from one location to another. Has to specify a `source` and a `target` path; relative paths are resolved against the project directory. Can also specify a schedule (defaults `SCENARIO`). Can take an array of operations.
+- `delete-file`: Deletes a file or a directory. Has to specify a `target` path; when relative it is resolved against the project directory. Can also specify a schedule (defaults `SCENARIO`). Can take an array of operations.
 - `git-checkout`: Checks out a specific commit for the build step, and a different one for the cleanup step.
 - `git-revert`: Reverts a given set of commits before the build and resets it afterward.
 - `iterations`: Number of builds to actually measure
@@ -352,8 +352,10 @@ They can be added to a scenario file like this:
         }
         delete-file = [{
             target = ".mvn/develocity.xml"
+            schedule = CLEANUP
         }, {
             target = ".gradle"
+            schedule = CLEANUP
         }]
         git-checkout = {
             cleanup = "efb43a1"

--- a/src/main/java/org/gradle/profiler/BuildInvoker.java
+++ b/src/main/java/org/gradle/profiler/BuildInvoker.java
@@ -28,7 +28,7 @@ public class BuildInvoker {
         return 2;
     }
 
-    public boolean allowsCleanupBetweenBuilds() {
+    public boolean allowsMutationBetweenBuilds() {
         return true;
     }
 

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -10,7 +10,7 @@ import org.gradle.profiler.bazel.BazelScenarioDefinition;
 import org.gradle.profiler.buck.BuckScenarioDefinition;
 import org.gradle.profiler.gradle.*;
 import org.gradle.profiler.maven.MavenScenarioDefinition;
-import org.gradle.profiler.mutations.AbstractCleanupMutator.CleanupSchedule;
+import org.gradle.profiler.mutations.AbstractScheduledMutator.Schedule;
 import org.gradle.profiler.mutations.ApplyAbiChangeToSourceFileMutator;
 import org.gradle.profiler.mutations.ApplyBuildScriptChangeFileMutator;
 import org.gradle.profiler.mutations.ApplyChangeToAndroidLayoutFileMutator;
@@ -444,7 +444,7 @@ class ScenarioLoader {
     }
 
     private static GradleBuildInvoker getAndroidStudioInvoker(Config config) {
-        CleanupSchedule schedule = ConfigUtil.enumValue(config, CLEAR_ANDROID_STUDIO_CACHE_BEFORE, CleanupSchedule.class, null);
+        Schedule schedule = ConfigUtil.enumValue(config, CLEAR_ANDROID_STUDIO_CACHE_BEFORE, Schedule.class, null);
         if (schedule == null) {
             return GradleBuildInvoker.AndroidStudio;
         }

--- a/src/main/java/org/gradle/profiler/gradle/GradleBuildInvoker.java
+++ b/src/main/java/org/gradle/profiler/gradle/GradleBuildInvoker.java
@@ -28,7 +28,7 @@ public class GradleBuildInvoker extends BuildInvoker {
     }
 
     @Override
-    public boolean allowsCleanupBetweenBuilds() {
+    public boolean allowsMutationBetweenBuilds() {
         // Warm daemons keep caches open and thus they cannot be removed
         return !isReuseDaemon();
     }

--- a/src/main/java/org/gradle/profiler/mutations/AbstractCacheCleanupMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/AbstractCacheCleanupMutator.java
@@ -2,19 +2,19 @@ package org.gradle.profiler.mutations;
 
 import java.io.File;
 
-public abstract class AbstractCacheCleanupMutator extends AbstractCleanupMutator {
+public abstract class AbstractCacheCleanupMutator extends AbstractScheduledMutator {
 
     private final File gradleUserHome;
     private final String cacheNamePrefix;
 
-    public AbstractCacheCleanupMutator(File gradleUserHome, CleanupSchedule schedule, String cacheNamePrefix) {
+    public AbstractCacheCleanupMutator(File gradleUserHome, Schedule schedule, String cacheNamePrefix) {
         super(schedule);
         this.gradleUserHome = gradleUserHome;
         this.cacheNamePrefix = cacheNamePrefix;
     }
 
     @Override
-    protected void cleanup() {
+    protected void executeOnSchedule() {
         System.out.println("> Cleaning " + cacheNamePrefix + " caches in " + gradleUserHome);
         File cachesDir = new File(gradleUserHome, "caches");
         if (cachesDir.isDirectory()) {

--- a/src/main/java/org/gradle/profiler/mutations/AbstractFileSystemMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/AbstractFileSystemMutator.java
@@ -1,10 +1,13 @@
 package org.gradle.profiler.mutations;
 
-import org.gradle.profiler.BuildMutator;
-
 import java.io.File;
 
-public class AbstractFileSystemMutator implements BuildMutator {
+public abstract class AbstractFileSystemMutator extends AbstractScheduledMutator {
+
+    protected AbstractFileSystemMutator(Schedule schedule) {
+        super(schedule);
+    }
+
     protected static File resolveProjectFile(File projectDir, String path) {
         File file = new File(path);
         if (file.isAbsolute()) {

--- a/src/main/java/org/gradle/profiler/mutations/AbstractScheduledMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/AbstractScheduledMutator.java
@@ -11,43 +11,43 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
-public abstract class AbstractCleanupMutator implements BuildMutator {
+public abstract class AbstractScheduledMutator implements BuildMutator {
 
-    private final CleanupSchedule schedule;
+    private final Schedule schedule;
 
-    public AbstractCleanupMutator(CleanupSchedule schedule) {
+    public AbstractScheduledMutator(Schedule schedule) {
         this.schedule = schedule;
     }
 
     @Override
     public void validate(BuildInvoker invoker) {
-        if (schedule != CleanupSchedule.SCENARIO && !invoker.allowsCleanupBetweenBuilds()) {
+        if (schedule != Schedule.SCENARIO && !invoker.allowsMutationBetweenBuilds()) {
             throw new IllegalStateException(this + " is not allowed to be executed between builds with invoker " + invoker);
         }
     }
 
     @Override
     public void beforeBuild(BuildContext context) {
-        if (schedule == CleanupSchedule.BUILD) {
-            cleanup();
+        if (schedule == Schedule.BUILD) {
+            executeOnSchedule();
         }
     }
 
     @Override
     public void beforeScenario(ScenarioContext context) {
-        if (schedule == CleanupSchedule.SCENARIO) {
-            cleanup();
+        if (schedule == Schedule.SCENARIO) {
+            executeOnSchedule();
         }
     }
 
     @Override
     public void beforeCleanup(BuildContext context) {
-        if (schedule == CleanupSchedule.CLEANUP) {
-            cleanup();
+        if (schedule == Schedule.CLEANUP) {
+            executeOnSchedule();
         }
     }
 
-    abstract protected void cleanup();
+    abstract protected void executeOnSchedule();
 
     protected static void delete(File f) {
         try {
@@ -64,14 +64,14 @@ public abstract class AbstractCleanupMutator implements BuildMutator {
     protected static abstract class Configurator implements BuildMutatorConfigurator {
         @Override
         public BuildMutator configure(String key, BuildMutatorConfiguratorSpec spec) {
-            CleanupSchedule schedule = ConfigUtil.enumValue(spec.getScenario(), key, CleanupSchedule.class, null);
+            Schedule schedule = ConfigUtil.enumValue(spec.getScenario(), key, Schedule.class, null);
             if (schedule == null) {
-                throw new IllegalArgumentException("Schedule for cleanup is not specified");
+                throw new IllegalArgumentException("Schedule is not specified");
             }
             return newInstance(spec, key, schedule);
         }
 
-        protected abstract BuildMutator newInstance(BuildMutatorConfiguratorSpec spec, String key, CleanupSchedule schedule);
+        protected abstract BuildMutator newInstance(BuildMutatorConfiguratorSpec spec, String key, Schedule schedule);
     }
 
     @Override
@@ -79,7 +79,7 @@ public abstract class AbstractCleanupMutator implements BuildMutator {
         return getClass().getSimpleName() + "(" + schedule + ")";
     }
 
-    public enum CleanupSchedule {
+    public enum Schedule {
         SCENARIO, CLEANUP, BUILD
     }
 }

--- a/src/main/java/org/gradle/profiler/mutations/ClearArtifactTransformCacheMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ClearArtifactTransformCacheMutator.java
@@ -6,7 +6,7 @@ import java.io.File;
 
 public class ClearArtifactTransformCacheMutator extends AbstractCacheCleanupMutator {
 
-    public ClearArtifactTransformCacheMutator(File gradleUserHome, CleanupSchedule schedule) {
+    public ClearArtifactTransformCacheMutator(File gradleUserHome, Schedule schedule) {
         super(gradleUserHome, schedule, "transforms-");
     }
 
@@ -15,9 +15,9 @@ public class ClearArtifactTransformCacheMutator extends AbstractCacheCleanupMuta
         delete(cacheDir);
     }
 
-    public static class Configurator extends AbstractCleanupMutator.Configurator {
+    public static class Configurator extends AbstractScheduledMutator.Configurator {
         @Override
-        protected BuildMutator newInstance(BuildMutatorConfiguratorSpec spec, String key, CleanupSchedule schedule) {
+        protected BuildMutator newInstance(BuildMutatorConfiguratorSpec spec, String key, Schedule schedule) {
             return new ClearArtifactTransformCacheMutator(spec.getGradleUserHome(), schedule);
         }
     }

--- a/src/main/java/org/gradle/profiler/mutations/ClearBuildCacheMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ClearBuildCacheMutator.java
@@ -8,13 +8,13 @@ import java.util.Objects;
 
 public class ClearBuildCacheMutator extends AbstractCacheCleanupMutator {
 
-    public ClearBuildCacheMutator(File gradleUserHome, CleanupSchedule schedule) {
+    public ClearBuildCacheMutator(File gradleUserHome, Schedule schedule) {
         super(gradleUserHome, schedule, "build-cache-");
     }
 
     @Override
     protected void cleanupCacheDir(File cacheDir) {
-        Arrays.stream(Objects.requireNonNull(cacheDir.listFiles(ClearBuildCacheMutator::shouldRemoveFile))).forEach(AbstractCleanupMutator::delete);
+        Arrays.stream(Objects.requireNonNull(cacheDir.listFiles(ClearBuildCacheMutator::shouldRemoveFile))).forEach(AbstractScheduledMutator::delete);
     }
 
     private static boolean shouldRemoveFile(File file) {
@@ -22,9 +22,9 @@ public class ClearBuildCacheMutator extends AbstractCacheCleanupMutator {
         return file.getName().length() == 32 || file.getName().endsWith(".db");
     }
 
-    public static class Configurator extends AbstractCleanupMutator.Configurator {
+    public static class Configurator extends AbstractScheduledMutator.Configurator {
         @Override
-        protected BuildMutator newInstance(BuildMutatorConfiguratorSpec spec, String key, CleanupSchedule schedule) {
+        protected BuildMutator newInstance(BuildMutatorConfiguratorSpec spec, String key, Schedule schedule) {
             return new ClearBuildCacheMutator(spec.getGradleUserHome(), schedule);
         }
     }

--- a/src/main/java/org/gradle/profiler/mutations/ClearConfigurationCacheStateMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ClearConfigurationCacheStateMutator.java
@@ -8,10 +8,10 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-public class ClearConfigurationCacheStateMutator extends AbstractCleanupMutator {
+public class ClearConfigurationCacheStateMutator extends AbstractScheduledMutator {
     private final File projectDir;
 
-    public ClearConfigurationCacheStateMutator(File projectDir, CleanupSchedule schedule) {
+    public ClearConfigurationCacheStateMutator(File projectDir, Schedule schedule) {
         super(schedule);
         this.projectDir = projectDir;
     }
@@ -22,7 +22,7 @@ public class ClearConfigurationCacheStateMutator extends AbstractCleanupMutator 
     }
 
     @Override
-    protected void cleanup() {
+    protected void executeOnSchedule() {
         System.out.println("> Cleaning configuration cache state");
         cleanup(new File(projectDir, ".gradle/configuration-cache"));
         cleanup(new File(projectDir, ".instant-execution-state"));
@@ -36,9 +36,9 @@ public class ClearConfigurationCacheStateMutator extends AbstractCleanupMutator 
         }
     }
 
-    public static class Configurator extends AbstractCleanupMutator.Configurator {
+    public static class Configurator extends AbstractScheduledMutator.Configurator {
         @Override
-        protected BuildMutator newInstance(BuildMutatorConfiguratorSpec spec, String key, CleanupSchedule schedule) {
+        protected BuildMutator newInstance(BuildMutatorConfiguratorSpec spec, String key, Schedule schedule) {
             return new ClearConfigurationCacheStateMutator(spec.getProjectDir(), schedule);
         }
     }

--- a/src/main/java/org/gradle/profiler/mutations/ClearGradleUserHomeMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ClearGradleUserHomeMutator.java
@@ -7,16 +7,16 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 
-public class ClearGradleUserHomeMutator extends AbstractCleanupMutator {
+public class ClearGradleUserHomeMutator extends AbstractScheduledMutator {
     private final File gradleUserHome;
 
-    public ClearGradleUserHomeMutator(File gradleUserHome, CleanupSchedule schedule) {
+    public ClearGradleUserHomeMutator(File gradleUserHome, Schedule schedule) {
         super(schedule);
         this.gradleUserHome = gradleUserHome;
     }
 
     @Override
-    protected void cleanup() {
+    protected void executeOnSchedule() {
         System.out.println(String.format("> Cleaning Gradle user home: %s", gradleUserHome.getAbsolutePath()));
         if (!gradleUserHome.exists()) {
             throw new IllegalArgumentException(String.format(
@@ -34,9 +34,9 @@ public class ClearGradleUserHomeMutator extends AbstractCleanupMutator {
         }
     }
 
-    public static class Configurator extends AbstractCleanupMutator.Configurator {
+    public static class Configurator extends AbstractScheduledMutator.Configurator {
         @Override
-        protected BuildMutator newInstance(BuildMutatorConfiguratorSpec spec, String key, CleanupSchedule schedule) {
+        protected BuildMutator newInstance(BuildMutatorConfiguratorSpec spec, String key, Schedule schedule) {
             return new ClearGradleUserHomeMutator(spec.getGradleUserHome(), schedule);
         }
     }

--- a/src/main/java/org/gradle/profiler/mutations/ClearJarsCacheMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ClearJarsCacheMutator.java
@@ -6,7 +6,7 @@ import java.io.File;
 
 public class ClearJarsCacheMutator extends AbstractCacheCleanupMutator {
 
-    public ClearJarsCacheMutator(File gradleUserHome, CleanupSchedule schedule) {
+    public ClearJarsCacheMutator(File gradleUserHome, Schedule schedule) {
         super(gradleUserHome, schedule, "jars-");
     }
 
@@ -15,9 +15,9 @@ public class ClearJarsCacheMutator extends AbstractCacheCleanupMutator {
         delete(cacheDir);
     }
 
-    public static class Configurator extends AbstractCleanupMutator.Configurator {
+    public static class Configurator extends AbstractScheduledMutator.Configurator {
         @Override
-        protected BuildMutator newInstance(BuildMutatorConfiguratorSpec spec, String key, CleanupSchedule schedule) {
+        protected BuildMutator newInstance(BuildMutatorConfiguratorSpec spec, String key, Schedule schedule) {
             return new ClearJarsCacheMutator(spec.getGradleUserHome(), schedule);
         }
     }

--- a/src/main/java/org/gradle/profiler/mutations/ClearProjectCacheMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ClearProjectCacheMutator.java
@@ -7,16 +7,16 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-public class ClearProjectCacheMutator extends AbstractCleanupMutator {
+public class ClearProjectCacheMutator extends AbstractScheduledMutator {
     private final File projectDir;
 
-    public ClearProjectCacheMutator(File projectDir, CleanupSchedule schedule) {
+    public ClearProjectCacheMutator(File projectDir, Schedule schedule) {
         super(schedule);
         this.projectDir = projectDir;
     }
 
     @Override
-    protected void cleanup() {
+    protected void executeOnSchedule() {
         deleteGradleCache("project", projectDir);
         File buildSrc = new File(projectDir, "buildSrc");
         if (buildSrc.exists()) {
@@ -34,9 +34,9 @@ public class ClearProjectCacheMutator extends AbstractCleanupMutator {
         }
     }
 
-    public static class Configurator extends AbstractCleanupMutator.Configurator {
+    public static class Configurator extends AbstractScheduledMutator.Configurator {
         @Override
-        protected BuildMutator newInstance(BuildMutatorConfiguratorSpec spec, String key, CleanupSchedule schedule) {
+        protected BuildMutator newInstance(BuildMutatorConfiguratorSpec spec, String key, Schedule schedule) {
             return new ClearProjectCacheMutator(spec.getProjectDir(), schedule);
         }
     }

--- a/src/main/java/org/gradle/profiler/mutations/CopyFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/CopyFileMutator.java
@@ -6,7 +6,6 @@ import com.typesafe.config.Config;
 import org.gradle.profiler.BuildMutator;
 import org.gradle.profiler.CompositeBuildMutator;
 import org.gradle.profiler.ConfigUtil;
-import org.gradle.profiler.ScenarioContext;
 
 import java.io.File;
 import java.io.IOException;
@@ -18,14 +17,14 @@ public class CopyFileMutator extends AbstractFileSystemMutator {
     private final File source;
     private final File target;
 
-    public CopyFileMutator(File source, File target) {
+    public CopyFileMutator(File source, File target, Schedule schedule) {
+        super(schedule);
         this.source = source;
         this.target = target;
     }
 
-    @SuppressWarnings("UnstableApiUsage")
     @Override
-    public void beforeScenario(ScenarioContext context) {
+    protected void executeOnSchedule() {
         try {
             System.out.println("Copying '" + source.getAbsolutePath() + "' to '" + target.getAbsolutePath() + "'");
             if (!target.exists()) {
@@ -54,12 +53,13 @@ public class CopyFileMutator extends AbstractFileSystemMutator {
         private static CopyFileMutator createMutator(BuildMutatorConfiguratorSpec spec, Config config) {
             String source = ConfigUtil.string(config, "source", null);
             String target = ConfigUtil.string(config, "target", null);
+            Schedule schedule = ConfigUtil.enumValue(config, "schedule", Schedule.class, Schedule.SCENARIO);
 
             if (Strings.isNullOrEmpty(source) || Strings.isNullOrEmpty(target)) {
                 throw new IllegalArgumentException("The `source` and `target` are required for copy-file");
             }
             File projectDir = spec.getProjectDir();
-            return new CopyFileMutator(resolveProjectFile(projectDir, source), resolveProjectFile(projectDir, target));
+            return new CopyFileMutator(resolveProjectFile(projectDir, source), resolveProjectFile(projectDir, target), schedule);
         }
     }
 }

--- a/src/main/java/org/gradle/profiler/mutations/DeleteFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/DeleteFileMutator.java
@@ -5,7 +5,6 @@ import org.apache.commons.io.FileUtils;
 import org.gradle.profiler.BuildMutator;
 import org.gradle.profiler.CompositeBuildMutator;
 import org.gradle.profiler.ConfigUtil;
-import org.gradle.profiler.ScenarioContext;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,12 +15,13 @@ public class DeleteFileMutator extends AbstractFileSystemMutator {
 
     private final File target;
 
-    public DeleteFileMutator(File target) {
+    public DeleteFileMutator(File target, Schedule schedule) {
+        super(schedule);
         this.target = target;
     }
 
     @Override
-    public void beforeScenario(ScenarioContext context) {
+    protected void executeOnSchedule() {
         System.out.println("Removing file: '" + target.getAbsolutePath() + "'");
         try {
             if (target.exists()) {
@@ -43,8 +43,9 @@ public class DeleteFileMutator extends AbstractFileSystemMutator {
 
         private static DeleteFileMutator createMutator(BuildMutatorConfiguratorSpec spec, Config config) {
             String target = ConfigUtil.string(config, "target");
+            Schedule schedule = ConfigUtil.enumValue(config, "schedule", Schedule.class, Schedule.SCENARIO);
             File projectDir = spec.getProjectDir();
-            return new DeleteFileMutator(resolveProjectFile(projectDir, target));
+            return new DeleteFileMutator(resolveProjectFile(projectDir, target), schedule);
         }
     }
 }

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -9,7 +9,7 @@ import org.gradle.profiler.gradle.GradleScenarioDefinition
 import org.gradle.profiler.gradle.LoadToolingModelAction
 import org.gradle.profiler.gradle.RunToolingAction
 import org.gradle.profiler.maven.MavenScenarioDefinition
-import org.gradle.profiler.mutations.AbstractCleanupMutator
+import org.gradle.profiler.mutations.AbstractScheduledMutator
 import org.gradle.profiler.report.Format
 import org.gradle.profiler.studio.AndroidStudioSyncAction
 import org.gradle.profiler.studio.invoker.StudioGradleScenarioDefinition
@@ -21,7 +21,7 @@ import spock.lang.Specification
 import spock.lang.Unroll
 
 import static org.gradle.profiler.ScenarioLoader.loadScenarios
-import static org.gradle.profiler.mutations.AbstractCleanupMutator.CleanupSchedule.*
+import static org.gradle.profiler.mutations.AbstractScheduledMutator.Schedule.*
 
 class ScenarioLoaderTest extends Specification {
     @Rule
@@ -554,7 +554,7 @@ class ScenarioLoaderTest extends Specification {
         noExceptionThrown()
 
         where:
-        schedule << AbstractCleanupMutator.CleanupSchedule.values()
+        schedule << AbstractScheduledMutator.Schedule.values()
     }
 
     @Unroll

--- a/src/test/groovy/org/gradle/profiler/mutations/ClearArtifactTransformCacheMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ClearArtifactTransformCacheMutatorTest.groovy
@@ -16,7 +16,7 @@ class ClearArtifactTransformCacheMutatorTest extends AbstractMutatorTest {
         ignored2.mkdirs()
 
         when:
-        def mutator = new ClearArtifactTransformCacheMutator(userHome, AbstractCleanupMutator.CleanupSchedule.BUILD)
+        def mutator = new ClearArtifactTransformCacheMutator(userHome, AbstractScheduledMutator.Schedule.BUILD)
         mutator.beforeBuild(buildContext)
 
         then:

--- a/src/test/groovy/org/gradle/profiler/mutations/ClearBuildCacheMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ClearBuildCacheMutatorTest.groovy
@@ -1,8 +1,8 @@
 package org.gradle.profiler.mutations
 
-import static org.gradle.profiler.mutations.AbstractCleanupMutator.CleanupSchedule.BUILD
-import static org.gradle.profiler.mutations.AbstractCleanupMutator.CleanupSchedule.CLEANUP
-import static org.gradle.profiler.mutations.AbstractCleanupMutator.CleanupSchedule.SCENARIO
+import static org.gradle.profiler.mutations.AbstractScheduledMutator.Schedule.BUILD
+import static org.gradle.profiler.mutations.AbstractScheduledMutator.Schedule.CLEANUP
+import static org.gradle.profiler.mutations.AbstractScheduledMutator.Schedule.SCENARIO
 
 class ClearBuildCacheMutatorTest extends AbstractMutatorTest {
 

--- a/src/test/groovy/org/gradle/profiler/mutations/ClearJarsCacheMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ClearJarsCacheMutatorTest.groovy
@@ -16,7 +16,7 @@ class ClearJarsCacheMutatorTest extends AbstractMutatorTest {
         ignored2.mkdirs()
 
         when:
-        def mutator = new ClearJarsCacheMutator(userHome, AbstractCleanupMutator.CleanupSchedule.BUILD)
+        def mutator = new ClearJarsCacheMutator(userHome, AbstractScheduledMutator.Schedule.BUILD)
         mutator.beforeBuild(buildContext)
 
         then:


### PR DESCRIPTION
This allows a `copy-file` or `delete-file` to be scheduled to be executed before a scenario, cleanup or build step.