### PR TITLE
Avoid the undefined behavior for method without return statement

### DIFF
--- a/src/main/java/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutator.java
@@ -54,10 +54,13 @@ public class ApplyChangeToNativeSourceFileMutator extends AbstractFileChangeMuta
     }
 
     private void applyChangeAt(BuildContext context, StringBuilder text, int insertPos) {
-        text.insert(insertPos, "\nint " + getFieldName(context) + " () { }");
+        // The code need to be confusing enough so the compiler and linker doesn't decide to simply inline it away.
+        //   The compiler generally doesn't try to optimize away `volatile` variable.
+        //   To make extra-sure, we return a value that can't be statically inferred from code analysis.
+        text.insert(insertPos, "\nint " + getFieldName(context) + "(void) { volatile int dummy = 0; return (int)((unsigned long)&dummy & 0x7FFFFFFFul); }");
     }
 
     private void applyHeaderChangeAt(BuildContext context, StringBuilder text, int insertPos) {
-        text.insert(insertPos, "int " + getFieldName(context) + "();\n");
+        text.insert(insertPos, "int " + getFieldName(context) + "(void);\n");
     }
 }

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyChangeToNativeSourceFileMutatorTest.groovy
@@ -15,7 +15,7 @@ class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == " \nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7 () { }"
+        sourceFile.text == " \nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7(void) { volatile int dummy = 0; return (int)((unsigned long)&dummy & 0x7FFFFFFFul); }"
 
         where:
         extension << ["c", "C", "cpp", "CPP", "c++", "cxx"]
@@ -32,7 +32,7 @@ class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "#ifndef ABC\n\nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7();\n#endif"
+        sourceFile.text == "#ifndef ABC\n\nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7(void);\n#endif"
 
         where:
         extension << ["h", "H", "hpp", "HPP", "hxx"]
@@ -52,14 +52,14 @@ class ApplyChangeToNativeSourceFileMutatorTest extends AbstractMutatorTest {
         mutatorC.beforeBuild(buildContext)
 
         then:
-        sourceFileCPP.text == " \nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7 () { }"
+        sourceFileCPP.text == " \nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7(void) { volatile int dummy = 0; return (int)((unsigned long)&dummy & 0x7FFFFFFFul); }"
 
         when:
         mutatorH.beforeScenario(scenarioContext)
         mutatorH.beforeBuild(buildContext)
 
         then:
-        sourceFileH.text == "#ifndef ABC\n\nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7();\n#endif"
+        sourceFileH.text == "#ifndef ABC\n\nint _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7(void);\n#endif"
     }
 
     def "complains when a file with not-allowed file extension is specified"() {


### PR DESCRIPTION
According to C standard 6.9.1/12, a function without a return statement will produce an undefined behaviour (if the caller uses the value). Although the profiler will not use the dummy code, a project with `-Wall` or equivalent will generate a compiler error. The same is true for C code without `void` as its parameter list (also fixed in this PR).

The new mutator implementation code aims to preserve the essence of the previous undefined behaviour by computing a value that is exempt from warnings but can't be inlined.