### PR TITLE
Allow customizing the installation directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ hs_err_pid*.log
 
 /local.properties
 /incoming-distributions/
+
+# Default installation directory
+/distribution

--- a/README.md
+++ b/README.md
@@ -37,11 +37,14 @@ Binaries are available and linked from the [releases](https://github.com/gradle/
 
 First, build and install the `gradle-profiler` app using:
 
-    > ./gradlew installDist
+    > ./gradlew install
 
-This will install the executable into `./build/install/gradle-profiler/bin`. The examples below assume that you add this location to your PATH or create a `gradle-profiler` alias for it.
+This will install the executable into `./distribution/gradle-profiler/bin`. The examples below assume that you add this location to your PATH or create a `gradle-profiler` alias for it.
 
 NOTE: You have to use Java 11 or later to build this project.
+
+You can choose a different installation location by providing the `gradle-profiler.install.dir` property.
+E.g. `./gradlew install -Pgradle-profiler.install.dir=/usr/local/bin`.
 
 ## Benchmarking a build
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -253,3 +253,16 @@ tasks.register("releaseToSdkMan") {
         }
     }
 }
+
+tasks.register<Sync>("install") {
+    val installDirName = "gradle-profiler.install.dir"
+    val installDir = providers.gradleProperty(installDirName).orElse("distribution")
+        .map { layout.settingsDirectory.file(it) }
+
+    from(tasks.named<Sync>("installDist").map { it.destinationDir })
+    into(installDir)
+
+    doLast {
+        println("Installed gradle-profiler to '${installDir.get()}'")
+    }
+}


### PR DESCRIPTION
You can now choose a different installation location by providing the `gradle-profiler.install.dir` property.
E.g. `./gradlew install -Pgradle-profiler.install.dir=/usr/local/bin`.