### PR TITLE
chore: linting

### DIFF
--- a/buildSrc/src/main/kotlin/providers/AndroidStudioSystemProperties.kt
+++ b/buildSrc/src/main/kotlin/providers/AndroidStudioSystemProperties.kt
@@ -11,7 +11,6 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.process.CommandLineArgumentProvider
-import java.io.File
 
 class AndroidStudioSystemProperties(
     @get:Internal

--- a/src/main/java/org/gradle/profiler/DefaultScenarioContext.java
+++ b/src/main/java/org/gradle/profiler/DefaultScenarioContext.java
@@ -35,7 +35,7 @@ public class DefaultScenarioContext implements ScenarioContext {
             name.append(Character.isJavaIdentifierPart(ch) ? ch : '_');
         }
         name.append('_');
-        name.append(Hashing.murmur3_32().hashString(scenarioName, StandardCharsets.UTF_8));
+        name.append(Hashing.murmur3_32_fixed().hashString(scenarioName, StandardCharsets.UTF_8));
         return name.toString();
     }
 }

--- a/src/main/java/org/gradle/profiler/InstrumentingProfiler.java
+++ b/src/main/java/org/gradle/profiler/InstrumentingProfiler.java
@@ -118,16 +118,16 @@ public abstract class InstrumentingProfiler extends Profiler {
     public abstract SnapshotCapturingProfilerController newSnapshottingController(ScenarioSettings settings);
 
     public interface SnapshotCapturingProfilerController {
-        void startRecording(String pid) throws IOException, InterruptedException;
+        default void startRecording(String pid) throws IOException, InterruptedException {}
 
-        void stopRecording(String pid) throws IOException, InterruptedException;
+        default void stopRecording(String pid) throws IOException, InterruptedException {}
 
         /**
          * Capture snapshot, if not already performed on stop.
          */
-        void captureSnapshot(String pid) throws IOException, InterruptedException;
+        default void captureSnapshot(String pid) throws IOException, InterruptedException {}
 
-        void stopSession() throws IOException, InterruptedException;
+        default void stopSession() throws IOException, InterruptedException {}
     }
 
     private static class DelegatingController implements ProfilerController {

--- a/src/main/java/org/gradle/profiler/ProfilerController.java
+++ b/src/main/java/org/gradle/profiler/ProfilerController.java
@@ -18,27 +18,7 @@ package org.gradle.profiler;
 import java.io.IOException;
 
 public interface ProfilerController {
-    ProfilerController EMPTY = new ProfilerController() {
-        @Override
-        public void startSession() {
-
-        }
-
-        @Override
-        public void startRecording() {
-
-        }
-
-        @Override
-        public void stopRecording(String pid) {
-
-        }
-
-        @Override
-        public void stopSession() {
-
-        }
-    };
+    ProfilerController EMPTY = new ProfilerController() {};
 
     /**
      * Connects the profiler to the daemon and does any other one-time setup work.
@@ -46,13 +26,13 @@ public interface ProfilerController {
      * connect without starting data collection, it should defer startup to {@link #startRecording()}
      * instead.
      */
-    void startSession() throws IOException, InterruptedException;
+    default void startSession() throws IOException, InterruptedException {}
 
     /**
-     * Tells the profiler to start collecting data (again). Profilers may chose to throw an
+     * Tells the profiler to start collecting data (again). Profilers may choose to throw an
      * exception if they don't support multiple start/stop operations.
      */
-    void startRecording() throws IOException, InterruptedException;
+    default void startRecording() throws IOException, InterruptedException {}
 
     /**
      * Tells the profiler to stop collecting data for now, e.g. so it doesn't
@@ -61,11 +41,11 @@ public interface ProfilerController {
      * and throw an exception when {@link #startRecording()} is called another
      * time.
      */
-    void stopRecording(String pid) throws IOException, InterruptedException;
+    default void stopRecording(String pid) throws IOException, InterruptedException {}
 
     /**
      * Ends the profiling session, writing the collected results to disk
      * and disconnecting the profiler from the daemon.
      */
-    void stopSession() throws IOException, InterruptedException;
+    default void stopSession() throws IOException, InterruptedException {}
 }

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -263,7 +263,7 @@ class ScenarioLoader {
 
                 List<String> targets = ConfigUtil.strings(executionInstructions, TARGETS);
                 File bazelHome = getToolHome(executionInstructions);
-                File outputDir = new File(scenarioBaseDir, "bazel");
+                File outputDir = new File(scenarioBaseDir, BAZEL);
                 int warmUpCount = getWarmUpCount(settings, scenario);
                 List<BuildMutator> mutators = getMutators(scenario, scenarioName, settings, warmUpCount, buildCount);
                 definitions.add(new BazelScenarioDefinition(scenarioName, title, targets, mutators, warmUpCount, buildCount, outputDir, bazelHome));
@@ -280,7 +280,7 @@ class ScenarioLoader {
                 Config executionInstructions = getConfig(scenarioFile, settings, scenarioName, scenario, MAVEN, MAVEN_KEYS);
                 List<String> targets = ConfigUtil.strings(executionInstructions, TARGETS);
                 File mavenHome = getToolHome(executionInstructions);
-                File outputDir = new File(scenarioBaseDir, "maven");
+                File outputDir = new File(scenarioBaseDir, MAVEN);
                 int warmUpCount = getWarmUpCount(settings, scenario);
                 Map<String, String> systemProperties = ConfigUtil.map(scenario, SYSTEM_PROPERTIES, settings.getSystemProperties());
                 List<BuildMutator> mutators = getMutators(scenario, scenarioName, settings, warmUpCount, buildCount);
@@ -451,7 +451,7 @@ class ScenarioLoader {
             String value = ConfigUtil.string(config, RUN_USING, null);
             if (value.equals("cli")) {
                 invoker = GradleBuildInvoker.Cli;
-            } else if (value.equals("tooling-api")) {
+            } else if (value.equals(TOOLING_API)) {
                 invoker = GradleBuildInvoker.ToolingApi;
             } else {
                 throw new IllegalArgumentException("Unexpected value for '" + RUN_USING + "' provided: " + value);

--- a/src/main/java/org/gradle/profiler/TeeOutputStream.java
+++ b/src/main/java/org/gradle/profiler/TeeOutputStream.java
@@ -24,12 +24,12 @@ class TeeOutputStream extends OutputStream {
 
     @Override
     public void flush() throws IOException {
-        withAll(stream -> stream.flush());
+        withAll(OutputStream::flush);
     }
 
     @Override
     public void close() throws IOException {
-        withAll(stream -> stream.close());
+        withAll(OutputStream::close);
     }
 
     private void withAll(IOAction action) throws IOException {

--- a/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerController.java
+++ b/src/main/java/org/gradle/profiler/asyncprofiler/AsyncProfilerController.java
@@ -118,10 +118,6 @@ public class AsyncProfilerController implements InstrumentingProfiler.SnapshotCa
     }
 
     @Override
-    public void captureSnapshot(String pid) {
-    }
-
-    @Override
     public void stopSession() {
         List<Stacks> stacks = generateStacks(scenarioSettings.getProfilerOutputBaseDir(), scenarioSettings.getProfilerOutputBaseName());
         flameGraphGenerator.generateGraphs(scenarioSettings.getProfilerOutputBaseDir(), stacks);

--- a/src/main/java/org/gradle/profiler/flamegraph/JfrToStacksConverter.java
+++ b/src/main/java/org/gradle/profiler/flamegraph/JfrToStacksConverter.java
@@ -75,12 +75,12 @@ public class JfrToStacksConverter {
         File stacks = File.createTempFile("stacks", ".txt");
         convertToStacks(recordings, stacks, new Options(type, level.isShowArguments(), level.isShowLineNumbers()));
         if (stacks.length() == 0) {
-            stacks.delete();
+            Files.delete(stacks.toPath());
             return null;
         }
         File sanitizedStacks = new File(baseDir, eventFileBaseName + Stacks.STACKS_FILE_SUFFIX);
         sanitizers.get(level).sanitize(stacks, sanitizedStacks);
-        stacks.delete();
+        Files.delete(stacks.toPath());
         return sanitizedStacks;
     }
 

--- a/src/main/java/org/gradle/profiler/jfr/JFRControl.java
+++ b/src/main/java/org/gradle/profiler/jfr/JFRControl.java
@@ -42,10 +42,6 @@ public class JFRControl implements InstrumentingProfiler.SnapshotCapturingProfil
     }
 
     @Override
-    public void captureSnapshot(String pid) {
-    }
-
-    @Override
     public void stopSession() {
         String jfrFileName = jfrFile.getName();
         String outputBaseName = jfrFileName.substring(0, jfrFileName.length() - 4);

--- a/src/main/java/org/gradle/profiler/yourkit/YourKitProfilerController.java
+++ b/src/main/java/org/gradle/profiler/yourkit/YourKitProfilerController.java
@@ -41,10 +41,6 @@ public class YourKitProfilerController implements InstrumentingProfiler.Snapshot
         }
     }
 
-    @Override
-    public void stopSession() {
-    }
-
     private void runYourKitCommand(String command) {
         File controllerJar = findControllerJar();
         new CommandExec().run(System.getProperty("java.home") + "/bin/java",

--- a/subprojects/chrome-trace/src/main/java/org/gradle/trace/monitoring/GCMonitoring.java
+++ b/subprojects/chrome-trace/src/main/java/org/gradle/trace/monitoring/GCMonitoring.java
@@ -38,7 +38,6 @@ public class GCMonitoring {
                 if (notification.getType().equals(GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION)) {
                     GarbageCollectionNotificationInfo info = GarbageCollectionNotificationInfo.from((CompositeData) notification.getUserData());
                     //get all the info and pretty print it
-                    long duration = info.getGcInfo().getDuration();
                     String gctype = info.getGcAction();
                     Map<String, String> args = new HashMap<>();
                     args.put("type", gctype);

--- a/subprojects/scenario-definition/src/main/java/org/gradle/profiler/ConfigUtil.java
+++ b/subprojects/scenario-definition/src/main/java/org/gradle/profiler/ConfigUtil.java
@@ -78,7 +78,7 @@ public class ConfigUtil {
 			if (value instanceof List) {
 				List<?> list = (List) value;
 				return list.stream().map(Object::toString).collect(Collectors.toList());
-			} else if (value.toString().length() > 0) {
+			} else if (!value.toString().isEmpty()) {
 				return Collections.singletonList(value.toString());
 			}
 		}

--- a/subprojects/studio-plugin/src/main/kotlin/org/gradle/profiler/studio/plugin/GradleProfilerStartupActivity.kt
+++ b/subprojects/studio-plugin/src/main/kotlin/org/gradle/profiler/studio/plugin/GradleProfilerStartupActivity.kt
@@ -19,11 +19,7 @@ import org.jetbrains.plugins.gradle.settings.GradleProjectSettings
 import org.jetbrains.plugins.gradle.settings.GradleSettings
 import java.io.File
 import java.io.FileInputStream
-import java.io.IOException
-import java.io.UncheckedIOException
 import java.util.*
-import java.util.function.Consumer
-import java.util.stream.Collectors
 
 class GradleProfilerStartupActivity : ProjectActivity {
     companion object {


### PR DESCRIPTION
**Summary**

- added some default interface method implementations so that the implementers don't have to define empty-bodied methods to comply with the interface.
- removed unused imports.
- used existing String constants instead of string literals.
- used `Files.delete(...)` instead of `file.delete()` as the former provides more debugging information in case of a failure.
- used `Hashing.murmur3_32_fixed` instead of deprecated `Hashing.murmur3_32`