### PR TITLE
Rename BuildOperationMeasurer to match renamed kinds

### DIFF
--- a/src/test/groovy/org/gradle/profiler/BuildOperationInstrumentationGradleCrossVersionTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/BuildOperationInstrumentationGradleCrossVersionTest.groovy
@@ -372,7 +372,7 @@ class BuildOperationInstrumentationGradleCrossVersionTest extends AbstractGradle
         def timeToLastInclusiveMs = Double.valueOf(configureBuildOp[0][2])
         timeToLastInclusiveMs > 1
         // With our project that only has one build, the cumulative time should always be less than the time to last completed
-        // As there is time before the configure build operation starts that is included in the time to last completed but not in the duration sum
+        // As there is time before the configure build operation starts that is included in the time to last completed but not in the cumulative time
         // This operates as a sanity check that the two measurements are being recorded in a consistent way
         assertThat(
             "'cumulative time' should be less than 'time to last inclusive'",

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/BuildOperationMeasurer.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/BuildOperationMeasurer.java
@@ -13,11 +13,11 @@ interface BuildOperationMeasurer {
     static BuildOperationMeasurer createForKind(BuildOperationMeasurementKind kind, long buildStartTime) {
         switch (kind) {
             case CUMULATIVE_TIME:
-                return new DurationSumBuildOperationMeasurer();
+                return new CumulativeTimeBuildOperationMeasurer();
             case TIME_TO_LAST_INCLUSIVE:
-                return new TimeToLastCompletedBuildOperationMeasurer(buildStartTime);
+                return new TimeToLastInclusiveBuildOperationMeasurer(buildStartTime);
             case TIME_TO_FIRST_EXCLUSIVE:
-                return new TimeToFirstStartedBuildOperationMeasurer(buildStartTime);
+                return new TimeToFirstExclusiveBuildOperationMeasurer(buildStartTime);
             default:
                 throw new IllegalArgumentException("Unsupported BuildOperationMeasurementKind: " + kind);
         }

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/CumulativeTimeBuildOperationMeasurer.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/CumulativeTimeBuildOperationMeasurer.java
@@ -5,10 +5,10 @@ import org.gradle.internal.operations.OperationFinishEvent;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 
-final class DurationSumBuildOperationMeasurer implements BuildOperationMeasurer {
+final class CumulativeTimeBuildOperationMeasurer implements BuildOperationMeasurer {
     private final AtomicLong buildOperationTime = new AtomicLong(0);
 
-    DurationSumBuildOperationMeasurer() {
+    CumulativeTimeBuildOperationMeasurer() {
     }
 
     @Override

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/TimeToFirstExclusiveBuildOperationMeasurer.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/TimeToFirstExclusiveBuildOperationMeasurer.java
@@ -5,11 +5,11 @@ import org.gradle.internal.operations.OperationFinishEvent;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 
-final class TimeToFirstStartedBuildOperationMeasurer implements BuildOperationMeasurer {
+final class TimeToFirstExclusiveBuildOperationMeasurer implements BuildOperationMeasurer {
     private final long buildStartTime;
     private final AtomicLong minStartTime = new AtomicLong(Long.MIN_VALUE);
 
-    TimeToFirstStartedBuildOperationMeasurer(long buildStartTime) {
+    TimeToFirstExclusiveBuildOperationMeasurer(long buildStartTime) {
         this.buildStartTime = buildStartTime;
     }
 

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/TimeToLastInclusiveBuildOperationMeasurer.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/TimeToLastInclusiveBuildOperationMeasurer.java
@@ -5,11 +5,11 @@ import org.gradle.internal.operations.OperationFinishEvent;
 import java.time.Duration;
 import java.util.concurrent.atomic.AtomicLong;
 
-final class TimeToLastCompletedBuildOperationMeasurer implements BuildOperationMeasurer {
+final class TimeToLastInclusiveBuildOperationMeasurer implements BuildOperationMeasurer {
     private final long buildStartTime;
     private final AtomicLong maxEndTime;
 
-    TimeToLastCompletedBuildOperationMeasurer(long buildStartTime) {
+    TimeToLastInclusiveBuildOperationMeasurer(long buildStartTime) {
         this.buildStartTime = buildStartTime;
         // Make sure we're never earlier than the build start time, even if no operations are recorded
         this.maxEndTime = new AtomicLong(buildStartTime);


### PR DESCRIPTION
Follow-up on #706 and #718 