### PR TITLE
Introduce a `kotlin-library` project type

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -6,3 +6,7 @@ repositories {
     mavenCentral()
     gradlePluginPortal()
 }
+
+dependencies {
+    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:${libs.versions.kotlin.get()}")
+}

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,7 @@
+dependencyResolutionManagement {
+    versionCatalogs {
+        create("libs") {
+            from(files("../gradle/libs.versions.toml"))
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/profiler.kotlin-library.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.kotlin-library.gradle.kts
@@ -1,0 +1,15 @@
+import org.gradle.api.tasks.testing.Test
+import org.gradle.internal.os.OperatingSystem
+import org.gradle.kotlin.dsl.withType
+
+plugins {
+    id("profiler.allprojects")
+    kotlin("jvm")
+}
+
+tasks.withType<Test>().configureEach {
+    // Add OS as inputs since tests on different OS may behave differently https://github.com/gradle/gradle-private/issues/2831
+    // the version currently differs between our dev infrastructure, so we only track the name and the architecture
+    inputs.property("operatingSystem", "${OperatingSystem.current().name} ${System.getProperty("os.arch")}")
+    useJUnitPlatform()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+kotlin = "2.1.20"
 groovy = "3.0.15"
 spock = "2.1-groovy-3.0"
 # Ladybug Patch 1 (2024.2.1.10)

--- a/subprojects/studio-plugin/build.gradle.kts
+++ b/subprojects/studio-plugin/build.gradle.kts
@@ -5,9 +5,8 @@ import org.jetbrains.intellij.IntelliJPluginConstants.INTELLIJ_DEFAULT_DEPENDENC
 plugins {
     groovy
     `java-test-fixtures`
-    id("profiler.allprojects")
+    id("profiler.kotlin-library")
     id("org.jetbrains.intellij") version "1.17.4"
-    id("org.jetbrains.kotlin.jvm") version "2.0.21"
 }
 
 description = "Contains logic for Android Studio plugin that communicates with profiler"


### PR DESCRIPTION
As a preparation to `IDEA Sync`, introduced a `kotlin-library` project type and bump kotlin version