### PR TITLE
Migrate to Node Gradle plugin 7.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     application
     `maven-publish`
     id("profiler.publication")
-    id("com.github.node-gradle.node") version "3.4.0"
+    id("com.github.node-gradle.node") version "7.1.0"
     id("io.sdkman.vendors") version "2.0.0"
     id("io.github.gradle-nexus.publish-plugin") version "2.0.0"
 }
@@ -75,8 +75,8 @@ tasks.withType<Jar>().configureEach {
 application.mainClass.set("org.gradle.profiler.Main")
 
 node {
-    download.set(true)
-    version.set("17.6.0")
+    download = true
+    version = "24.13.0"
 }
 
 val generateHtmlReportJavaScript = tasks.register<NpxTask>("generateHtmlReportJavaScript") {


### PR DESCRIPTION
Also bump the Node version to the latest LTS -- 24.13.0

Since we didn't use any removed APIs, no build script migration is necessary.

The 7.1.0 plugin version supports even some Gradle 7.x releases, so we are good with 8.14 in the build.

---

We don't have automated tests, but I did the following manual testing:

- [x] `./gradlew npmInstall` completes successfully
- [x] `./gradlew generateHtmlReportJavaScript` produces output in `build/html-report/`
- [x] `./gradlew testHtmlReports` generates all 5 test reports in `build/test-html-report/`
- [x] `./gradlew build` passes
- [x] Open a generated HTML report in browser and verify it renders correctly
- [x] Check that browserify correctly bundles the JavaScript (verify `mann-whitney-utest` is included)