### PR TITLE
Add CODEOWNERS and enable groupArtifactsByBuild for TeamCity parallel tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Build infrastructure
+/.github/   @gradle/bt-developer-productivity
+/.teamcity/ @gradle/bt-developer-productivity

--- a/.teamcity/src/main/kotlin/GradleProfilerTest.kt
+++ b/.teamcity/src/main/kotlin/GradleProfilerTest.kt
@@ -33,6 +33,7 @@ open class GradleProfilerTest(os: Os, javaVersion: JavaVersion, arch: Arch) : Bu
             } else {
                 4
             }
+            groupArtifactsByBuild = true
         }
 
         commitStatusPublisher {


### PR DESCRIPTION
- Adds `.github/CODEOWNERS` assigning `@gradle/bt-developer-productivity` ownership of `.github/` and `.teamcity/`
- Adds `groupArtifactsByBuild = true` to `parallelTests` feature blocks, making the TeamCity 2025.11 default explicit