### PR TITLE
Fix CodeQL for java/kotlin

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -54,7 +54,7 @@ jobs:
 
       - if: ${{ matrix.build-mode == 'manual' }}
         name: Build with Gradle
-        run: ./gradlew clean assemble
+        run: ./gradlew --no-build-cache clean assemble
 
       - name: Perform CodeQL Analysis
         # Should use the same action version as the `init` step above


### PR DESCRIPTION
It seems running with Build Cache made the manual compilation step skip work, making CodeQL trip.

Also, found in the docs how to combine Java and Kotlin jobs into one.