### PR TITLE
CI: Replace Intel macOS Java 8 tests with Apple Silicon macOS Java 11 tests

### DIFF
--- a/.teamcity/settings/GradleProfilerTest.kt
+++ b/.teamcity/settings/GradleProfilerTest.kt
@@ -32,10 +32,8 @@ open class GradleProfilerTest(os: Os, javaVersion: JavaVersion, arch: Arch) : Bu
 
     features {
         parallelTests {
-            numberOfBatches = if (os == Os.macos && arch == Arch.AMD64) {
-                2 // only 2 Intel mac's left
-            } else if (os == Os.windows) {
-                8 // balance so Windows and Linux run with similar wall clock time
+            numberOfBatches = if (os == Os.windows) {
+                8 // balance so Windows, Linux and macOS run with similar wall clock time
             } else {
                 4
             }
@@ -79,9 +77,8 @@ object LinuxJava11 : GradleProfilerTest(Os.linux, JavaVersion.OPENJDK_11, Arch.A
     name = "Linux - Java 11"
 })
 
-
-object MacOSJava8 : GradleProfilerTest(Os.macos, JavaVersion.ORACLE_JAVA_8, Arch.AMD64, {
-    name = "macOS - Java 8"
+object MacOSJava11 : GradleProfilerTest(Os.macos, JavaVersion.OPENJDK_11, Arch.AARCH64, {
+    name = "macOS - Java 11"
 })
 
 object WindowsJava11 : GradleProfilerTest(Os.windows, JavaVersion.OPENJDK_11, Arch.AMD64, {

--- a/.teamcity/settings/root-project.kt
+++ b/.teamcity/settings/root-project.kt
@@ -5,7 +5,7 @@ fun Project.configureGradleProfilerProject() {
     description = "Runs tests and integration tests of the Gradle Profiler (https://github.com/gradle/gradle-profiler)"
 
     val testBuilds = listOf(
-        MacOSJava8,
+        MacOSJava11,
         WindowsJava11,
         LinuxJava8,
         LinuxJava11,

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,11 +118,11 @@ tasks.test {
     environment("JAVA_HOME" to javaLauncher.get().metadata.installationPath)
 
     // We had some build failures on macOS, where it seems to be a Socket was already closed when trying to download the Gradle distribution.
-    // The tests failing were consistenly in ProfilerIntegrationTest.
+    // The tests failing were consistently in ProfilerIntegrationTest.
     // Running only ProfilerIntegrationTest did not expose the failures.
     // The problem went away when running every test class in its on JVM.
     // So I suppose the problem is that the JVM shares the TAPI client, and one of the tests leave the client in a bad state.
-    // We now use forkEvery = 1 to run each test class in its own JVM, so we don't run into this problem any more.
+    // We now use forkEvery = 1 to run each test class in its own JVM, so we don't run into this problem anymore.
     setForkEvery(1)
     maxHeapSize = "2g"
 }


### PR DESCRIPTION
* Intel macOS is nearing it's EOL
* we have few Intel macOS machines left thus slowing us down here