### PR TITLE
Prepare 0.25.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ Gradle Profiler can benchmark Gradle sync performed by IntelliJ-based IDEs. This
 
 ### Supported IDEs
 
-- **IntelliJ IDEA** 2025.3 or newer
-- **Android Studio** Panda (2025.3) or newer
+- **IntelliJ IDEA** 2026.1 or newer
+- **Android Studio** Quail (2026.1) or newer
 
 Both IDEs are based on the IntelliJ platform. The profiler installs a lightweight plugin into the IDE that controls the sync lifecycle and communicates results back to the profiler.
 

--- a/buildSrc/src/main/kotlin/tasks/ExtractIdeTask.kt
+++ b/buildSrc/src/main/kotlin/tasks/ExtractIdeTask.kt
@@ -75,9 +75,8 @@ abstract class ExtractIdeTask @Inject constructor(
         val appName = dmgAppName.get()
         val volume = appName.replace(" ", "")
         val volumeDir = "/Volumes/$volume"
-        val srcDir = "/Volumes/$volume/$appName"
-        require(!File(srcDir).exists()) {
-            "The directory $srcDir already exists. Please unmount it via `hdiutil detach $volumeDir`."
+        require(!File(volumeDir).exists()) {
+            "The directory $volumeDir already exists. Please unmount it via `hdiutil detach $volumeDir`."
         }
 
         try {
@@ -85,9 +84,16 @@ abstract class ExtractIdeTask @Inject constructor(
                 commandLine("hdiutil", "attach", distributionFile.absolutePath, "-mountpoint", volumeDir)
             }
 
+            // The .app bundle name may differ across releases (e.g. "Android Studio.app"
+            // for stable, "Android Studio Preview.app" for canary). Find the actual .app bundle.
+            val appBundle = File(volumeDir).listFiles()
+                ?.firstOrNull { it.name.endsWith(".app") && it.isDirectory }
+                ?: error("No .app bundle found in $volumeDir")
+            val contentsDir = "${appBundle.absolutePath}/Contents"
+
             outputDir.get().asFile.mkdirs()
             execOps.exec {
-                commandLine("cp", "-r", "$srcDir/Contents", outputDir.get().asFile.absolutePath)
+                commandLine("cp", "-r", contentsDir, outputDir.get().asFile.absolutePath)
             }
         } finally {
             execOps.exec {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-profiler.version=0.25.0-alpha-2
+profiler.version=0.25.0-alpha-3
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=768m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-profiler.version=0.25.0-alpha-3
+profiler.version=0.25.0-alpha-6
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=768m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-profiler.version=0.25.0-alpha-6
+profiler.version=0.25.0
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=768m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,15 +3,15 @@ groovy = "4.0.29"
 protobuf = "3.21.12"
 spock = "2.4-groovy-4.0"
 
-# Panda 2 (2025.3.2.6)
-testAndroidStudioVersion = "2025.3.2.6"
+# Quail 1 Canary 3 (2026.1.1.3)
+testAndroidStudioVersion = "2026.1.1.3"
 # Download artifact suffix changed from version to codename starting with Panda
-testAndroidStudioCodename = "panda2"
+testAndroidStudioCodename = "quail1-canary3"
 testAndroidSdkVersion = "9.1.0"
-testIntellijVersion = "2025.3.4"
-intellijPlatformVersion = "2025.3"
-minimalSupportedPlatformCode = "253"
-jetbrainsAndroidPluginVersion = "253.28294.334"
+testIntellijVersion = "2026.1.1"
+intellijPlatformVersion = "2026.1"
+minimalSupportedPlatformCode = "261"
+jetbrainsAndroidPluginVersion = "261.23567.138"
 
 [libraries]
 ant-compress = { module = "org.apache.ant:ant-compress", version = "1.5" }
@@ -30,7 +30,7 @@ jmc-flightrecorder = { module = "org.openjdk.jmc:flightrecorder", version = "8.3
 jopt = { module = "net.sf.jopt-simple:jopt-simple", version = "5.0.4" }
 junit-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version = "6.0.3" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "1.14.3" }
-kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version = "2.1.20" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version = "2.3.0" }
 mockito-core = { module = "org.mockito:mockito-core", version = "5.23.0" }
 objenesis = { module = "org.objenesis:objenesis", version = "2.6" }
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
@@ -45,7 +45,7 @@ typesafe-config = { module = "com.typesafe:config", version = "1.4.6" }
 testDependencies = ["spock-core", "spock-junit4", "junit-platform-launcher", "mockito-core"]
 
 [plugins]
-intellij-platform = { id = "org.jetbrains.intellij.platform", version = "2.13.1" }
+intellij-platform = { id = "org.jetbrains.intellij.platform", version = "2.15.0" }
 nexus = { id = "io.github.gradle-nexus.publish-plugin", version = "2.0.0" }
 node = { id = "com.github.node-gradle.node", version = "7.1.0" }
 protobuf = { id = "com.google.protobuf", version = "0.9.6" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,12 +3,12 @@ groovy = "4.0.29"
 protobuf = "3.21.12"
 spock = "2.4-groovy-4.0"
 
-# Quail 1 Canary 3 (2026.1.1.3)
-testAndroidStudioVersion = "2026.1.1.3"
+# Quail 1 Patch 2 (2026.1.1.10)
+testAndroidStudioVersion = "2026.1.1.10"
 # Download artifact suffix changed from version to codename starting with Panda
-testAndroidStudioCodename = "quail1-canary3"
+testAndroidStudioCodename = "quail1-patch2"
 testAndroidSdkVersion = "9.1.0"
-testIntellijVersion = "2026.1.1"
+testIntellijVersion = "2026.1.4"
 intellijPlatformVersion = "2026.1"
 minimalSupportedPlatformCode = "261"
 jetbrainsAndroidPluginVersion = "261.23567.138"

--- a/src/main/java/org/gradle/profiler/ide/process/IdeProcess.java
+++ b/src/main/java/org/gradle/profiler/ide/process/IdeProcess.java
@@ -17,7 +17,7 @@ import java.util.List;
 
 public class IdeProcess implements Closeable {
 
-    private static final Duration IDE_START_TIMEOUT = Duration.ofSeconds(15);
+    private static final Duration IDE_START_TIMEOUT = Duration.ofSeconds(60);
     private static final Duration PLUGIN_CONNECT_TIMEOUT = Duration.ofMinutes(1);
     private static final Duration AGENT_CONNECT_TIMEOUT = Duration.ofMinutes(1);
 

--- a/src/test/groovy/org/gradle/profiler/AbstractIdeSyncIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/AbstractIdeSyncIntegrationTest.groovy
@@ -2,7 +2,7 @@ package org.gradle.profiler
 
 import org.gradle.api.JavaVersion
 import org.gradle.profiler.fixtures.AbstractProfilerIntegrationTest
-import org.gradle.profiler.fixtures.compatibility.ide.IntellijGradleJvmCompatibility
+import org.gradle.profiler.fixtures.compatibility.ide.IdeGradleJvmCompatibility
 import org.gradle.profiler.instrument.GradleInstrumentation
 import org.gradle.profiler.spock.extensions.ShowIdeLogsOnFailure
 import org.gradle.profiler.ide.IdeType
@@ -41,7 +41,7 @@ abstract class AbstractIdeSyncIntegrationTest extends AbstractProfilerIntegratio
         // IDE must support Java version we're going to run the test build with.
         // So far we expect the current version to work always, however some downgrading logic
         // may need to be applied in future.
-        Set<Integer> supportedJavaVersionsByIde = IntellijGradleJvmCompatibility.fromIdeHome(ideHome).supportedJavaVersions
+        Set<Integer> supportedJavaVersionsByIde = IdeGradleJvmCompatibility.fromIdeHome(ideType(), ideHome).supportedJavaVersions
         Integer currentJvm = JavaVersion.current().majorVersion as int
         assert supportedJavaVersionsByIde.contains(currentJvm)
 

--- a/src/test/groovy/org/gradle/profiler/fixtures/compatibility/ide/IdeGradleJvmCompatibility.groovy
+++ b/src/test/groovy/org/gradle/profiler/fixtures/compatibility/ide/IdeGradleJvmCompatibility.groovy
@@ -1,6 +1,7 @@
 package org.gradle.profiler.fixtures.compatibility.ide
 
 import groovy.json.JsonSlurper
+import org.gradle.profiler.ide.IdeType
 
 import java.util.jar.JarFile
 
@@ -11,22 +12,22 @@ import java.util.jar.JarFile
  * Used to check if a given Java version is supported by the IDE,
  * so tests can downgrade the JVM when needed.
  */
-class IntellijGradleJvmCompatibility {
+class IdeGradleJvmCompatibility {
 
     private final Set<Integer> supportedJavaVersions
 
-    private IntellijGradleJvmCompatibility(Set<Integer> supportedJavaVersions) {
+    private IdeGradleJvmCompatibility(Set<Integer> supportedJavaVersions) {
         this.supportedJavaVersions = supportedJavaVersions
     }
 
-    static IntellijGradleJvmCompatibility fromIdeHome(File ideHome) {
+    static IdeGradleJvmCompatibility fromIdeHome(IdeType ide, File ideHome) {
         def gradleJar = findGradlePluginJar(ideHome)
         if (gradleJar == null) {
-            throw new IllegalStateException("Can't find gradle.jar in IntelliJ distribution at: $ideHome")
+            throw new IllegalStateException("Can't find gradle.jar in ${ide.displayName} distribution at: $ideHome")
         }
         def json = extractCompatibilityJson(gradleJar)
         if (json == null) {
-            throw new IllegalStateException("Can't find compatibility.json in IntelliJ distribution at: $ideHome")
+            throw new IllegalStateException("Can't find compatibility.json in ${ide.displayName} distribution at: $ideHome")
         }
         return parse(json)
     }
@@ -37,8 +38,10 @@ class IntellijGradleJvmCompatibility {
 
     private static File findGradlePluginJar(File ideHome) {
         def candidates = [
-            new File(ideHome, "Contents/plugins/gradle/lib/gradle.jar"), // macOS .app
-            new File(ideHome, "plugins/gradle/lib/gradle.jar"),          // Linux/Windows
+            new File(ideHome, "Contents/plugins/gradle/lib/gradle.jar"),             // macOS .app (pre-2026.1)
+            new File(ideHome, "plugins/gradle/lib/gradle.jar"),                      // Linux/Windows (pre-2026.1)
+            new File(ideHome, "Contents/plugins/gradle-plugin/lib/gradle-plugin.jar"), // macOS .app (2026.1+)
+            new File(ideHome, "plugins/gradle-plugin/lib/gradle-plugin.jar"),          // Linux/Windows (2026.1+)
         ]
         return candidates.find { it.isFile() }
     }
@@ -56,10 +59,10 @@ class IntellijGradleJvmCompatibility {
         }
     }
 
-    private static IntellijGradleJvmCompatibility parse(String json) {
+    private static IdeGradleJvmCompatibility parse(String json) {
         def entries = new JsonSlurper().parseText(json) as List<Map>
         def latestEntry = entries.findAll { it.containsKey("supportedJavaVersions") }.last()
         def versions = (latestEntry.supportedJavaVersions as List<String>).collect { it as int }.toSet()
-        return new IntellijGradleJvmCompatibility(versions)
+        return new IdeGradleJvmCompatibility(versions)
     }
 }

--- a/subprojects/ide-plugin/build.gradle.kts
+++ b/subprojects/ide-plugin/build.gradle.kts
@@ -21,13 +21,12 @@ dependencies {
         intellijIdea(libs.versions.intellijPlatformVersion)
         bundledPlugin("com.intellij.java")
         bundledPlugin("com.intellij.gradle")
-        bundledPlugin("org.jetbrains.plugins.gradle")
         // JB Android plugin version may need to be bumped in case of IntelliJ platform version bump
         plugin("org.jetbrains.android", libs.versions.jetbrainsAndroidPluginVersion.get())
     }
 }
 
-// IntelliJ 2025.3 is compiled for Java 21
+// IntelliJ 2026.1 is compiled for Java 21
 kotlin {
     jvmToolchain(21)
 }

--- a/subprojects/ide-plugin/build.gradle.kts
+++ b/subprojects/ide-plugin/build.gradle.kts
@@ -26,7 +26,6 @@ dependencies {
     }
 }
 
-// IntelliJ 2026.1 is compiled for Java 21
 kotlin {
     jvmToolchain(21)
 }

--- a/subprojects/ide-plugin/src/main/kotlin/org/gradle/profiler/ide/plugin/GradleProfilerStartupActivity.kt
+++ b/subprojects/ide-plugin/src/main/kotlin/org/gradle/profiler/ide/plugin/GradleProfilerStartupActivity.kt
@@ -1,6 +1,6 @@
 package org.gradle.profiler.ide.plugin
 
-import com.intellij.ide.impl.setTrusted
+import com.intellij.ide.trustedProjects.TrustedProjects
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.externalSystem.service.notification.ExternalSystemProgressNotificationManager
@@ -36,7 +36,7 @@ class GradleProfilerStartupActivity : ProjectActivity {
         val gradleSystemListener = GradleSystemListener()
         ExternalSystemProgressNotificationManager.getInstance().addNotificationListener(gradleSystemListener, project)
 
-        project.setTrusted(true)
+        TrustedProjects.setProjectTrusted(project, true)
 
         ApplicationManager.getApplication().executeOnPooledThread {
             val lastRequest = listenForSyncRequests(project, gradleSystemListener)

--- a/subprojects/ide-plugin/src/main/resources/META-INF/plugin.xml
+++ b/subprojects/ide-plugin/src/main/resources/META-INF/plugin.xml
@@ -8,7 +8,7 @@
 
     <!-- Plugin dependencies -->
     <!-- Any dependency here should also be added to build.gradle.kts intellij extension -->
-    <depends>org.jetbrains.plugins.gradle</depends>
+    <depends>com.intellij.gradle</depends>
     <depends>com.intellij.modules.java</depends>
     <depends optional="true" config-file="android-studio-extensions.xml">org.jetbrains.android</depends>
 


### PR DESCRIPTION
PR bumps platform version to 261 to be able to run IDEA and AS 2026.1+ versions.
Also IJP plugin updated to the latest. 