### PR TITLE
Explicitly provide npm package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "gradle-profiler",
       "dependencies": {
         "mann-whitney-utest": "1.0.5"
       },

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "gradle-profiler",
   "dependencies": {
     "mann-whitney-utest": "1.0.5"
   },


### PR DESCRIPTION
to avoid package-lock file to get update if the project is checked out in a directory other than `gradle-profiler`