### PR TITLE
Use Java 17 for most of gradle-profiler tests

### DIFF
--- a/.teamcity/settings/GradleProfilerPublishToSdkMan.kt
+++ b/.teamcity/settings/GradleProfilerPublishToSdkMan.kt
@@ -28,9 +28,9 @@ class GradleProfilerPublishToSdkMan(publishingBuild: GradleProfilerPublishing) :
     }
 
     params {
-        // Java home must always use Java11
+        // Java home must always use Java17
         // since intellij-gradle-plugin is not compatible with Java8
-        javaHome(os, JavaVersion.OPENJDK_11)
+        javaHome(os, JavaVersion.OPENJDK_17)
         text("additional.gradle.parameters", "")
 
         param("env.ORG_GRADLE_PROJECT_sdkmanKey", "%gradleprofiler.sdkman.key%")

--- a/.teamcity/settings/GradleProfilerPublishing.kt
+++ b/.teamcity/settings/GradleProfilerPublishing.kt
@@ -15,9 +15,9 @@ object GradleProfilerPublishing : BuildType({
     val os = Os.linux
 
     params {
-        // Java home must always use Java11
+        // Java home must always use Java17
         // since intellij-gradle-plugin is not compatible with Java8
-        javaHome(os, JavaVersion.OPENJDK_11)
+        javaHome(os, JavaVersion.OPENJDK_17)
         password("pgpSigningKey", "credentialsJSON:20c56c10-3c97-4753-91c2-685ddf26700e", display = ParameterDisplay.HIDDEN)
         password("pgpSigningPassphrase", "credentialsJSON:d49291bd-101e-4165-a9a8-912ca457926b", display = ParameterDisplay.HIDDEN)
         password("mavenCentralStagingRepoUser", "credentialsJSON:ce6ff00a-dc06-4b9b-aa1f-7b01bea2eb2f", display = ParameterDisplay.HIDDEN)

--- a/.teamcity/settings/GradleProfilerTest.kt
+++ b/.teamcity/settings/GradleProfilerTest.kt
@@ -10,9 +10,9 @@ open class GradleProfilerTest(os: Os, javaVersion: JavaVersion, arch: Arch = Arc
     gradleProfilerVcs()
 
     params {
-        // Java home must always use Java11
+        // Java home must always use Java17
         // since intellij-gradle-plugin is not compatible with Java8
-        javaHome(os, JavaVersion.OPENJDK_11)
+        javaHome(os, JavaVersion.OPENJDK_17)
         androidHome(os)
     }
 
@@ -64,14 +64,14 @@ object LinuxJava8 : GradleProfilerTest(Os.linux, JavaVersion.ORACLE_JAVA_8, {
     name = "Linux - Java 8"
 })
 
-object LinuxJava11 : GradleProfilerTest(Os.linux, JavaVersion.OPENJDK_11, {
-    name = "Linux - Java 11"
+object LinuxJava17 : GradleProfilerTest(Os.linux, JavaVersion.OPENJDK_17, {
+    name = "Linux - Java 17"
 })
 
-object MacOSJava8 : GradleProfilerTest(Os.macos, JavaVersion.ORACLE_JAVA_8, {
-    name = "MacOS - Java 8"
+object MacOSJava17 : GradleProfilerTest(Os.macos, JavaVersion.OPENJDK_17, {
+    name = "MacOS - Java 17"
 })
 
-object WindowsJava11 : GradleProfilerTest(Os.windows, JavaVersion.OPENJDK_11, {
-    name = "Windows - Java 11"
+object WindowsJava17 : GradleProfilerTest(Os.windows, JavaVersion.OPENJDK_17, {
+    name = "Windows - Java 17"
 })

--- a/.teamcity/settings/extensions.kt
+++ b/.teamcity/settings/extensions.kt
@@ -17,7 +17,10 @@ fun BuildType.agentRequirement(os: Os, arch: Arch = Arch.AMD64) {
 fun toolchainConfiguration(os: Os) = listOf(
     "-Porg.gradle.java.installations.auto-detect=false",
     "-Porg.gradle.java.installations.auto-download=false",
-    """"-Porg.gradle.java.installations.paths=%${os.name}.java8.oracle.64bit%,%${os.name}.java11.openjdk.64bit%""""
+    """"-Porg.gradle.java.installations.paths=
+        |%${os.name}.java8.oracle.64bit%,
+        |%${os.name}.java11.openjdk.64bit%,
+        |%${os.name}.java17.openjdk.64bit%"""".trimMargin()
 ).joinToString(" ")
 
 fun ParametrizedWithType.javaHome(os: Os, javaVersion: JavaVersion) {
@@ -35,7 +38,7 @@ fun ParametrizedWithType.androidHome(os: Os) {
 
 enum class JavaVersion(val majorVersion: String, val vendor: String, private val javaHomePostfix: String) {
     ORACLE_JAVA_8("8", "oracle", "java8.oracle.64bit"),
-    OPENJDK_11("11", "openjdk", "java11.openjdk.64bit");
+    OPENJDK_17("17", "openjdk", "java17.openjdk.64bit");
 
     fun javaHome(os: Os) = "%${os.name}.$javaHomePostfix%"
 }

--- a/.teamcity/settings/root-project.kt
+++ b/.teamcity/settings/root-project.kt
@@ -5,10 +5,10 @@ fun Project.configureGradleProfilerProject() {
     description = "Runs tests and integration tests of the Gradle Profiler (https://github.com/gradle/gradle-profiler)"
 
     val testBuilds = listOf(
-        MacOSJava8,
-        WindowsJava11,
+        MacOSJava17,
+        WindowsJava17,
         LinuxJava8,
-        LinuxJava11
+        LinuxJava17
     )
 
     testBuilds.forEach(this::buildType)


### PR DESCRIPTION
Since we will upgrade Android Studio that supports just Java 17. Additionally in the future Gradle will support only Java 17. 

We will keep Linux running with Java 8 for now.