### PR TITLE
Add foojay-resolver-convention plugin.

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.gradle.develocity").version("4.1")
     id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.2")
+    id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
 }
 
 checkIfCurrentJavaIsCompatible()


### PR DESCRIPTION
This repo uses toolchains in several places, but without the foojay plugin, the build can fail when a necessary JDK isn't available.

For example, in our CI system, I have seen this error:
```
* What went wrong:

Could not determine the dependencies of task ':installDist'.
> Could not resolve all dependencies for configuration ':runtimeClasspath'.
   > Failed to calculate the value of task ':compileJava' property 'javaCompiler'.
      > Cannot find a Java installation on your machine ... matching: {languageVersion=8, vendor=any vendor, implementation=vendor-specific, nativeImageCapable=false}. Toolchain ownload repositories have not been configured.
```