### PR TITLE
Add support specifying gradle distribution in the gradle-version argument

### DIFF
--- a/src/main/java/org/gradle/profiler/CommandLineParser.java
+++ b/src/main/java/org/gradle/profiler/CommandLineParser.java
@@ -64,7 +64,7 @@ class CommandLineParser {
         parser.nonOptions("The scenarios or task names to run");
         ArgumentAcceptingOptionSpec<File> projectOption = parser.accepts("project-dir", "The directory containing the build to run (default: working directory)")
             .withRequiredArg().ofType(File.class);
-        ArgumentAcceptingOptionSpec<String> gradleVersionOption = parser.accepts("gradle-version", "Gradle version or installation to use to run build")
+        ArgumentAcceptingOptionSpec<String> gradleVersionOption = parser.accepts("gradle-version", "Gradle version, distribution or installation to use to run build")
             .withRequiredArg();
         ArgumentAcceptingOptionSpec<File> gradleUserHomeOption = parser.accepts("gradle-user-home", "The Gradle user home to use")
             .withRequiredArg()

--- a/src/main/java/org/gradle/profiler/gradle/DefaultGradleBuildConfigurationReader.java
+++ b/src/main/java/org/gradle/profiler/gradle/DefaultGradleBuildConfigurationReader.java
@@ -18,6 +18,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.net.URI;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -91,6 +92,9 @@ public class DefaultGradleBuildConfigurationReader implements GradleBuildConfigu
             }
             if (versionString.matches("\\d+(\\.\\d+)+(-.+)?")) {
                 return probe(connector().useGradleVersion(versionString));
+            }
+            if (versionString.matches("^(https?|file)://\\S+")) {
+                return probe(connector().useDistribution(URI.create(versionString)));
             }
         } catch (IOException e) {
             throw new RuntimeException("Could not locate Gradle distribution for requested version '" + versionString + "'.", e);

--- a/src/main/java/org/gradle/profiler/gradle/DefaultGradleBuildConfigurationReader.java
+++ b/src/main/java/org/gradle/profiler/gradle/DefaultGradleBuildConfigurationReader.java
@@ -86,7 +86,7 @@ public class DefaultGradleBuildConfigurationReader implements GradleBuildConfigu
         Logging.startOperation("Inspecting the build using Gradle version '" + versionString + "'");
         try {
             File dir = new File(versionString);
-            if (dir.isDirectory()) {
+            if (!versionString.isEmpty() && dir.isDirectory()) {
                 dir = dir.getCanonicalFile();
                 return probe(connector().useInstallation(dir));
             }

--- a/src/main/java/org/gradle/profiler/gradle/DefaultGradleBuildConfigurationReader.java
+++ b/src/main/java/org/gradle/profiler/gradle/DefaultGradleBuildConfigurationReader.java
@@ -18,6 +18,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.net.URI;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -92,6 +93,12 @@ public class DefaultGradleBuildConfigurationReader implements GradleBuildConfigu
             if (versionString.matches("\\d+(\\.\\d+)+(-.+)?")) {
                 return probe(connector().useGradleVersion(versionString));
             }
+            if (versionString.matches("^(https?|file)://\\S+")) {
+                return probe(connector().useDistribution(URI.create(versionString)));
+            }
+            if (dir.isFile() && dir.getName().endsWith(".zip")) {
+                return probe(connector().useDistribution(dir.toURI()));
+            }
         } catch (IOException e) {
             throw new RuntimeException("Could not locate Gradle distribution for requested version '" + versionString + "'.", e);
         }
@@ -116,7 +123,7 @@ public class DefaultGradleBuildConfigurationReader implements GradleBuildConfigu
             Properties properties = new Properties();
             properties.load(inputStream);
             return new BuildDetails(
-                properties.getProperty("gradleHome").trim(),
+                properties.getProperty("gradleHome", "").trim(),
                 properties.getProperty("isBuildScanPluginApplied", "false").trim().equals("true"),
                 properties.getProperty("isEnterprisePluginApplied", "false").trim().equals("true"),
                 properties.getProperty("isDevelocityPluginApplied", "false").trim().equals("true")

--- a/src/test/groovy/org/gradle/profiler/CommandLineIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/CommandLineIntegrationTest.groovy
@@ -54,8 +54,8 @@ Option                                   Description
                                            without running
 --gradle-user-home <File>                The Gradle user home to use (default:
                                            gradle-user-home)
---gradle-version <String>                Gradle version or installation to use
-                                           to run build
+--gradle-version <String>                Gradle version, distribution or
+                                           installation to use to run build
 --group <String>                         Run scenarios from a group
 -h, --help                               Show this usage information
 --idea-install-dir <File>                The IntelliJ IDEA installation to use

--- a/src/test/groovy/org/gradle/profiler/gradle/DefaultGradleBuildConfigurationReaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/gradle/DefaultGradleBuildConfigurationReaderTest.groovy
@@ -1,0 +1,44 @@
+package org.gradle.profiler.gradle
+
+import org.gradle.profiler.fixtures.AbstractIntegrationTest
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+class DefaultGradleBuildConfigurationReaderTest extends AbstractIntegrationTest {
+
+    @Rule
+    TemporaryFolder tmpDir = new TemporaryFolder()
+    File projectDir
+    File gradleUserHome
+    DaemonControl daemonControl
+
+    def setup() {
+        projectDir = tmpDir.newFolder("test-project")
+        gradleUserHome = tmpDir.newFolder("gradle-home")
+        daemonControl = new DaemonControl(gradleUserHome)
+    }
+
+    def "configuration reader throw exception when gradle version is some garbage string"() {
+        given: "Given"
+        def reader = new DefaultGradleBuildConfigurationReader(projectDir, gradleUserHome, daemonControl)
+
+        when: "When"
+        reader.readConfiguration("some garbage string")
+
+        then: "Then"
+        IllegalArgumentException exception = thrown(IllegalArgumentException.class)
+        exception.message == "Unrecognized Gradle version 'some garbage string' specified."
+    }
+
+    def "configuration reader throw exception when gradle version is empty string"() {
+        given: "Given"
+        def reader = new DefaultGradleBuildConfigurationReader(projectDir, gradleUserHome, daemonControl)
+
+        when: "When"
+        reader.readConfiguration("")
+
+        then: "Then"
+        IllegalArgumentException exception = thrown(IllegalArgumentException.class)
+        exception.message == "Unrecognized Gradle version '' specified."
+    }
+}

--- a/src/test/groovy/org/gradle/profiler/gradle/DefaultGradleBuildConfigurationReaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/gradle/DefaultGradleBuildConfigurationReaderTest.groovy
@@ -33,7 +33,7 @@ class DefaultGradleBuildConfigurationReaderTest extends AbstractIntegrationTest 
         reader.readConfiguration(gradleVersion)
 
         then:
-        IllegalArgumentException exception = thrown(IllegalArgumentException.class)
+        RuntimeException exception = thrown(RuntimeException.class)
         exception.message == "Unrecognized Gradle version '$gradleVersion' specified."
 
         where:

--- a/src/test/groovy/org/gradle/profiler/gradle/DefaultGradleBuildConfigurationReaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/gradle/DefaultGradleBuildConfigurationReaderTest.groovy
@@ -1,0 +1,92 @@
+package org.gradle.profiler.gradle
+
+import org.gradle.profiler.fixtures.AbstractIntegrationTest
+import org.gradle.tooling.BuildLauncher
+import org.gradle.tooling.GradleConnector
+import org.gradle.tooling.ProjectConnection
+import org.gradle.tooling.model.Launchable
+import org.gradle.tooling.model.Task
+import org.gradle.tooling.model.build.BuildEnvironment
+import org.gradle.tooling.model.build.GradleEnvironment
+import org.gradle.tooling.model.build.JavaEnvironment
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+
+class DefaultGradleBuildConfigurationReaderTest extends AbstractIntegrationTest {
+
+    @Rule
+    TemporaryFolder tmpDir = new TemporaryFolder()
+    File projectDir
+    File gradleUserHome
+
+    def setup() {
+        projectDir = tmpDir.newFolder("test-project")
+        gradleUserHome = tmpDir.newFolder("gradle-home")
+    }
+
+    def "configuration reader throw exception when gradle version is unsupported string"() {
+        given:
+        def daemonControl = Mock(DaemonControl)
+        def reader = new DefaultGradleBuildConfigurationReader(projectDir, gradleUserHome, daemonControl)
+
+        when:
+        reader.readConfiguration(gradleVersion)
+
+        then:
+        IllegalArgumentException exception = thrown(IllegalArgumentException.class)
+        exception.message == "Unrecognized Gradle version '$gradleVersion' specified."
+
+        where:
+        gradleVersion << ["some garbage string", "ftp://unsupported/distribution.zip", ""]
+    }
+
+    def "configuration reader returns build config when gradle version is valid"() {
+        given:
+        def buildLauncher = Mock(BuildLauncher)
+        buildLauncher.forTasks(_ as Iterable<? extends Task>) >> buildLauncher
+        buildLauncher.forLaunchables(_ as Iterable<? extends Launchable>) >> buildLauncher
+        def javaEnvironment = Mock(JavaEnvironment)
+        javaEnvironment.getJavaHome() >> Mock(File)
+        javaEnvironment.getJvmArguments() >> []
+        def gradleEnvironment = Mock(GradleEnvironment)
+        gradleEnvironment.gradleVersion >> expectedVersion
+        def buildEnvironment = Mock(BuildEnvironment)
+        buildEnvironment.getJava() >> javaEnvironment
+        buildEnvironment.getGradle() >> gradleEnvironment
+        def projectConnection = Mock(ProjectConnection)
+        projectConnection.newBuild() >> buildLauncher
+        projectConnection.getModel(_ as Class<Object>) >> buildEnvironment
+        def gradleConnector = Mock(GradleConnector)
+        gradleConnector.connect() >> projectConnection
+        gradleConnector.useInstallation(_ as File) >> gradleConnector
+        gradleConnector.useGradleVersion(_ as String) >> gradleConnector
+        gradleConnector.useDistribution(_ as URI) >> gradleConnector
+        gradleConnector.useBuildDistribution() >> gradleConnector
+        gradleConnector.forProjectDirectory(_ as File) >> gradleConnector
+        gradleConnector.useGradleUserHomeDir(_ as File) >> gradleConnector
+        SpyStatic(GradleConnector)
+        GradleConnector.newConnector() >> gradleConnector
+        def daemonControl = Mock(DaemonControl)
+        def reader = new DefaultGradleBuildConfigurationReader(projectDir, gradleUserHome, daemonControl)
+        if (gradleVersion == "gradle-9-dir") {
+            gradleVersion = tmpDir.newFolder(gradleVersion).path
+        } else if (gradleVersion == "gradle-9.5.0.zip") {
+            gradleVersion = tmpDir.newFile(gradleVersion).path
+        }
+
+        when:
+        def result = reader.readConfiguration(gradleVersion)
+
+        then:
+        result.gradleVersion.version == expectedVersion
+
+        where:
+        gradleVersion                   || expectedVersion
+        "gradle-9-dir"                  || "9.0.0"
+        "9.6.1"                         || "9.6.1"
+        "http://gradle-9.6.0-all.zip"   || "9.6.0"
+        "https://gradle-9.4.1-bin.zip"  || "9.4.1"
+        "file://gradle-9.2.1-bin.zip"   || "9.2.1"
+        "gradle-9.5.0.zip"              || "9.5.0"
+    }
+}


### PR DESCRIPTION
Currently the `gradle-version` argument supports:
- path to a local directory with gradle;
- gradle version that will be downloaded from the official repository.

Changes in this pull request allows you to specify a URI to gradle distribution. This can be useful when we compare different gradle versions on a machine that does not have access to external repositories.

Usage:
```shell
--gradle-version="https://<some_internal_repo>/<path>/gradle-<version_1>-bin.zip" --gradle-version="https://<some_internal_repo>/<path>/gradle-<version_2>-bin.zip"
```