### PR TITLE
enhancements on ReflectionUtil#invokerGetter()

### DIFF
--- a/subprojects/chrome-trace/src/main/java/org/gradle/trace/util/ReflectionUtil.java
+++ b/subprojects/chrome-trace/src/main/java/org/gradle/trace/util/ReflectionUtil.java
@@ -4,13 +4,22 @@ import java.lang.reflect.Method;
 
 public interface ReflectionUtil {
 
-    static Object invokerGetter(Object object, String method) {
+    static Object invokerGetter(Object object, String methodName) {
+        boolean originalAccessibility;
+        Method method;
         try {
-            Method getterMethod = object.getClass().getMethod(method);
-            getterMethod.setAccessible(true);
-            return getterMethod.invoke(object);
+            method = object.getClass().getDeclaredMethod(methodName);
+            originalAccessibility = method.isAccessible();
+            method.setAccessible(true);
         } catch (Exception e) {
             throw new RuntimeException(e);
+        }
+        try {
+            return method.invoke(object);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            method.setAccessible(originalAccessibility);
         }
     }
 }


### PR DESCRIPTION
- `getMethod()` will return public method, should use `getDeclaredMethod` instead.
- storing the original accessibility of target method after reflective invocation.