### PR TITLE
Revert "Add foojay-resolver-convention plugin."

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("com.gradle.develocity").version("4.1")
     id("io.github.gradle.gradle-enterprise-conventions-plugin").version("0.10.2")
-    id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
 }
 
 checkIfCurrentJavaIsCompatible()


### PR DESCRIPTION
Reverts gradle/gradle-profiler#622

The plugin requires Java 17 to run, and our setup uses Java 11. I'll reland the PR when this is addressed.