### PR TITLE
Rename `android-studio-sync` to `studio-sync`

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ By default, this is set to `<output-dir>/idea-sandbox`.
 If you want the IDE to keep old data (e.g. indexes), set and reuse your own folder.
 - `--no-idea-sandbox`: Do not use the IntelliJ IDEA sandbox; instead use the default IDE folders for the IDE data.
 - `--studio-install-dir`: The Android Studio installation directory.
-Required when measuring an `android-studio-sync` scenario.
+Required when measuring an `studio-sync` scenario.
 On macOS, it is the app directory, e.g. `~/Applications/Android Studio.app`.
 - `--studio-sandbox-dir`: The Android Studio sandbox directory.
 By default, this is set to `<output-dir>/studio-sandbox`.
@@ -313,7 +313,7 @@ By default, this is set to `<output-dir>/studio-sandbox`.
 
 ### Scenario file blocks
 
-Inside an `idea-sync` or `android-studio-sync` block:
+Inside an `idea-sync` or `studio-sync` block:
 
 - `ide-jvm-args`: JVM arguments for the IDE process. Defaults to `["-Xms256m", "-Xmx4096m"]`.
 - `idea-properties`: Additional entries to write to the IDE's `idea.properties` file. Useful for setting registry values.
@@ -329,7 +329,7 @@ For Android Studio, swap `--idea-install-dir` for `--studio-install-dir` and use
     }
 
     myStudioSync {
-        android-studio-sync {
+        studio-sync {
             ide-jvm-args = ["-Xms256m", "-Xmx4096m"]
         }
     }
@@ -344,6 +344,7 @@ The following options are still accepted but deprecated. A warning will be print
 | Deprecated                          | Replacement              |
 |-------------------------------------|--------------------------|
 | `studio-jvm-args`                   | `ide-jvm-args`           |
+| `android-studio-sync`               | `studio-sync`            |
 | `clear-android-studio-cache-before` | `clear-ide-cache-before` |
 
 ## Advanced profiling scenarios
@@ -412,7 +413,7 @@ Here is an example:
         # Can also run tasks
         # tasks = ["assemble"]
     }
-    # For IDE-sync scenarios (`idea-sync` / `android-studio-sync`), see IDE sync support section.
+    # For IDE-sync scenarios (`idea-sync` / `studio-sync`), see IDE sync support section.
 
 Values are optional and default to the values provided on the command-line or defined in the build.
 

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -391,7 +391,9 @@ class ScenarioLoader {
     }
 
     private static IdeGradleScenarioDefinition newIdeGradleScenarioDefinition(GradleScenarioDefinition gradleScenarioDefinition, Config scenario, IdeType ideType, File scenarioFile, String scenarioName) {
-        String syncKey = ideType == IdeType.ANDROID_STUDIO ? resolveStudioSyncKey(scenario) : getIdeSyncKey(ideType);
+        String syncKey = ideType == IdeType.ANDROID_STUDIO
+            ? resolveKeyWithDeprecatedFallback(scenario, STUDIO_SYNC, ANDROID_STUDIO_SYNC)
+            : IDEA_SYNC;
         Config ideSyncConfig = scenario.getConfig(syncKey);
         for (String key : scenario.getObject(syncKey).keySet()) {
             if (!IDE_SYNC_SCENARIO_KEYS.contains(key)) {
@@ -418,17 +420,6 @@ class ScenarioLoader {
             return IdeType.ANDROID_STUDIO;
         }
         return null;
-    }
-
-    private static String getIdeSyncKey(IdeType ideType) {
-        return switch (ideType) {
-            case INTELLIJ_IDEA -> IDEA_SYNC;
-            case ANDROID_STUDIO -> STUDIO_SYNC;
-        };
-    }
-
-    private static String resolveStudioSyncKey(Config scenario) {
-        return resolveKeyWithDeprecatedFallback(scenario, STUDIO_SYNC, ANDROID_STUDIO_SYNC);
     }
 
     private static List<BuildMutator> getMutators(Config scenario, String scenarioName, InvocationSettings settings, int warmUpCount, int buildCount) {

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -85,6 +85,10 @@ class ScenarioLoader {
     private static final String MEASUREMENT_KIND = "measurement-kind";
     private static final String TOOLING_API = "tooling-api";
     private static final String IDEA_SYNC = "idea-sync";
+    private static final String STUDIO_SYNC = "studio-sync";
+    /**
+     * @deprecated Use {@link #STUDIO_SYNC} instead.
+     */
     private static final String ANDROID_STUDIO_SYNC = "android-studio-sync";
     private static final String IDE_JVM_ARGS = "ide-jvm-args";
     /**
@@ -146,6 +150,7 @@ class ScenarioLoader {
             TOOLING_API,
             TOOL_HOME,
             IDEA_SYNC,
+            STUDIO_SYNC,
             ANDROID_STUDIO_SYNC,
             DAEMON,
             JVM_ARGS,
@@ -386,7 +391,7 @@ class ScenarioLoader {
     }
 
     private static IdeGradleScenarioDefinition newIdeGradleScenarioDefinition(GradleScenarioDefinition gradleScenarioDefinition, Config scenario, IdeType ideType, File scenarioFile, String scenarioName) {
-        String syncKey = getIdeSyncKey(ideType);
+        String syncKey = ideType == IdeType.ANDROID_STUDIO ? resolveStudioSyncKey(scenario) : getIdeSyncKey(ideType);
         Config ideSyncConfig = scenario.getConfig(syncKey);
         for (String key : scenario.getObject(syncKey).keySet()) {
             if (!IDE_SYNC_SCENARIO_KEYS.contains(key)) {
@@ -402,9 +407,9 @@ class ScenarioLoader {
     @Nullable
     private static IdeType getIdeSyncType(Config scenario) {
         boolean hasIdea = scenario.hasPath(IDEA_SYNC);
-        boolean hasStudio = scenario.hasPath(ANDROID_STUDIO_SYNC);
+        boolean hasStudio = hasKeyWithDeprecatedFallback(scenario, STUDIO_SYNC, ANDROID_STUDIO_SYNC);
         if (hasIdea && hasStudio) {
-            throw new IllegalArgumentException("Cannot specify both '" + IDEA_SYNC + "' and '" + ANDROID_STUDIO_SYNC + "' in the same scenario.");
+            throw new IllegalArgumentException("Cannot specify both '" + IDEA_SYNC + "' and '" + STUDIO_SYNC + "' in the same scenario.");
         }
         if (hasIdea) {
             return IdeType.INTELLIJ_IDEA;
@@ -418,8 +423,12 @@ class ScenarioLoader {
     private static String getIdeSyncKey(IdeType ideType) {
         return switch (ideType) {
             case INTELLIJ_IDEA -> IDEA_SYNC;
-            case ANDROID_STUDIO -> ANDROID_STUDIO_SYNC;
+            case ANDROID_STUDIO -> STUDIO_SYNC;
         };
+    }
+
+    private static String resolveStudioSyncKey(Config scenario) {
+        return resolveKeyWithDeprecatedFallback(scenario, STUDIO_SYNC, ANDROID_STUDIO_SYNC);
     }
 
     private static List<BuildMutator> getMutators(Config scenario, String scenarioName, InvocationSettings settings, int warmUpCount, int buildCount) {

--- a/src/test/groovy/org/gradle/profiler/AbstractIdeSyncIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AbstractIdeSyncIntegrationTest.groovy
@@ -34,7 +34,7 @@ abstract class AbstractIdeSyncIntegrationTest extends AbstractProfilerIntegratio
         sandboxDir = tmpDir.createDir('sandbox')
         ideHome = findIdeHome()
         ideDisplayName = ideType().displayName
-        scenarioSyncOption = ideType() == IdeType.INTELLIJ_IDEA ? "idea-sync" : "android-studio-sync"
+        scenarioSyncOption = ideType() == IdeType.INTELLIJ_IDEA ? "idea-sync" : "studio-sync"
         installDirOption = ideType() == IdeType.INTELLIJ_IDEA ? "--idea-install-dir" : "--studio-install-dir"
         sandboxDirOption = ideType() == IdeType.INTELLIJ_IDEA ? "--idea-sandbox-dir" : "--studio-sandbox-dir"
 

--- a/src/test/groovy/org/gradle/profiler/ChromeTraceGradleCrossVersionTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ChromeTraceGradleCrossVersionTest.groovy
@@ -52,7 +52,7 @@ class ChromeTraceGradleCrossVersionTest extends AbstractGradleCrossVersionTest {
         new File(projectDir, "buildSrc/gradle.build").createNewFile()
         def scenarioFile = file("performance.scenarios") << """
             scenario {
-                android-studio-sync {}
+                studio-sync {}
             }
         """
 

--- a/src/test/groovy/org/gradle/profiler/IntellijIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/IntellijIntegrationTest.groovy
@@ -18,11 +18,11 @@ class IntellijIntegrationTest extends AbstractIdeSyncIntegrationTest {
         return IdeType.INTELLIJ_IDEA
     }
 
-    def "fails when android-studio-sync points to IntelliJ IDEA install dir"() {
+    def "fails when studio-sync points to IntelliJ IDEA install dir"() {
         given:
         def scenarioFile = file("performance.scenarios") << """
             $scenarioName {
-                android-studio-sync {}
+                studio-sync {}
             }
         """
 

--- a/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioLoaderTest.groovy
@@ -421,9 +421,11 @@ class ScenarioLoaderTest extends Specification {
         where:
         syncKey               | jvmArgsKey        | expectedWarnings
         "idea-sync"           | "ide-jvm-args"    | []
-        "android-studio-sync" | "ide-jvm-args"    | []
+        "studio-sync"         | "ide-jvm-args"    | []
+        "android-studio-sync" | "ide-jvm-args"    | ["WARNING: Scenario key 'android-studio-sync' is deprecated. Use 'studio-sync' instead."]
         "idea-sync"           | "studio-jvm-args" | ["WARNING: Scenario key 'studio-jvm-args' is deprecated. Use 'ide-jvm-args' instead."]
-        "android-studio-sync" | "studio-jvm-args" | ["WARNING: Scenario key 'studio-jvm-args' is deprecated. Use 'ide-jvm-args' instead."]
+        "studio-sync"         | "studio-jvm-args" | ["WARNING: Scenario key 'studio-jvm-args' is deprecated. Use 'ide-jvm-args' instead."]
+        "android-studio-sync" | "studio-jvm-args" | ["WARNING: Scenario key 'android-studio-sync' is deprecated. Use 'studio-sync' instead.", "WARNING: Scenario key 'studio-jvm-args' is deprecated. Use 'ide-jvm-args' instead."]
     }
 
     def "loads default scenarios only"() {


### PR DESCRIPTION
For consistency with AS control flags, prefixed with `studio-`