### PR TITLE
Publish build scan commit statuses

### DIFF
--- a/.github/workflows/build-scan-commit-status.yml
+++ b/.github/workflows/build-scan-commit-status.yml
@@ -14,7 +14,7 @@ jobs:
       - name: configure aws credentials
         uses: aws-actions/configure-aws-credentials@v3
         with:
-          role-to-assume: arn:aws:iam::992382829881:role/GitHubActions_SecretAccess_gradle_profiler_all
+          role-to-assume: arn:aws:iam::992382829881:role/GHASecrets_gradle-profiler_all
           aws-region: "eu-central-1"
       - name: get secrets
         uses: aws-actions/aws-secretsmanager-get-secrets@v2

--- a/.github/workflows/build-scan-commit-status.yml
+++ b/.github/workflows/build-scan-commit-status.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           repository: gradle/gradle-github-actions
           ref: main
-          token: ${{ secrets.GH_PAT }}
+          token: ${{ env.GH_PAT }}
           path: .github/actions/gradle-github-actions
       - name: Publish BuildScan Commit Status
         uses: ./.github/actions/gradle-github-actions/buildscan-commit-status-action

--- a/.github/workflows/build-scan-commit-status.yml
+++ b/.github/workflows/build-scan-commit-status.yml
@@ -5,11 +5,22 @@ on:
 
 permissions:
   statuses: write
+  id-token: write
 
 jobs:
   build_scan_commit_status:
     runs-on: ubuntu-latest
     steps:
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: arn:aws:iam::992382829881:role/GitHubActions_SecretAccess_gradle_profiler_all
+          aws-region: "eu-central-1"
+      - name: get secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@v2
+        with:
+          secret-ids: |
+            GH_PAT, gha/gradle-profiler/_all/GH_BOT_GITHUB_TOKEN
       - name: Checkout gradle-github-actions Repo
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-scan-commit-status.yml
+++ b/.github/workflows/build-scan-commit-status.yml
@@ -1,0 +1,21 @@
+name: Publish BuildScan Commit Status
+
+on:
+  status
+
+permissions:
+  statuses: write
+
+jobs:
+  build_scan_commit_status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gradle-github-actions Repo
+        uses: actions/checkout@v4
+        with:
+          repository: gradle/gradle-github-actions
+          ref: main
+          token: ${{ secrets.GH_PAT }}
+          path: .github/actions/gradle-github-actions
+      - name: Publish BuildScan Commit Status
+        uses: ./.github/actions/gradle-github-actions/buildscan-commit-status-action


### PR DESCRIPTION
This is a preparation for making TeamCity private. Currently, we run the builds on TeamCity and all links in the commit statuses point to TeamCity. Once we make TC private, the links are no longer visible to community contributors.

This PR adds a GitHub action that attaches an extra commit status to the commit:

1. If the TeamCity build succeeds, it will attach a link pointing to all builds with the specific commit on ge.gradle.org
2. If the TeamCity build fails,  it will attach a link pointing to failed builds with the specific commit on ge.gradle.org

Example:

<img width="636" alt="image" src="https://github.com/user-attachments/assets/15376154-c245-4cf1-a3fd-15a790f5e655">

<img width="624" alt="image" src="https://github.com/user-attachments/assets/ffa12498-8663-495d-b000-7ab88df5924b">
