### PR TITLE
Add `--dump-scenarios` option

### DIFF
--- a/src/main/java/org/gradle/profiler/CommandLineParser.java
+++ b/src/main/java/org/gradle/profiler/CommandLineParser.java
@@ -70,6 +70,7 @@ class CommandLineParser {
         OptionSpecBuilder measureConfigTimeOption = parser.accepts("measure-config-time", "Include a breakdown of configuration time in benchmark results");
         OptionSpecBuilder buildOpsTraceOption = parser.accepts("build-ops-trace", "Enable Gradle build operations trace");
         OptionSpecBuilder dryRunOption = parser.accepts("dry-run", "Verify configuration");
+        OptionSpecBuilder dumpScenariosOption = parser.accepts("dump-scenarios", "Dump resolved config for scenario(s) without running");
         OptionSpecBuilder bazelOption = parser.accepts("bazel", "Benchmark scenarios using Bazel");
         OptionSpecBuilder buckOption = parser.accepts("buck", "Benchmark scenarios using buck");
         OptionSpecBuilder mavenOption = parser.accepts("maven", "Benchmark scenarios using Maven");
@@ -113,7 +114,8 @@ class CommandLineParser {
         Profiler profiler = profilerFactory.createFromOptions(parsedOptions);
         boolean generateDiffs = !parsedOptions.has(noDifferentialFlamegraphOption) && hasProfiler && profiler.isCreatesStacksFiles();
         boolean benchmark = parsedOptions.has(benchmarkOption);
-        if (!benchmark && !hasProfiler) {
+        boolean dumpScenarios = parsedOptions.has(dumpScenariosOption);
+        if (!benchmark && !hasProfiler && !dumpScenarios) {
             return fail(parser, "Neither --profile or --benchmark specified.");
         }
 
@@ -182,6 +184,7 @@ class CommandLineParser {
             .setOutputDir(outputDir)
             .setInvoker(invoker)
             .setDryRun(dryRun)
+            .setDumpScenarios(dumpScenarios)
             .setScenarioFile(scenarioFile)
             .setVersions(gradleVersions)
             .setTargets(targetNames)

--- a/src/main/java/org/gradle/profiler/InvocationSettings.java
+++ b/src/main/java/org/gradle/profiler/InvocationSettings.java
@@ -16,6 +16,7 @@ public class InvocationSettings {
     private final boolean generateDiffs;
     private final boolean benchmark;
     private final boolean dryRun;
+    private final boolean dumpScenarios;
     private final File scenarioFile;
     private final File outputDir;
     private final BuildInvoker invoker;
@@ -51,6 +52,7 @@ public class InvocationSettings {
         File outputDir,
         BuildInvoker invoker,
         boolean dryRun,
+        boolean dumpScenarios,
         File scenarioFile,
         List<String> versions,
         List<String> targets,
@@ -77,6 +79,7 @@ public class InvocationSettings {
         this.outputDir = outputDir;
         this.invoker = invoker;
         this.dryRun = dryRun;
+        this.dumpScenarios = dumpScenarios;
         this.scenarioFile = scenarioFile;
         this.versions = versions;
         this.targets = targets;
@@ -112,6 +115,10 @@ public class InvocationSettings {
 
     public boolean isDryRun() {
         return dryRun;
+    }
+
+    public boolean isDumpScenarios() {
+        return dumpScenarios;
     }
 
     public boolean isBenchmark() {
@@ -235,6 +242,7 @@ public class InvocationSettings {
             .setGenerateDiffs(generateDiffs)
             .setBenchmark(benchmark)
             .setDryRun(dryRun)
+            .setDumpScenarios(dumpScenarios)
             .setScenarioFile(scenarioFile)
             .setOutputDir(outputDir)
             .setInvoker(invoker)
@@ -292,6 +300,7 @@ public class InvocationSettings {
         private boolean generateDiffs;
         private boolean benchmark;
         private boolean dryRun;
+        private boolean dumpScenarios;
         private File scenarioFile;
         private File outputDir;
         private BuildInvoker invoker;
@@ -335,6 +344,11 @@ public class InvocationSettings {
 
         public InvocationSettingsBuilder setDryRun(boolean dryRun) {
             this.dryRun = dryRun;
+            return this;
+        }
+
+        public InvocationSettingsBuilder setDumpScenarios(boolean dumpScenarios) {
+            this.dumpScenarios = dumpScenarios;
             return this;
         }
 
@@ -457,6 +471,7 @@ public class InvocationSettings {
                 outputDir,
                 invoker,
                 dryRun,
+                dumpScenarios,
                 scenarioFile,
                 versions,
                 targets,

--- a/src/main/java/org/gradle/profiler/Main.java
+++ b/src/main/java/org/gradle/profiler/Main.java
@@ -51,6 +51,16 @@ public class Main {
                 return;
             }
 
+            if (settings.isDumpScenarios()) {
+                if (settings.getScenarioFile() == null) {
+                    System.err.println("--dump-scenarios requires a scenario file (--scenario-file)");
+                    throw new IllegalArgumentException("--dump-scenarios requires a scenario file");
+                }
+                String output = ScenarioLoader.dumpScenarios(settings.getScenarioFile(), settings);
+                System.out.print(output);
+                return;
+            }
+
             System.out.println();
             System.out.println("* Writing results to " + settings.getOutputDir().getAbsolutePath());
 

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -6,6 +6,9 @@ import com.google.common.collect.ImmutableSet;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigParseOptions;
+import com.typesafe.config.ConfigRenderOptions;
+
+import java.util.Arrays;
 import org.gradle.profiler.bazel.BazelScenarioDefinition;
 import org.gradle.profiler.buck.BuckScenarioDefinition;
 import org.gradle.profiler.gradle.AdhocGradleScenarioDefinition;
@@ -239,7 +242,7 @@ class ScenarioLoader {
     }
 
     static List<ScenarioDefinition> loadScenarios(File scenarioFile, InvocationSettings settings, GradleBuildConfigurationReader inspector) {
-        Config config = ConfigFactory.parseFile(scenarioFile, ConfigParseOptions.defaults().setAllowMissing(false)).resolve();
+        Config config = parseScenarioFile(scenarioFile);
         Set<String> selectedScenarios = selectScenarios(config, settings, scenarioFile);
 
         List<ScenarioDefinition> definitions = new ArrayList<>();
@@ -329,6 +332,10 @@ class ScenarioLoader {
         definitions.forEach(ScenarioDefinition::validate);
 
         return definitions;
+    }
+
+    private static Config parseScenarioFile(File scenarioFile) {
+        return ConfigFactory.parseFile(scenarioFile, ConfigParseOptions.defaults().setAllowMissing(false)).resolve();
     }
 
     private static StudioGradleScenarioDefinition newStudioGradleScenarioDefinition(GradleScenarioDefinition gradleScenarioDefinition, Config scenario) {
@@ -623,5 +630,53 @@ class ScenarioLoader {
                 ));
             }
         }
+    }
+
+    /**
+     * Formats resolved scenario configurations as a string.
+     *
+     * <p>Each scenario output is standalone and can be copied into a new scenario file as-is.
+     *
+     * @param scenarioFile The scenario configuration file to read
+     * @param settings Invocation settings that determine which scenarios to dump (via targets, groups, or defaults)
+     * @return A formatted string containing all selected scenarios with their resolved configurations
+     */
+    public static String dumpScenarios(File scenarioFile, InvocationSettings settings) {
+        Config config = parseScenarioFile(scenarioFile);
+        Set<String> selectedScenarios = selectScenarios(config, settings, scenarioFile);
+
+        ConfigRenderOptions renderOptions = ConfigRenderOptions.defaults()
+            .setOriginComments(false)
+            .setComments(false)
+            .setJson(false)
+            .setFormatted(true);
+
+        StringBuilder output = new StringBuilder();
+        int scenarioCount = selectedScenarios.size();
+        int scenarioIndex = 0;
+        for (String scenarioName : selectedScenarios) {
+            scenarioIndex++;
+            output.append('\n');
+
+            Config scenario = config.getConfig(scenarioName);
+
+
+            output.append(String.format("# Scenario %d/%d", scenarioIndex, scenarioCount));
+            String title = scenario.hasPath(TITLE) ? scenario.getString(TITLE) : null;
+            if (title != null) {
+                output.append(" '").append(title).append("'");
+            }
+            output.append('\n');
+
+            output.append(scenarioName).append(" {\n");
+
+            String rendered = scenario.root().render(renderOptions);
+            Arrays.stream(rendered.split("\n"))
+                .filter(line -> !line.isEmpty())
+                .forEach(line -> output.append("    ").append(line).append("\n"));
+
+            output.append("}\n");
+        }
+        return output.toString();
     }
 }

--- a/src/test/groovy/org/gradle/profiler/CommandLineIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/CommandLineIntegrationTest.groovy
@@ -1,9 +1,15 @@
 package org.gradle.profiler
 
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
 import spock.lang.Unroll
 
 @Unroll
 class CommandLineIntegrationTest extends AbstractIntegrationTest {
+
+    @Rule
+    TemporaryFolder tmpDir = new TemporaryFolder()
+
     def "can show help with #option"() {
         when:
         new Main().run(option)
@@ -22,5 +28,40 @@ class CommandLineIntegrationTest extends AbstractIntegrationTest {
 
         where:
         option << ["-v", "--version"]
+    }
+
+    def "--dump-scenarios requires --scenario-file"() {
+        when:
+        new Main().run("--benchmark", "--dump-scenarios")
+
+        then:
+        def e = thrown(IllegalArgumentException)
+        e.message == "--dump-scenarios requires a scenario file"
+    }
+
+    def "can dump simple scenario"() {
+        given:
+        def scenarioFile = tmpDir.newFile("test.conf")
+        scenarioFile << """
+            my-scenario {
+                tasks = ["help"]
+                warm-ups = 3
+            }
+        """
+
+        when:
+        new Main().run("--benchmark", "--scenario-file", scenarioFile.absolutePath, "--dump-scenarios", "my-scenario")
+
+        then:
+        output == """
+# Scenario 1/1
+my-scenario {
+    tasks=[
+        help
+    ]
+    warm-ups=3
+}
+
+"""
     }
 }

--- a/src/test/groovy/org/gradle/profiler/DumpScenariosTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/DumpScenariosTest.groovy
@@ -1,0 +1,300 @@
+package org.gradle.profiler
+
+import org.gradle.profiler.gradle.GradleBuildInvoker
+import org.gradle.profiler.report.Format
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class DumpScenariosTest extends Specification {
+    @Rule
+    TemporaryFolder tmpDir = new TemporaryFolder()
+
+    File projectDir
+    File gradleUserHomeDir
+    File outputDir
+    File scenarioFile
+
+    def setup() {
+        projectDir = tmpDir.newFolder()
+        outputDir = tmpDir.newFolder()
+        scenarioFile = tmpDir.newFile()
+    }
+
+    private settingsBuilder(
+        BuildInvoker invoker = GradleBuildInvoker.Cli,
+        boolean benchmark = true
+    ) {
+        new InvocationSettings.InvocationSettingsBuilder()
+            .setProjectDir(projectDir)
+            .setProfiler(Profiler.NONE)
+            .setBenchmark(benchmark)
+            .setOutputDir(outputDir)
+            .setInvoker(invoker)
+            .setDryRun(false)
+            .setScenarioFile(scenarioFile)
+            .setVersions([])
+            .setTargets([])
+            .setSysProperties([:])
+            .setGradleUserHome(gradleUserHomeDir)
+            .setStudioInstallDir(tmpDir.newFolder())
+            .setMeasureGarbageCollection(false)
+            .setMeasureConfigTime(false)
+            .setMeasuredBuildOperations([])
+            .setCsvFormat(Format.WIDE)
+    }
+
+    private settings(
+        BuildInvoker invoker = GradleBuildInvoker.Cli,
+        boolean benchmark = true
+    ) {
+        settingsBuilder(invoker, benchmark)
+            .build()
+    }
+
+    def "dumpScenarios returns formatted output for single scenario"() {
+        def settings = settings()
+
+        scenarioFile << """
+            default {
+                tasks = ["help"]
+                warm-ups = 5
+            }
+        """
+
+        when:
+        def output = ScenarioLoader.dumpScenarios(scenarioFile, settings)
+
+        then:
+        output == """
+# Scenario 1/1
+default {
+    tasks=[
+        help
+    ]
+    warm-ups=5
+}
+"""
+    }
+
+    def "dumpScenarios returns resolved config"() {
+        def settings = settings()
+
+        scenarioFile << """
+            default {
+                daemon = cold
+                iterations = 10
+                tasks = ["assemble"]
+                system-properties {
+                    "prop1" = "value1"
+                    "prop2" = "value2"
+                }
+            }
+
+            # HOCON allows duplicate object declarations, in which case they are merged
+            default {
+                # primitive values are overridden
+                iterations = 33
+                # arrays are also overridden
+                tasks = ["build"]
+                # nested objects are merged
+                system-properties {
+                    "prop2" = "overridden"
+                    "prop3" = "value3"
+                }
+            }
+        """
+
+        when:
+        def output = ScenarioLoader.dumpScenarios(scenarioFile, settings)
+
+        then:
+        output == """
+# Scenario 1/1
+default {
+    daemon=cold
+    iterations=33
+    system-properties {
+        prop1=value1
+        prop2=overridden
+        prop3=value3
+    }
+    tasks=[
+        build
+    ]
+}
+"""
+    }
+
+    def "dumpScenarios returns output for multiple scenarios with explicit targets"() {
+        def settings = settingsBuilder()
+            .setTargets(["scenario1", "scenario2"])
+            .build()
+
+        scenarioFile << """
+            scenario1 {
+                tasks = ["clean", "assemble"]
+                warm-ups = 2
+            }
+            scenario2 {
+                tasks = ["build"]
+                iterations = 5
+            }
+            scenario3 {
+                tasks = ["test"]
+            }
+        """
+
+        when:
+        def output = ScenarioLoader.dumpScenarios(scenarioFile, settings)
+
+        then:
+        output == """
+# Scenario 1/2
+scenario1 {
+    tasks=[
+        clean,
+        assemble
+    ]
+    warm-ups=2
+}
+
+# Scenario 2/2
+scenario2 {
+    iterations=5
+    tasks=[
+        build
+    ]
+}
+"""
+    }
+
+    def "dumpScenarios returns default scenarios when no targets specified"() {
+        def settings = settings()
+
+        scenarioFile << """
+            default-scenarios = ["scenario1", "scenario2"]
+
+            scenario1 {
+                tasks = ["assemble"]
+                daemon = warm
+            }
+            scenario2 {
+                tasks = ["build"]
+                iterations = 10
+            }
+            scenario3 {
+                tasks = ["test"]
+            }
+        """
+
+        when:
+        def output = ScenarioLoader.dumpScenarios(scenarioFile, settings)
+
+        then:
+        output == """
+# Scenario 1/2
+scenario1 {
+    daemon=warm
+    tasks=[
+        assemble
+    ]
+}
+
+# Scenario 2/2
+scenario2 {
+    iterations=10
+    tasks=[
+        build
+    ]
+}
+"""
+    }
+
+    def "dumpScenarios returns scenarios from a group"() {
+        def settings = settingsBuilder()
+            .setScenarioGroup("smoke-tests")
+            .build()
+
+        scenarioFile << """
+            scenario-groups {
+                smoke-tests = ["quick-build", "quick-test"]
+                full-suite = ["full-build"]
+            }
+
+            quick-build {
+                tasks = ["assemble"]
+                warm-ups = 1
+            }
+            quick-test {
+                tasks = ["test"]
+                iterations = 3
+            }
+            full-build {
+                tasks = ["clean", "build"]
+                warm-ups = 5
+            }
+        """
+
+        when:
+        def output = ScenarioLoader.dumpScenarios(scenarioFile, settings)
+
+        then:
+        output == """
+# Scenario 1/2
+quick-build {
+    tasks=[
+        assemble
+    ]
+    warm-ups=1
+}
+
+# Scenario 2/2
+quick-test {
+    iterations=3
+    tasks=[
+        test
+    ]
+}
+"""
+    }
+
+    def "dumpScenarios includes scenario title in header when present"() {
+        def settings = settingsBuilder()
+            .setTargets(["with-title", "without-title"])
+            .build()
+
+        scenarioFile << """
+            with-title {
+                title = "Custom title"
+                tasks = ["build"]
+                warm-ups = 5
+            }
+            without-title {
+                tasks = ["assemble"]
+            }
+        """
+
+        when:
+        def output = ScenarioLoader.dumpScenarios(scenarioFile, settings)
+
+        then:
+        output == """
+# Scenario 1/2 'Custom title'
+with-title {
+    tasks=[
+        build
+    ]
+    title="Custom title"
+    warm-ups=5
+}
+
+# Scenario 2/2
+without-title {
+    tasks=[
+        assemble
+    ]
+}
+"""
+    }
+}


### PR DESCRIPTION
Introduces a new `--dump-scenarios` CLI option that outputs resolved scenario configurations without running them. This is useful
for:
- Verifying scenario configuration and HOCON merging behavior
- Debugging scenario definitions before executing benchmarks
- Understanding how default values and overrides are applied

Each scenario is formatted as a standalone HOCON block that can be copied into a new scenario file as-is.

Example usage:
```
gradle-profiler --benchmark --scenario-file test-scenarios.conf --dump-scenarios my-scenario
```

Example output:
```
# Scenario 1/1
my-scenario {
tasks=[
help
]
warm-ups=3
}
```

The option works with:
- Explicit scenario targets
- Default scenarios (via `default-scenarios`)
- Scenario groups (via `--group`)