### PR TITLE
Add JsonGenerator to output a JSON file that can be directly parsed by custom tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Run the `gradle-profiler` app using:
 Where `<root-dir-of-build>` is the directory containing the build to be benchmarked, and `<task>` is the name of the task to run,
 exactly as you would use for the `gradle` command.
 
-Results will be written to a file called `profile-out/benchmark.html` and `profile-out/benchmark.csv`.
+Results will be written to files called `profile-out/benchmark.html`, `profile-out/benchmark.csv` and `profile-out/benchmark.json`.
+The JSON file contains the scenario definitions, the measured samples and the value of each sample for every iteration, so it can be parsed by custom tooling.
 
 When the profiler runs the build, it will use the tasks you specified. The profiler will use the default
 Gradle version, Java installation and JVM args that have been specified for your build, if any.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -164,6 +164,11 @@ tasks.test {
 
     val keepTestDirs = providers.gradleProperty("keepTestDirs").orElse("false")
     systemProperty("org.gradle.integtest.keepTestDirs", keepTestDirs.get())
+
+    // Spock snapshot testing (golden files). Regenerate snapshots with: ./gradlew test -PupdateSnapshots=true
+    systemProperty("spock.snapshots.rootPath", layout.projectDirectory.dir("src/test/resources").asFile.absolutePath)
+    val updateSnapshots = providers.gradleProperty("updateSnapshots").orElse("false")
+    systemProperty("spock.snapshots.updateSnapshots", updateSnapshots.get())
 }
 
 val autoDownloadAndRunInHeadless = providers.gradleProperty("autoDownloadAndRunInHeadless")

--- a/src/main/java/org/gradle/profiler/Main.java
+++ b/src/main/java/org/gradle/profiler/Main.java
@@ -16,6 +16,7 @@ import org.gradle.profiler.maven.MavenScenarioDefinition;
 import org.gradle.profiler.maven.MavenScenarioInvoker;
 import org.gradle.profiler.report.CsvGenerator;
 import org.gradle.profiler.report.HtmlGenerator;
+import org.gradle.profiler.report.JsonGenerator;
 import org.gradle.profiler.result.BuildInvocationResult;
 import org.gradle.profiler.result.SampleProvider;
 import org.gradle.profiler.studio.invoker.StudioGradleScenarioDefinition;
@@ -77,7 +78,8 @@ public class Main {
 
             File cvsFile = new File(settings.getOutputDir(), "benchmark.csv");
             File htmlFile = new File(settings.getOutputDir(), "benchmark.html");
-            BenchmarkResultCollector benchmarkResults = new BenchmarkResultCollector(new CsvGenerator(cvsFile, settings.getCsvFormat()), new HtmlGenerator(htmlFile));
+            File jsonFile = new File(settings.getOutputDir(), "benchmark.json");
+            BenchmarkResultCollector benchmarkResults = new BenchmarkResultCollector(new CsvGenerator(cvsFile, settings.getCsvFormat()), new HtmlGenerator(htmlFile), new JsonGenerator(jsonFile));
             PidInstrumentation pidInstrumentation = new PidInstrumentation();
 
 

--- a/src/main/java/org/gradle/profiler/Main.java
+++ b/src/main/java/org/gradle/profiler/Main.java
@@ -16,6 +16,7 @@ import org.gradle.profiler.maven.MavenScenarioDefinition;
 import org.gradle.profiler.maven.MavenScenarioInvoker;
 import org.gradle.profiler.report.CsvGenerator;
 import org.gradle.profiler.report.HtmlGenerator;
+import org.gradle.profiler.report.JsonGenerator;
 import org.gradle.profiler.result.BuildInvocationResult;
 import org.gradle.profiler.result.SampleProvider;
 import org.gradle.profiler.ide.invoker.IdeGradleScenarioDefinition;
@@ -77,7 +78,8 @@ public class Main {
 
             File cvsFile = new File(settings.getOutputDir(), "benchmark.csv");
             File htmlFile = new File(settings.getOutputDir(), "benchmark.html");
-            BenchmarkResultCollector benchmarkResults = new BenchmarkResultCollector(new CsvGenerator(cvsFile, settings.getCsvFormat()), new HtmlGenerator(htmlFile));
+            File jsonFile = new File(settings.getOutputDir(), "benchmark.json");
+            BenchmarkResultCollector benchmarkResults = new BenchmarkResultCollector(new CsvGenerator(cvsFile, settings.getCsvFormat()), new HtmlGenerator(htmlFile), new JsonGenerator(jsonFile));
             PidInstrumentation pidInstrumentation = new PidInstrumentation();
 
 

--- a/src/main/java/org/gradle/profiler/report/JsonGenerator.java
+++ b/src/main/java/org/gradle/profiler/report/JsonGenerator.java
@@ -1,0 +1,24 @@
+package org.gradle.profiler.report;
+
+import org.gradle.profiler.InvocationSettings;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+
+public class JsonGenerator extends AbstractGenerator {
+    public JsonGenerator(File outputFile) {
+        super(outputFile);
+    }
+
+    @Override
+    protected void write(InvocationSettings settings, BenchmarkResult benchmarkResult, BufferedWriter writer) throws IOException {
+        new JsonResultWriter(true).write(
+            settings.getBenchmarkTitle(),
+            Instant.now(),
+            benchmarkResult.getScenarios(),
+            writer
+        );
+    }
+}

--- a/src/test/groovy/org/gradle/profiler/JsonReportIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/JsonReportIntegrationTest.groovy
@@ -1,0 +1,27 @@
+package org.gradle.profiler
+
+import com.google.gson.Gson
+import org.gradle.profiler.fixtures.AbstractProfilerIntegrationTest
+
+class JsonReportIntegrationTest extends AbstractProfilerIntegrationTest {
+
+    def "json file is written for benchmarks"() {
+        given:
+        instrumentedBuildScript()
+
+        when:
+        run([
+            "--gradle-version", minimalSupportedGradleVersion,
+            "--benchmark",
+            "assemble"
+        ])
+
+        then:
+        checkInstrumentedBuildScriptOutputs(minimalSupportedGradleVersion, "assemble")
+
+        def file = new File(outputDir, "benchmark.json")
+        assert file.isFile()
+        def report = new Gson().fromJson(file.text, Map.class)
+        assert (((report.get("scenarios") as List).get(0) as Map).get("iterations") as List).size() == 2
+    }
+}

--- a/src/test/groovy/org/gradle/profiler/JsonReportIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/JsonReportIntegrationTest.groovy
@@ -1,6 +1,9 @@
 package org.gradle.profiler
 
-import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
 import org.gradle.profiler.fixtures.AbstractProfilerIntegrationTest
 
 class JsonReportIntegrationTest extends AbstractProfilerIntegrationTest {
@@ -20,8 +23,93 @@ class JsonReportIntegrationTest extends AbstractProfilerIntegrationTest {
         checkInstrumentedBuildScriptOutputs(minimalSupportedGradleVersion, "assemble")
 
         def file = new File(outputDir, "benchmark.json")
-        assert file.isFile()
-        def report = new Gson().fromJson(file.text, Map.class)
-        assert (((report.get("scenarios") as List).get(0) as Map).get("iterations") as List).size() == 2
+        file.isFile()
+        normalize(file.text) == """\
+{
+  "date": "<date>",
+  "environment": {
+    "profilerVersion": "<profilerVersion>",
+    "operatingSystem": "<operatingSystem>"
+  },
+  "scenarios": [
+    {
+      "definition": {
+        "name": "default",
+        "title": "default",
+        "displayName": "using Gradle ${minimalSupportedGradleVersion}",
+        "buildTool": "Gradle ${minimalSupportedGradleVersion}",
+        "tasks": "assemble",
+        "version": "${minimalSupportedGradleVersion}",
+        "gradleHome": "<gradleHome>",
+        "javaHome": "<javaHome>",
+        "usesScanPlugin": false,
+        "action": "run tasks assemble",
+        "cleanup": "do nothing",
+        "invoker": "Tooling API",
+        "mutators": [],
+        "args": [],
+        "jvmArgs": [],
+        "systemProperties": {},
+        "id": "_<uuid>_default_9f67c942"
+      },
+      "samples": [
+        {
+          "name": "total execution time",
+          "unit": "ms"
+        }
+      ],
+      "iterations": [
+        {
+          "id": "_<uuid>_default_9f67c942_WARM_UP_1",
+          "phase": "WARM_UP",
+          "iteration": 1,
+          "title": "warm-up build #1",
+          "values": {
+            "total execution time": "<duration>"
+          }
+        },
+        {
+          "id": "_<uuid>_default_9f67c942_MEASURE_1",
+          "phase": "MEASURE",
+          "iteration": 1,
+          "title": "measured build #1",
+          "values": {
+            "total execution time": "<duration>"
+          }
+        }
+      ]
+    }
+  ]
+}"""
+    }
+
+    /**
+     * Replaces environment-dependent values with placeholders, keeping the JSON structure intact.
+     */
+    private static String normalize(String json) {
+        JsonObject root = JsonParser.parseString(json).asJsonObject
+        root.addProperty("date", "<date>")
+        JsonObject environment = root.getAsJsonObject("environment")
+        environment.addProperty("profilerVersion", "<profilerVersion>")
+        environment.addProperty("operatingSystem", "<operatingSystem>")
+        root.getAsJsonArray("scenarios").each { scenario ->
+            JsonObject definition = scenario.asJsonObject.getAsJsonObject("definition")
+            definition.addProperty("gradleHome", "<gradleHome>")
+            definition.addProperty("javaHome", "<javaHome>")
+            definition.addProperty("id", normalizeId(definition.get("id").asString))
+            // JVM args of the benchmarked build depend on the environment the test runs in
+            definition.add("jvmArgs", new JsonArray())
+            scenario.asJsonObject.getAsJsonArray("iterations").each { iteration ->
+                JsonObject iterationJson = iteration.asJsonObject
+                iterationJson.addProperty("id", normalizeId(iterationJson.get("id").asString))
+                JsonObject values = iterationJson.getAsJsonObject("values")
+                new ArrayList<>(values.keySet()).each { values.addProperty(it, "<duration>") }
+            }
+        }
+        return new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create().toJson(root)
+    }
+
+    private static String normalizeId(String id) {
+        return id.replaceAll(/[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}/, "<uuid>")
     }
 }

--- a/src/test/groovy/org/gradle/profiler/JsonReportIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/JsonReportIntegrationTest.groovy
@@ -5,8 +5,13 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 import org.gradle.profiler.fixtures.AbstractProfilerIntegrationTest
+import spock.lang.Snapshot
+import spock.lang.Snapshotter
 
 class JsonReportIntegrationTest extends AbstractProfilerIntegrationTest {
+
+    @Snapshot(extension = 'json')
+    Snapshotter snapshotter
 
     def "json file is written for benchmarks"() {
         given:
@@ -24,69 +29,13 @@ class JsonReportIntegrationTest extends AbstractProfilerIntegrationTest {
 
         def file = new File(outputDir, "benchmark.json")
         file.isFile()
-        normalize(file.text) == """\
-{
-  "date": "<date>",
-  "environment": {
-    "profilerVersion": "<profilerVersion>",
-    "operatingSystem": "<operatingSystem>"
-  },
-  "scenarios": [
-    {
-      "definition": {
-        "name": "default",
-        "title": "default",
-        "displayName": "using Gradle ${minimalSupportedGradleVersion}",
-        "buildTool": "Gradle ${minimalSupportedGradleVersion}",
-        "tasks": "assemble",
-        "version": "${minimalSupportedGradleVersion}",
-        "gradleHome": "<gradleHome>",
-        "javaHome": "<javaHome>",
-        "usesScanPlugin": false,
-        "action": "run tasks assemble",
-        "cleanup": "do nothing",
-        "invoker": "Tooling API",
-        "mutators": [],
-        "args": [],
-        "jvmArgs": [],
-        "systemProperties": {},
-        "id": "_<uuid>_default_9f67c942"
-      },
-      "samples": [
-        {
-          "name": "total execution time",
-          "unit": "ms"
-        }
-      ],
-      "iterations": [
-        {
-          "id": "_<uuid>_default_9f67c942_WARM_UP_1",
-          "phase": "WARM_UP",
-          "iteration": 1,
-          "title": "warm-up build #1",
-          "values": {
-            "total execution time": "<duration>"
-          }
-        },
-        {
-          "id": "_<uuid>_default_9f67c942_MEASURE_1",
-          "phase": "MEASURE",
-          "iteration": 1,
-          "title": "measured build #1",
-          "values": {
-            "total execution time": "<duration>"
-          }
-        }
-      ]
-    }
-  ]
-}"""
+        snapshotter.assertThat(normalize(file.text, minimalSupportedGradleVersion)).matchesSnapshot()
     }
 
     /**
      * Replaces environment-dependent values with placeholders, keeping the JSON structure intact.
      */
-    private static String normalize(String json) {
+    private static String normalize(String json, String gradleVersion) {
         JsonObject root = JsonParser.parseString(json).asJsonObject
         root.addProperty("date", "<date>")
         JsonObject environment = root.getAsJsonObject("environment")
@@ -94,6 +43,9 @@ class JsonReportIntegrationTest extends AbstractProfilerIntegrationTest {
         environment.addProperty("operatingSystem", "<operatingSystem>")
         root.getAsJsonArray("scenarios").each { scenario ->
             JsonObject definition = scenario.asJsonObject.getAsJsonObject("definition")
+            ["displayName", "buildTool", "version"].each { key ->
+                definition.addProperty(key, definition.get(key).asString.replace(gradleVersion, "<gradleVersion>"))
+            }
             definition.addProperty("gradleHome", "<gradleHome>")
             definition.addProperty("javaHome", "<javaHome>")
             definition.addProperty("id", normalizeId(definition.get("id").asString))

--- a/src/test/resources/org/gradle/profiler/JsonReportIntegrationTest/json_file_is_written_for_benchmarks.json
+++ b/src/test/resources/org/gradle/profiler/JsonReportIntegrationTest/json_file_is_written_for_benchmarks.json
@@ -1,0 +1,56 @@
+{
+  "date": "<date>",
+  "environment": {
+    "profilerVersion": "<profilerVersion>",
+    "operatingSystem": "<operatingSystem>"
+  },
+  "scenarios": [
+    {
+      "definition": {
+        "name": "default",
+        "title": "default",
+        "displayName": "using Gradle <gradleVersion>",
+        "buildTool": "Gradle <gradleVersion>",
+        "tasks": "assemble",
+        "version": "<gradleVersion>",
+        "gradleHome": "<gradleHome>",
+        "javaHome": "<javaHome>",
+        "usesScanPlugin": false,
+        "action": "run tasks assemble",
+        "cleanup": "do nothing",
+        "invoker": "Tooling API",
+        "mutators": [],
+        "args": [],
+        "jvmArgs": [],
+        "systemProperties": {},
+        "id": "_<uuid>_default_9f67c942"
+      },
+      "samples": [
+        {
+          "name": "total execution time",
+          "unit": "ms"
+        }
+      ],
+      "iterations": [
+        {
+          "id": "_<uuid>_default_9f67c942_WARM_UP_1",
+          "phase": "WARM_UP",
+          "iteration": 1,
+          "title": "warm-up build #1",
+          "values": {
+            "total execution time": "<duration>"
+          }
+        },
+        {
+          "id": "_<uuid>_default_9f67c942_MEASURE_1",
+          "phase": "MEASURE",
+          "iteration": 1,
+          "title": "measured build #1",
+          "values": {
+            "total execution time": "<duration>"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-profiler/issues/561

Adding a simple `JsonGenerator` which re-uses the `JsonResultWriter` that the `HtmlGenerator` already uses the generate JSON for HTML file to also output a standalone JSON file