### PR TITLE
Add `toString` to heap dump profiler

### DIFF
--- a/src/main/java/org/gradle/profiler/Profiler.java
+++ b/src/main/java/org/gradle/profiler/Profiler.java
@@ -81,4 +81,9 @@ public abstract class Profiler {
     public boolean isCreatesStacksFiles() {
         return false;
     }
+
+    /**
+     * Human-readable profiler name as specified from the command line.
+     */
+    public abstract String toString();
 }

--- a/src/main/java/org/gradle/profiler/heapdump/HeapDumpProfiler.java
+++ b/src/main/java/org/gradle/profiler/heapdump/HeapDumpProfiler.java
@@ -32,4 +32,9 @@ public class HeapDumpProfiler extends Profiler {
             consumer.accept(resultFile.getAbsolutePath());
         }
     }
+
+    @Override
+    public String toString() {
+        return "heap-dump";
+    }
 }


### PR DESCRIPTION
Currently using the heap dump profiler shows the default `Object.toString()`

    Profiler: chrome-trace, org.gradle.profiler.heapdump.HeapDumpProfiler@20d525, async-profiler

This changes it match the others

    Profiler: chrome-trace, heap-dump, async-profiler

Additionally, the addition of the abstract `toString` on `Profiler` itself ensures all subtypes declare an override.