### PR TITLE
Add a delay before complaining about missing PR label

### DIFF
--- a/.github/workflows/enforce-labels.yml
+++ b/.github/workflows/enforce-labels.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   enforce-label:
     runs-on: ubuntu-latest
+    # Adds a 5-minute wait before running, so authors have time to add labels before the check fails.
+    # The delay is configured in repo Settings > Environments > "delayed-check" > Wait timer.
+    environment: delayed-check
     steps:
     - uses: yogevbd/enforce-label-action@2.2.2
       with:


### PR DESCRIPTION
Delays the label enforcement check by 5 minutes using a GitHub [environment wait timer](https://docs.github.com/en/actions/managing-workflow-runs-and-deployments/managing-deployments/reviewing-deployments#about-wait-timers), giving PR authors time to add a label before the check fails and sends an email.

## Setup required after merging

1. Go to **Settings > Environments > New environment**
2. Name it **`delayed-check`**
3. Enable **Wait timer** and set it to **5** minutes
4. Save
