### PR TITLE
Create a new Publish project

### DIFF
--- a/.teamcity/src/main/kotlin/GradleProfilerPublishProject.kt
+++ b/.teamcity/src/main/kotlin/GradleProfilerPublishProject.kt
@@ -1,0 +1,8 @@
+import jetbrains.buildServer.configs.kotlin.Project
+
+fun Project.configureGradleProfilerPublishProject() {
+    description = "Publishes the Gradle Profiler to Sonatype, Maven Central, and SDKman"
+
+    buildType(GradleProfilerPublishing)
+    buildType(GradleProfilerPublishToSdkMan(GradleProfilerPublishing))
+}

--- a/.teamcity/src/main/kotlin/root-project.kt
+++ b/.teamcity/src/main/kotlin/root-project.kt
@@ -20,8 +20,12 @@ fun Project.configureGradleProfilerProject() {
 
     buildType(GradleProfilerSanityCheck)
     buildType(GradleProfilerTestTrigger(listOf(GradleProfilerSanityCheck) + testBuilds))
-    buildType(GradleProfilerPublishing)
-    buildType(GradleProfilerPublishToSdkMan(GradleProfilerPublishing))
+
+    subProject {
+        id("GradleProfilerPublish")
+        name = "GradleProfilerPublish"
+        configureGradleProfilerPublishProject()
+    }
 
     params {
         text("JdkProviderEnabled", "true")


### PR DESCRIPTION
Part of https://github.com/gradle/gradle-private/issues/5191. Create a project for the publish build types so we can assign them to bare metal agent pool.