### PR TITLE
Scenario groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Add the `--profile chrome-trace` option and open the result in Google Chrome in 
 - `--csv-format <format>`: Format of the CSV output file. Values: `wide` (default) or `long`. The `wide` format produces a matrix with scenarios as columns. The `long` format produces one row per iteration/sample, which is more suitable for concatenating multiple benchmark results together.
 - `--warmups`: Specifies the number of warm-up builds to run for each scenario. Defaults to 2 for profiling, 6 for benchmarking, and 1 when not using a warm daemon.
 - `--iterations`: Specifies the number of builds to run for each scenario. Defaults to 1 for profiling, 10 for benchmarking.
+- `--group <group-name>`: Run scenarios from the specified scenario group.
 - `--bazel`: Benchmark scenarios using Bazel instead of Gradle. By default, only Gradle scenarios are run. You cannot profile a Bazel build using this tool.
 - `--buck`: Benchmark scenarios using Buck instead of Gradle. By default, only Gradle scenarios are run. You cannot profile a Buck build using this tool.
 - `--maven`: Benchmark scenarios using Maven instead of Gradle. By default, only Gradle scenarios are run. You cannot profile a Maven build using this tool.
@@ -295,6 +296,32 @@ Here is an example:
     }
 
 Values are optional and default to the values provided on the command-line or defined in the build.
+
+### Scenario groups
+
+You can organize scenarios into groups to run related scenarios together. Define groups using the `scenario-groups` top-level element:
+
+    scenario-groups {
+        smoke-tests = ["assemble", "clean_build"]
+        performance-suite = ["incremental_build", "full_build", "no_op"]
+    }
+
+    assemble {
+        tasks = ["assemble"]
+    }
+
+    clean_build {
+        cleanup-tasks = ["clean"]
+        tasks = ["build"]
+    }
+
+    # ... definition of other scenarios ...
+
+To run scenarios from a specific group:
+
+    > gradle-profiler --benchmark --scenario-file performance.scenarios --group smoke-tests
+
+This will run only the scenarios defined in the `smoke-tests` group (`assemble` and `clean_build`).
 
 ### Benchmark options
 

--- a/src/main/java/org/gradle/profiler/CommandLineParser.java
+++ b/src/main/java/org/gradle/profiler/CommandLineParser.java
@@ -81,6 +81,10 @@ class CommandLineParser {
             "Title to show on benchmark report")
             .withOptionalArg()
             .ofType(String.class);
+        ArgumentAcceptingOptionSpec<String> groupOption = parser.accepts("group",
+            "Run scenarios from a group")
+            .withRequiredArg()
+            .ofType(String.class);
 
         OptionSet parsedOptions;
         try {
@@ -168,6 +172,7 @@ class CommandLineParser {
         }
         Format csvFormat = Format.parse(parsedOptions.valueOf(csvFormatOption));
         String benchmarkTitle = parsedOptions.valueOf(benchmarkTitleOption);
+        String scenarioGroup = parsedOptions.valueOf(groupOption);
 
         return new InvocationSettings.InvocationSettingsBuilder()
             .setProjectDir(projectDir)
@@ -193,6 +198,7 @@ class CommandLineParser {
             .setBuildOperationsTrace(buildOperationsTrace)
             .setCsvFormat(csvFormat)
             .setBenchmarkTitle(benchmarkTitle)
+            .setScenarioGroup(scenarioGroup)
             .build();
     }
 

--- a/src/main/java/org/gradle/profiler/InvocationSettings.java
+++ b/src/main/java/org/gradle/profiler/InvocationSettings.java
@@ -265,7 +265,13 @@ public class InvocationSettings {
         out.println("Benchmark: " + isBenchmark());
         out.println("Versions: " + getVersions());
         out.println("Gradle User Home: " + getGradleUserHome());
-        out.println("Targets: " + getTargets());
+        if (getScenarioGroup() != null) {
+            out.println("Targets: '" + getScenarioGroup() + "' (group)");
+        } else if (getTargets() != null && !getTargets().isEmpty()) {
+            out.println("Targets: " + getTargets());
+        } else {
+            out.println("Targets: default scenarios");
+        }
         if (warmupCount != null) {
             out.println("Warm-ups: " + warmupCount);
         }

--- a/src/main/java/org/gradle/profiler/InvocationSettings.java
+++ b/src/main/java/org/gradle/profiler/InvocationSettings.java
@@ -34,6 +34,7 @@ public class InvocationSettings {
     private final boolean buildOperationsTrace;
     private final Format csvFormat;
     private final String benchmarkTitle;
+    private final String scenarioGroup;
     /**
      * The log file which the build should write stdout and stderr to.
      * If {@code null}, the stdout and stderr are stored in memory.
@@ -66,6 +67,7 @@ public class InvocationSettings {
         boolean buildOperationsTrace,
         Format csvFormat,
         String benchmarkTitle,
+        String scenarioGroup,
         File buildLog
     ) {
         this.benchmark = benchmark;
@@ -91,6 +93,7 @@ public class InvocationSettings {
         this.buildOperationsTrace = buildOperationsTrace;
         this.csvFormat = csvFormat;
         this.benchmarkTitle = benchmarkTitle;
+        this.scenarioGroup = scenarioGroup;
         this.buildLog = buildLog;
     }
 
@@ -210,6 +213,17 @@ public class InvocationSettings {
         return benchmarkTitle;
     }
 
+    /**
+     * The name of the scenario group to run, if specified via --group.
+     * When set, only scenarios from this group will be executed.
+     *
+     * @return the scenario group name, or null if not specified
+     */
+    @Nullable
+    public String getScenarioGroup() {
+        return scenarioGroup;
+    }
+
     public UUID getInvocationId() {
         return invocationId;
     }
@@ -237,6 +251,7 @@ public class InvocationSettings {
             .setBuildOperationsTrace(buildOperationsTrace)
             .setCsvFormat(csvFormat)
             .setBenchmarkTitle(benchmarkTitle)
+            .setScenarioGroup(scenarioGroup)
             .setBuildLog(buildLog);
     }
 
@@ -289,6 +304,7 @@ public class InvocationSettings {
         private boolean buildOperationsTrace;
         private Format csvFormat;
         private String benchmarkTitle;
+        private String scenarioGroup;
         private File buildLog;
 
         public InvocationSettingsBuilder setProjectDir(File projectDir) {
@@ -409,6 +425,18 @@ public class InvocationSettings {
             return this;
         }
 
+        /**
+         * Sets the scenario group to run. When set, only scenarios from this group will be executed.
+         * Cannot be combined with individual scenario names.
+         *
+         * @param scenarioGroup the scenario group name, or null
+         * @return this builder
+         */
+        public InvocationSettingsBuilder setScenarioGroup(@Nullable String scenarioGroup) {
+            this.scenarioGroup = scenarioGroup;
+            return this;
+        }
+
         public InvocationSettingsBuilder setBuildLog(File buildLog) {
             this.buildLog = buildLog;
             return this;
@@ -439,6 +467,7 @@ public class InvocationSettings {
                 buildOperationsTrace,
                 csvFormat,
                 benchmarkTitle,
+                scenarioGroup,
                 buildLog
             );
         }

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -562,9 +562,16 @@ class ScenarioLoader {
             .filter(key -> !RESERVED_TOP_LEVEL_KEYS.contains(key))
             .collect(Collectors.toCollection(TreeSet::new));
 
-        if (settings.getScenarioGroup() != null) {
+        boolean groupRequested = settings.getScenarioGroup() != null;
+        boolean targetsRequested = !settings.getTargets().isEmpty();
+        if (groupRequested && targetsRequested) {
+            throw new IllegalArgumentException(
+                "Cannot specify both --group and individual scenario names. Use either only '--group " + settings.getScenarioGroup() + "' OR specify scenario names directly.");
+        }
+
+        if (groupRequested) {
             return selectScenariosFromGroup(config, settings, availableScenarios, scenarioFile);
-        } else if (!settings.getTargets().isEmpty()) {
+        } else if (targetsRequested) {
             return selectScenariosFromTargets(settings, availableScenarios);
         } else if (config.hasPath(DEFAULT_SCENARIOS)) {
             return selectDefaultScenarios(config.getStringList(DEFAULT_SCENARIOS), availableScenarios);
@@ -600,11 +607,6 @@ class ScenarioLoader {
             throw new IllegalArgumentException(String.format(
                 "Unknown scenario group '%s' requested. Available groups are: %s", groupName, String.join(", ", availableGroups)
             ));
-        }
-
-        if (!settings.getTargets().isEmpty()) {
-            throw new IllegalArgumentException(
-                "Cannot specify both --group and individual scenario names. Use either only '--group " + groupName + "' OR specify scenario names directly.");
         }
 
         List<String> targets = scenarioGroups.getStringList(groupName);

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -416,6 +416,29 @@ class ScenarioLoaderTest extends Specification {
         (scenarios[1] as GradleScenarioDefinition).action.tasks == ["bela"]
     }
 
+    def "fails when default scenario does not exist"() {
+        def settings = settings()
+
+        scenarioFile << """
+            default-scenarios = ["alma", "nonexistent"]
+
+            default {
+                tasks = ["help"]
+            }
+
+            alma {
+                tasks = ["alma"]
+            }
+        """
+
+        when:
+        loadScenarios(scenarioFile, settings, Mock(GradleBuildConfigurationReader))
+
+        then:
+        def ex = thrown IllegalArgumentException
+        ex.message == "Unknown scenario 'nonexistent' in default scenarios. Available scenarios are: alma, default"
+    }
+
     def "loads included config"() {
         def settings = settings()
 

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -63,8 +63,8 @@ class ScenarioLoaderTest extends Specification {
             .setMeasureGarbageCollection(false)
             .setMeasureConfigTime(false)
             .setMeasuredBuildOperations(measuredBuildOperations)
-            .setCsvFormat(Format.WIDE
-            ).build()
+            .setCsvFormat(Format.WIDE)
+            .build()
     }
 
     def "can load single scenario"() {


### PR DESCRIPTION
Introduces a new CLI option `--group <group name>` which allows to run a group of scenarios defined in the new `scenario-groups` block in the scenario files.

The grouping allows brining together relevant scenarios, so that it's easier to benchmark them together, since it's often interesting to _compare_ scenarios and not only measure absolute numbers. Groups provide a way for this to be represented explicitly in the scenario files.

A concrete case where this is useful is benchmarking a set of user scenarios with different performance features of Gradle, e.g. CC, Parallel CC, Parallel Execution, etc.

### Example

    scenario-groups {
        smoke-tests = ["assemble", "clean_build"]
        performance-suite = ["incremental_build", "full_build", "no_op"]
    }

    assemble {
        tasks = ["assemble"]
    }

    clean_build {
        cleanup-tasks = ["clean"]
        tasks = ["build"]
    }

    # ... definition of other scenarios ...

To run scenarios from a specific group:

    > gradle-profiler --benchmark --scenario-file performance.scenarios --group smoke-tests