### PR TITLE
Relax requirements for DifferentialFlameGraphIntegrationTest

### DIFF
--- a/src/test/groovy/org/gradle/profiler/DifferentialFlameGraphIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/DifferentialFlameGraphIntegrationTest.groovy
@@ -5,9 +5,9 @@ import org.gradle.profiler.fixtures.AbstractProfilerIntegrationTest
 import spock.lang.Requires
 
 @Requires({ !OperatingSystem.isWindows() })
-@Requires({ it.instance.isCurrentJvmSupportsMultipleGradleVersions() })
 // See: https://github.com/gradle/gradle-profiler/issues/685
-@Requires({ JavaVersion.current() <= JavaVersion.VERSION_11 })
+@Requires({ !OperatingSystem.isMacOS() || JavaVersion.current() < JavaVersion.VERSION_21 })
+@Requires({ it.instance.isCurrentJvmSupportsMultipleGradleVersions() })
 class DifferentialFlameGraphIntegrationTest extends AbstractProfilerIntegrationTest implements FlameGraphFixture {
     def "generates differential flame graphs with #profiler"() {
         given:


### PR DESCRIPTION
Previously, the test was confined to running only on Java 11 or below, due to supposed errors. This is problematic, because the upcoming [upgrade to Java 17](https://github.com/gradle/gradle-profiler/issues/683) would have made this test as always skipped, losing test coverage.

This PR narrows down the range of environments where the test [still fails](https://github.com/gradle/gradle-profiler/issues/685) -- macOS with Java 21+. Thus, we ignore only those environments. Note, the test is still not supposed to be running on Windows, as before.