### PR TITLE
Add scenario-matrices for declarative cartesian-product scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,70 @@ To run scenarios from a specific group:
 
 This will run only the scenarios defined in the `smoke-tests` group (`assemble` and `clean_build`).
 
+### Scenario matrices
+
+When you want to benchmark the cartesian product of several variable dimensions (e.g. *build task × daemon mode × configuration cache on/off*), declare each dimension and let `scenario-matrices` expand it into one runnable scenario per tuple:
+
+    # Ordinary scenarios — referenced from the matrix below, still runnable on their own.
+    assemble { tasks = ["assemble"] }
+    check    { tasks = ["check"] }
+
+    coldDaemon { daemon = cold }
+    warmDaemon { daemon = warm }
+
+    ccOn  { system-properties { "org.gradle.configuration-cache" = "true"  } }
+    ccOff { system-properties { "org.gradle.configuration-cache" = "false" } }
+
+    scenario-matrices {
+        matrix {
+            dimensions = [
+                { name = task,   scenarios = [assemble, check] }
+                { name = daemon, scenarios = [coldDaemon, warmDaemon] }
+                { name = cc,     scenarios = [ccOn, ccOff] }
+            ]
+        }
+    }
+
+This synthesizes 2 × 2 × 2 = 8 scenarios named `matrix_assemble_coldDaemon_ccOn`, `matrix_assemble_coldDaemon_ccOff`, …, each equivalent to merging the picked scenarios' HOCON blocks in order.
+
+Picked scenarios stay valid top-level scenarios — they remain selectable by name, runnable on their own, and usable in `default-scenarios` or hand-written `scenario-groups`. References inside `dimensions` must point to top-level scenarios in the same file; references to other matrices, reserved keys, or unknown names are rejected. Synthesized names must not collide with existing top-level scenarios or groups. Malformed configuration produces an error message naming the offending key and the scenario file.
+
+#### Merge semantics
+
+The scenarios picked from each dimension are merged using HOCON merge:
+
+- **Maps merge recursively.** `system-properties`, `idea-sync { … }`, `tooling-api { … }`, etc. — keys from all scenarios are kept; on a key conflict, the scenario from the **right-most** dimension wins.
+- **Arrays and primitives are replaced, not merged.** If two scenarios set `tasks` or `jvm-args`, the right-most one fully replaces the others.
+- **Mutators at distinct top-level keys compose freely.** E.g. one scenario sets `apply-abi-change-to` and another sets `clear-build-cache-before` — the synthesized scenario has both.
+
+#### Auto-generated scenario groups
+
+Two families of `scenario-groups` are emitted automatically. Both follow one rule: **the group name is a synthesized scenario name with the varying dimension(s) omitted.**
+
+*Fix one, vary the rest* — pin a single scenario:
+
+    > gradle-profiler --benchmark --scenario-file build.scenarios --group matrix_coldDaemon
+
+runs the four `coldDaemon` variants (all combinations of task × cc).
+
+*Fix all but one, vary that one* — pin all but one scenario, let the remaining dimension vary:
+
+    > gradle-profiler --benchmark --scenario-file build.scenarios --group matrix_assemble_ccOn
+
+runs the two daemon variants (`coldDaemon` and `warmDaemon`) of that otherwise-fixed configuration. This family is only emitted when there are 3 or more dimensions (with 2 dimensions it coincides with "fix one").
+
+You can also reference synthesized scenarios by name from the CLI, from `default-scenarios`, or from hand-written `scenario-groups`.
+
+#### Titles and separators
+
+A matrix entry accepts a few optional keys to control the names and titles of synthesized scenarios:
+
+- `title` — the human-readable label for the matrix, used as the prefix of each synthesized title. Defaults to the matrix's key (e.g. `matrix`). Set to the empty string (`title = ""`) to omit the prefix segment so synthesized titles read as just the picked scenarios joined by `title-separator` — useful for keeping result-file titles short.
+- `name-separator` — the separator used in synthesized scenario names and auto-generated group names. Defaults to `_`. Keep this within `[a-zA-Z0-9._-]`; other characters are mangled into `-` in output directory names by file-name sanitization.
+- `title-separator` — the separator used when joining the matrix title with each picked scenario's title. Defaults to `". "`.
+
+If any scenario or the matrix itself has a `title`, the synthesized scenario's title is composed from them using `title-separator`. If no titles are set anywhere, the synthesized scenario name is used as the title.
+
 ### Benchmark options
 
 - `iterations`: Number of builds to actually measure

--- a/src/main/java/org/gradle/profiler/ScenarioLoader.java
+++ b/src/main/java/org/gradle/profiler/ScenarioLoader.java
@@ -160,9 +160,10 @@ class ScenarioLoader {
         .add(CLEAR_ANDROID_STUDIO_CACHE_BEFORE)
         .build();
 
-    private static final Set<String> RESERVED_TOP_LEVEL_KEYS = ImmutableSet.of(
+    static final Set<String> RESERVED_TOP_LEVEL_KEYS = ImmutableSet.of(
         DEFAULT_SCENARIOS,
-        SCENARIO_GROUPS
+        SCENARIO_GROUPS,
+        ScenarioMatrices.SCENARIO_MATRICES
     );
 
     private static final List<String> BAZEL_KEYS = Arrays.asList(TARGETS, TOOL_HOME);
@@ -229,7 +230,7 @@ class ScenarioLoader {
     }
 
     static List<ScenarioDefinition> loadScenarios(File scenarioFile, InvocationSettings settings, GradleBuildConfigurationReader inspector) {
-        Config config = parseScenarioFile(scenarioFile);
+        Config config = parseAndExpandScenarioFile(scenarioFile);
         Set<String> selectedScenarios = selectScenarios(config, settings, scenarioFile);
 
         List<ScenarioDefinition> definitions = new ArrayList<>();
@@ -386,8 +387,12 @@ class ScenarioLoader {
         return ImmutableList.of(new MavenScenarioDefinition(scenarioName, title, targets, systemProperties, mutators, warmUpCount, buildCount, outputDir, mavenHome));
     }
 
-    private static Config parseScenarioFile(File scenarioFile) {
+    static Config parseScenarioFile(File scenarioFile) {
         return ConfigFactory.parseFile(scenarioFile, ConfigParseOptions.defaults().setAllowMissing(false)).resolve();
+    }
+
+    private static Config parseAndExpandScenarioFile(File scenarioFile) {
+        return ScenarioMatrices.expand(parseScenarioFile(scenarioFile), scenarioFile);
     }
 
     private static IdeGradleScenarioDefinition newIdeGradleScenarioDefinition(GradleScenarioDefinition gradleScenarioDefinition, Config scenario, IdeType ideType, File scenarioFile, String scenarioName) {
@@ -750,7 +755,7 @@ class ScenarioLoader {
      * <p>Each scenario output is standalone and can be copied into a new scenario file as-is.
      */
     public static String dumpScenarios(File scenarioFile, InvocationSettings settings) {
-        Config config = parseScenarioFile(scenarioFile);
+        Config config = parseAndExpandScenarioFile(scenarioFile);
         Set<String> selectedScenarios = selectScenarios(config, settings, scenarioFile);
 
         ConfigRenderOptions renderOptions = ConfigRenderOptions.defaults()
@@ -767,7 +772,6 @@ class ScenarioLoader {
             output.append('\n');
 
             Config scenario = config.getConfig(scenarioName);
-
 
             output.append(String.format("# Scenario %d/%d", scenarioIndex, scenarioCount));
             String title = scenario.hasPath(TITLE) ? scenario.getString(TITLE) : null;

--- a/src/main/java/org/gradle/profiler/ScenarioMatrices.java
+++ b/src/main/java/org/gradle/profiler/ScenarioMatrices.java
@@ -1,0 +1,489 @@
+package org.gradle.profiler;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigObject;
+import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueFactory;
+import com.typesafe.config.ConfigValueType;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Expands top-level {@code scenario-matrices { ... }} blocks into synthesized scenarios and
+ * scenario groups. The output is a normal HOCON {@link Config} that downstream code consumes
+ * without further knowledge of matrices.
+ *
+ * <p>Example input:
+ * <pre>
+ * cold { daemon = cold }
+ * warm { daemon = warm }
+ * assemble { tasks = ["assemble"] }
+ * check    { tasks = ["check"] }
+ *
+ * scenario-matrices {
+ *     matrix {
+ *         dimensions = [
+ *             { name = task,   scenarios = [assemble, check] }
+ *             { name = daemon, scenarios = [cold, warm] }
+ *         ]
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>Expansion produces four synthesized scenarios — {@code matrix_assemble_cold},
+ * {@code matrix_assemble_warm}, {@code matrix_check_cold}, {@code matrix_check_warm} — each formed
+ * by HOCON-merging the picked scenarios in dimension order (rightmost dimension wins on conflicts),
+ * plus auto-generated {@code scenario-groups} for selecting subsets.
+ */
+final class ScenarioMatrices {
+
+    static final String SCENARIO_MATRICES = "scenario-matrices";
+    private static final String SCENARIO_GROUPS = "scenario-groups";
+    private static final String DIMENSIONS = "dimensions";
+    private static final String NAME = "name";
+    private static final String SCENARIOS = "scenarios";
+    private static final String NAME_SEPARATOR = "name-separator";
+    private static final String TITLE_SEPARATOR = "title-separator";
+    private static final String TITLE = "title";
+    private static final String DEFAULT_NAME_SEPARATOR = "_";
+    private static final String DEFAULT_TITLE_SEPARATOR = ". ";
+    private static final Set<String> MATRIX_ENTRY_KEYS = Set.of(
+        DIMENSIONS, NAME_SEPARATOR, TITLE_SEPARATOR, TITLE
+    );
+    private static final Set<String> DIMENSION_KEYS = Set.of(NAME, SCENARIOS);
+
+    private ScenarioMatrices() {
+    }
+
+    /**
+     * Returns {@code rootConfig} with every {@code scenario-matrices { ... }} entry replaced by its
+     * synthesized scenarios and auto-generated groups. The {@code scenario-matrices} block itself is
+     * removed. If no such block is present the input is returned unchanged.
+     *
+     * <p>Throws {@link IllegalArgumentException} citing {@code scenarioFile} and the offending key
+     * for any malformed matrix definition or cross-batch collision.
+     */
+    static Config expand(Config rootConfig, File scenarioFile) {
+        if (!rootConfig.hasPath(SCENARIO_MATRICES)) {
+            return rootConfig;
+        }
+
+        ConfigValue scenarioMatricesValue = rootConfig.getValue(SCENARIO_MATRICES);
+        if (scenarioMatricesValue.valueType() != ConfigValueType.OBJECT) {
+            throw fail(scenarioFile, "'" + SCENARIO_MATRICES + "' must be an object mapping matrix names to matrix definitions");
+        }
+        ConfigObject matricesObject = (ConfigObject) scenarioMatricesValue;
+        if (matricesObject.isEmpty()) {
+            throw fail(scenarioFile, "'" + SCENARIO_MATRICES + "' is empty — remove it or declare at least one matrix");
+        }
+        Set<String> matrixKeys = new LinkedHashSet<>(matricesObject.keySet());
+
+        // Phase 1 — collect additions from every matrix without touching the input.
+        Map<String, ConfigValue> additionalScenarios = new LinkedHashMap<>();
+        Map<String, List<String>> additionalGroups = new LinkedHashMap<>();
+
+        Config matricesConfig = matricesObject.toConfig();
+        for (String prefix : matrixKeys) {
+            ConfigValue entryValue = matricesObject.get(prefix);
+            if (entryValue.valueType() != ConfigValueType.OBJECT) {
+                throw fail(scenarioFile, "Matrix '" + prefix + "' must be an object, but got " + entryValue.valueType().name().toLowerCase(Locale.ROOT));
+            }
+            Config entry = matricesConfig.getConfig(quote(prefix));
+            expandOne(rootConfig, prefix, entry, matrixKeys, additionalScenarios, additionalGroups, scenarioFile);
+        }
+
+        // Phase 2 — validate the batch of additions against the input in one pass, then merge.
+        Set<String> existingTopLevel = rootConfig.root().keySet();
+        for (String name : additionalScenarios.keySet()) {
+            if (existingTopLevel.contains(name)) {
+                throw fail(scenarioFile, "Synthesized scenario name '" + name + "' collides with an existing top-level entry");
+            }
+        }
+        Set<String> existingGroups = rootConfig.hasPath(SCENARIO_GROUPS)
+            ? rootConfig.getObject(SCENARIO_GROUPS).keySet()
+            : Set.of();
+        for (String groupName : additionalGroups.keySet()) {
+            if (existingGroups.contains(groupName)) {
+                throw fail(scenarioFile, "Synthesized scenario group '" + groupName + "' collides with an existing scenario-groups entry");
+            }
+        }
+
+        return buildResult(rootConfig, additionalScenarios, additionalGroups);
+    }
+
+    private static Config buildResult(
+        Config rootConfig,
+        Map<String, ConfigValue> additionalScenarios,
+        Map<String, List<String>> additionalGroups
+    ) {
+        Map<String, Object> additions = new LinkedHashMap<>();
+        additions.putAll(additionalScenarios);
+        if (!additionalGroups.isEmpty()) {
+            // Merge synthesized groups under the same scenario-groups key.
+            additions.put(SCENARIO_GROUPS, ConfigValueFactory.fromMap(new LinkedHashMap<>(additionalGroups)));
+        }
+        Config additionsConfig = ConfigValueFactory.fromMap(additions).toConfig();
+        // additionsConfig wins (no collisions — checked above), so we use it as the receiver.
+        return additionsConfig.withFallback(rootConfig.withoutPath(SCENARIO_MATRICES));
+    }
+
+    /**
+     * Expands one matrix entry into synthesized scenarios + auto-groups, appending them to the
+     * shared {@code additionalScenarios} and {@code additionalGroups} maps.
+     *
+     * <p>The {@code entry} corresponds to the body of a single matrix, for example:
+     * <pre>
+     * {
+     *     title = "Matrix"            // optional; "" omits the prefix segment; default = matrix key
+     *     name-separator = "_"        // optional; default "_"
+     *     title-separator = ". "      // optional; default ". "
+     *     dimensions = [ ... ]        // required
+     * }
+     * </pre>
+     *
+     * <p>Each tuple of scenarios produces one synthesized scenario named
+     * {@code <prefix><nameSep><scenario1><nameSep><scenario2>...}, formed by fold-right
+     * {@link Config#withFallback}.
+     */
+    private static void expandOne(
+        Config rootConfig,
+        String prefix,
+        Config entry,
+        Set<String> matrixKeys,
+        Map<String, ConfigValue> additionalScenarios,
+        Map<String, List<String>> additionalGroups,
+        File scenarioFile
+    ) {
+        for (String key : entry.root().keySet()) {
+            if (!MATRIX_ENTRY_KEYS.contains(key)) {
+                throw fail(scenarioFile, "Unrecognized key '" + prefix + "." + key + "' in '" + SCENARIO_MATRICES + "'. Allowed keys: " + String.join(", ", MATRIX_ENTRY_KEYS));
+            }
+        }
+        if (!entry.hasPath(DIMENSIONS)) {
+            throw fail(scenarioFile, "Matrix '" + prefix + "' must define a 'dimensions' list");
+        }
+        String nameSep = entry.hasPath(NAME_SEPARATOR) ? entry.getString(NAME_SEPARATOR) : DEFAULT_NAME_SEPARATOR;
+        if (nameSep.isEmpty()) {
+            throw fail(scenarioFile, "Matrix '" + prefix + "." + NAME_SEPARATOR + "' must not be empty");
+        }
+        String titleSep = entry.hasPath(TITLE_SEPARATOR) ? entry.getString(TITLE_SEPARATOR) : DEFAULT_TITLE_SEPARATOR;
+        String matrixTitle = entry.hasPath(TITLE) ? entry.getString(TITLE) : null;
+
+        List<Dimension> dimensions = parseDimensions(entry, prefix, rootConfig, matrixKeys, scenarioFile);
+
+        // Cartesian product, preserving the order of dimensions and scenarios as declared.
+        List<List<String>> tuples = cartesianProduct(dimensions.stream().map(Dimension::scenarios).toList());
+
+        // Synthesize one scenario per tuple.
+        List<String> tupleNames = new ArrayList<>(tuples.size());
+        for (List<String> tuple : tuples) {
+            String name = prefix + nameSep + String.join(nameSep, tuple);
+            if (additionalScenarios.containsKey(name)) {
+                throw fail(scenarioFile, "Synthesized scenario name '" + name + "' produced twice (likely two matrices collide)");
+            }
+
+            // Fold-right: last dimension's scenario wins on conflicts.
+            Config merged = ConfigFactory.empty();
+            for (String scenario : tuple) {
+                merged = rootConfig.getConfig(quote(scenario)).withFallback(merged);
+            }
+
+            String synthesizedTitle = composeTitle(rootConfig, matrixTitle, prefix, tuple, titleSep);
+            if (synthesizedTitle != null) {
+                merged = merged.withValue(TITLE, ConfigValueFactory.fromAnyRef(synthesizedTitle));
+            }
+            // Otherwise leave any scenario-inherited title in place — composeTitle returns null only when no scenario has one,
+            // so there's nothing to strip.
+
+            additionalScenarios.put(name, merged.root());
+            tupleNames.add(name);
+        }
+
+        generateAutoGroups(prefix, nameSep, dimensions, tuples, tupleNames, additionalGroups, scenarioFile);
+    }
+
+    /**
+     * Generates two families of auto-groups, both following the same naming rule: the group name is the synthesized
+     * scenario name with the varying dim(s) omitted.
+     *
+     * <ul>
+     *   <li>Fix-one (one pinned scenario, rest free): {@code <prefix>_<scenario>}. For "give me all variants where daemon=cold".</li>
+     *   <li>Fix-all-but-one (N−1 pinned scenarios, one dim free): {@code <prefix>_<scenario1>_<scenario2>...} in dimension order
+     *       with the varying dim's slot omitted. For "vary just this knob between two otherwise-identical configurations".</li>
+     * </ul>
+     *
+     * For N≤2 the two families coincide; we deduplicate. Collisions across families or scenarios fail loudly.
+     */
+    private static void generateAutoGroups(
+        String prefix,
+        String nameSep,
+        List<Dimension> dimensions,
+        List<List<String>> tuples,
+        List<String> tupleNames,
+        Map<String, List<String>> additionalGroups,
+        File scenarioFile
+    ) {
+        generateFixOneGroups(prefix, nameSep, dimensions, tuples, tupleNames, additionalGroups, scenarioFile);
+        // N≤2 is already covered by fix-one: with N=2 the names coincide; with N=1 there's no second dim to vary over.
+        if (dimensions.size() >= 3) {
+            generateFixAllButOneGroups(prefix, nameSep, dimensions, tuples, tupleNames, additionalGroups, scenarioFile);
+        }
+    }
+
+    /**
+     * Emits one group per scenario. The group fixes that single scenario and lets every other dimension vary.
+     *
+     * <p>Example: with scenarios {@code [a1, a2] × [b1, b2]} and prefix {@code matrix}, this emits
+     * {@code matrix_a1 = [matrix_a1_b1, matrix_a1_b2]}, {@code matrix_a2 = [matrix_a2_b1, matrix_a2_b2]},
+     * {@code matrix_b1 = [matrix_a1_b1, matrix_a2_b1]}, {@code matrix_b2 = [matrix_a1_b2, matrix_a2_b2]}.
+     */
+    private static void generateFixOneGroups(
+        String prefix,
+        String nameSep,
+        List<Dimension> dimensions,
+        List<List<String>> tuples,
+        List<String> tupleNames,
+        Map<String, List<String>> additionalGroups,
+        File scenarioFile
+    ) {
+        int dimensionCount = dimensions.size();
+        for (int d = 0; d < dimensionCount; d++) {
+            for (String scenario : dimensions.get(d).scenarios()) {
+                String groupName = prefix + nameSep + scenario;
+                List<String> members = new ArrayList<>();
+                for (int t = 0; t < tuples.size(); t++) {
+                    if (tuples.get(t).get(d).equals(scenario)) {
+                        members.add(tupleNames.get(t));
+                    }
+                }
+                putGroup(additionalGroups, groupName, members, scenarioFile);
+            }
+        }
+    }
+
+    /**
+     * Emits one group per choice of (which dimension varies, scenarios fixed in the others). The group
+     * name lists the pinned scenarios in dimension order, omitting the varying dimension's slot.
+     *
+     * <p>Example: with scenarios {@code [a1, a2] × [b1, b2] × [c1, c2]} and prefix {@code matrix},
+     * pinning {@code a1, b1} (cc varies) emits {@code matrix_a1_b1 = [matrix_a1_b1_c1, matrix_a1_b1_c2]};
+     * pinning {@code a1, c1} (daemon varies) emits {@code matrix_a1_c1 = [matrix_a1_b1_c1, matrix_a1_b2_c1]}.
+     */
+    private static void generateFixAllButOneGroups(
+        String prefix,
+        String nameSep,
+        List<Dimension> dimensions,
+        List<List<String>> tuples,
+        List<String> tupleNames,
+        Map<String, List<String>> additionalGroups,
+        File scenarioFile
+    ) {
+        int dimensionCount = dimensions.size();
+        for (int varying = 0; varying < dimensionCount; varying++) {
+            List<List<String>> fixedScenariosByDim = new ArrayList<>(dimensionCount);
+            for (int d = 0; d < dimensionCount; d++) {
+                fixedScenariosByDim.add(d == varying ? Collections.singletonList(null) : dimensions.get(d).scenarios());
+            }
+            for (List<String> assignment : cartesianProduct(fixedScenariosByDim)) {
+                StringBuilder groupName = new StringBuilder(prefix);
+                for (String scenario : assignment) {
+                    if (scenario != null) {
+                        groupName.append(nameSep).append(scenario);
+                    }
+                }
+                List<String> members = new ArrayList<>();
+                for (int t = 0; t < tuples.size(); t++) {
+                    boolean match = true;
+                    for (int d = 0; d < dimensionCount; d++) {
+                        String pinned = assignment.get(d);
+                        if (pinned != null && !pinned.equals(tuples.get(t).get(d))) {
+                            match = false;
+                            break;
+                        }
+                    }
+                    if (match) {
+                        members.add(tupleNames.get(t));
+                    }
+                }
+                putGroup(additionalGroups, groupName.toString(), members, scenarioFile);
+            }
+        }
+    }
+
+    /** Same name + same members is a no-op; same name + different members fails. */
+    private static void putGroup(Map<String, List<String>> groups, String groupName, List<String> members, File scenarioFile) {
+        List<String> previous = groups.putIfAbsent(groupName, members);
+        if (previous != null && !previous.equals(members)) {
+            throw fail(scenarioFile, "Synthesized scenario group '" + groupName + "' produced twice with different members (likely two dimensions share a scenario name)");
+        }
+    }
+
+    /**
+     * Builds the title of a synthesized scenario by joining the matrix title prefix with each scenario's title
+     * (or the scenario's name if it has no {@code title}) using {@code titleSep}. Returns {@code null} when
+     * nothing carries a title — the caller then leaves {@code title} unset so {@code ScenarioDefinition.getTitle()}
+     * falls back to the synthesized scenario name.
+     *
+     * <p>{@code matrixTitle} controls the prefix segment in three states:
+     * <ul>
+     *   <li>{@code null} — {@code title} wasn't set; use {@code prefix} (the matrix key).</li>
+     *   <li>{@code ""}   — user wrote {@code title = ""}; omit the prefix segment entirely.</li>
+     *   <li>non-empty   — use it verbatim.</li>
+     * </ul>
+     *
+     * <p>Examples with {@code titleSep = ". "}, scenarios {@code [a, b]}, scenario titles {@code "Alpha"} / {@code "Beta"}:
+     * <ul>
+     *   <li>{@code matrixTitle = "Matrix"} → {@code "Matrix. Alpha. Beta"}</li>
+     *   <li>{@code matrixTitle = null}, prefix {@code "matrix"} → {@code "matrix. Alpha. Beta"}</li>
+     *   <li>{@code matrixTitle = ""}     → {@code "Alpha. Beta"}</li>
+     * </ul>
+     */
+    private static String composeTitle(Config rootConfig, String matrixTitle, String prefix, List<String> tuple, String titleSep) {
+        boolean anyTitle = matrixTitle != null;
+        List<String> scenarioTitles = new ArrayList<>(tuple.size());
+        for (String scenario : tuple) {
+            Config component = rootConfig.getConfig(quote(scenario));
+            if (component.hasPath(TITLE)) {
+                anyTitle = true;
+                scenarioTitles.add(component.getString(TITLE));
+            } else {
+                scenarioTitles.add(scenario);
+            }
+        }
+        if (!anyTitle) {
+            return null;
+        }
+        String prefixSegment = matrixTitle != null ? matrixTitle : prefix;
+        StringBuilder titleBuilder = new StringBuilder();
+        if (!prefixSegment.isEmpty()) {
+            titleBuilder.append(prefixSegment);
+        }
+        for (String scenarioTitle : scenarioTitles) {
+            if (titleBuilder.length() > 0) {
+                titleBuilder.append(titleSep);
+            }
+            titleBuilder.append(scenarioTitle);
+        }
+        return titleBuilder.toString();
+    }
+
+    /**
+     * Reads the {@code dimensions} list from a matrix entry, validating its shape and every scenario
+     * reference. Returns the dimensions in declaration order.
+     *
+     * <p>Each dimension is an object with two required keys, for example:
+     * <pre>
+     * { name = daemon, scenarios = [cold, warm] }
+     * </pre>
+     * The {@code name} field is used in error messages and for the duplicate-dimension check; it does
+     * not appear in synthesized scenario names or group names.
+     */
+    private static List<Dimension> parseDimensions(Config entry, String prefix, Config rootConfig, Set<String> matrixKeys, File scenarioFile) {
+        ConfigValue dimensionsValue = entry.getValue(DIMENSIONS);
+        if (dimensionsValue.valueType() != ConfigValueType.LIST) {
+            throw fail(scenarioFile, "Matrix '" + prefix + "." + DIMENSIONS + "' must be a list of dimensions");
+        }
+        List<? extends ConfigObject> dimensionObjects;
+        try {
+            dimensionObjects = entry.getObjectList(DIMENSIONS);
+        } catch (Exception ex) {
+            throw fail(scenarioFile, "Matrix '" + prefix + "." + DIMENSIONS + "' must be a list of objects with 'name' and 'scenarios' keys");
+        }
+        if (dimensionObjects.isEmpty()) {
+            throw fail(scenarioFile, "Matrix '" + prefix + "." + DIMENSIONS + "' must declare at least one dimension");
+        }
+        List<Dimension> dimensions = new ArrayList<>(dimensionObjects.size());
+        Set<String> seenDimensionNames = new LinkedHashSet<>();
+        for (int i = 0; i < dimensionObjects.size(); i++) {
+            Config dim = dimensionObjects.get(i).toConfig();
+            String dimLocation = prefix + "." + DIMENSIONS + "[" + i + "]";
+            for (String key : dim.root().keySet()) {
+                if (!DIMENSION_KEYS.contains(key)) {
+                    throw fail(scenarioFile, "Unrecognized key '" + dimLocation + "." + key + "'. Allowed keys: " + String.join(", ", DIMENSION_KEYS));
+                }
+            }
+            if (!dim.hasPath(NAME)) {
+                throw fail(scenarioFile, "Dimension '" + dimLocation + "' must define a 'name'");
+            }
+            String dimName = dim.getString(NAME);
+            if (!seenDimensionNames.add(dimName)) {
+                throw fail(scenarioFile, "Matrix '" + prefix + "' declares dimension '" + dimName + "' more than once");
+            }
+            if (!dim.hasPath(SCENARIOS)) {
+                throw fail(scenarioFile, "Dimension '" + prefix + "." + dimName + "' must define a 'scenarios' list");
+            }
+            List<String> dimensionScenarios;
+            try {
+                dimensionScenarios = dim.getStringList(SCENARIOS);
+            } catch (Exception ex) {
+                throw fail(scenarioFile, "Dimension '" + prefix + "." + dimName + ".scenarios' must be a list of scenario names");
+            }
+            if (dimensionScenarios.isEmpty()) {
+                throw fail(scenarioFile, "Dimension '" + prefix + "." + dimName + ".scenarios' must list at least one scenario");
+            }
+            for (String scenario : dimensionScenarios) {
+                validateScenarioRef(scenario, prefix, rootConfig, matrixKeys, scenarioFile);
+            }
+            dimensions.add(new Dimension(dimName, dimensionScenarios));
+        }
+        return dimensions;
+    }
+
+    private static void validateScenarioRef(String scenario, String prefix, Config rootConfig, Set<String> matrixKeys, File scenarioFile) {
+        if (ScenarioLoader.RESERVED_TOP_LEVEL_KEYS.contains(scenario)) {
+            throw fail(scenarioFile, "Matrix '" + prefix + "' references reserved key '" + scenario + "'");
+        }
+        if (matrixKeys.contains(scenario)) {
+            throw fail(scenarioFile, "Matrix '" + prefix + "' references another matrix '" + scenario + "'; matrices referencing matrices is not supported");
+        }
+        if (!rootConfig.hasPath(quote(scenario))) {
+            throw fail(scenarioFile, "Matrix '" + prefix + "' references unknown scenario '" + scenario + "'");
+        }
+    }
+
+    /**
+     * Cartesian product over a list of axes, preserving declaration order.
+     *
+     * <p>Example: {@code [[a1, a2], [b1, b2]]} → {@code [[a1, b1], [a1, b2], [a2, b1], [a2, b2]]}.
+     *
+     * <p>Used both for synthesizing tuples and (with {@code null} sentinels in the "varying" slot)
+     * for enumerating fix-all-but-one group assignments.
+     */
+    private static List<List<String>> cartesianProduct(List<List<String>> dimensions) {
+        List<List<String>> result = new ArrayList<>();
+        result.add(new ArrayList<>());
+        for (List<String> dim : dimensions) {
+            List<List<String>> next = new ArrayList<>();
+            for (List<String> prev : result) {
+                for (String value : dim) {
+                    List<String> extended = new ArrayList<>(prev);
+                    extended.add(value);
+                    next.add(extended);
+                }
+            }
+            result = next;
+        }
+        return result;
+    }
+
+    private static String quote(String key) {
+        // Quote HOCON path segments so names containing dots or other special characters aren't treated as paths.
+        return "\"" + key.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+    }
+
+    private static IllegalArgumentException fail(File scenarioFile, String message) {
+        return new IllegalArgumentException(message + " in scenario file " + scenarioFile);
+    }
+
+    private record Dimension(String name, List<String> scenarios) {
+    }
+}

--- a/src/test/groovy/org/gradle/profiler/ScenarioMatricesIntegrationTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioMatricesIntegrationTest.groovy
@@ -1,0 +1,377 @@
+package org.gradle.profiler
+
+import org.gradle.profiler.fixtures.AbstractProfilerIntegrationTest
+import org.gradle.profiler.fixtures.file.LeaksFileHandles
+
+// https://github.com/gradle/gradle-profiler/issues/714
+@LeaksFileHandles({ OperatingSystem.isWindows() && it.name == "native-platform.dll" })
+class ScenarioMatricesIntegrationTest extends AbstractProfilerIntegrationTest {
+
+    def "synthesized scenarios are selectable by default, by name, and via auto-generated group"() {
+        given:
+        def scenarioFile = writeScenarioFile("""
+            workflowA { tasks = ["help"] }
+            workflowB { tasks = ["help"] }
+            cold { daemon = cold }
+            warm { daemon = warm }
+            standalone { tasks = ["help"] }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = workflow, scenarios = [workflowA, workflowB] }
+                        { name = daemon,   scenarios = [cold, warm] }
+                    ]
+                }
+            }
+        """)
+        buildFile.text = "apply plugin: BasePlugin"
+
+        when: "no selection — every synthesized and component scenario runs"
+        runProfiler(scenarioFile)
+
+        then:
+        outputFile("matrix_workflowA_cold").directory
+        outputFile("matrix_workflowA_warm").directory
+        outputFile("matrix_workflowB_cold").directory
+        outputFile("matrix_workflowB_warm").directory
+        outputFile("workflowA").directory
+        outputFile("workflowB").directory
+        outputFile("standalone").directory
+
+        when: "--group selects the fix-one auto-group"
+        resetOutputDir()
+        runProfiler(scenarioFile, "--group", "matrix_workflowA")
+
+        then:
+        outputFile("matrix_workflowA_cold").directory
+        outputFile("matrix_workflowA_warm").directory
+        !outputFile("matrix_workflowB_cold").directory
+        !outputFile("matrix_workflowB_warm").directory
+
+        when: "positional targets mix a synthesized scenario and a hand-written one"
+        resetOutputDir()
+        runProfiler(scenarioFile, "matrix_workflowA_cold", "standalone")
+
+        then:
+        outputFile("matrix_workflowA_cold").directory
+        outputFile("standalone").directory
+        !outputFile("matrix_workflowA_warm").directory
+        !outputFile("matrix_workflowB_cold").directory
+    }
+
+    def "a fix-all-but-one auto-group runs the variants of a single dimension"() {
+        given:
+        def scenarioFile = writeScenarioFile("""
+            workflowA { tasks = ["help"] }
+            workflowB { tasks = ["help"] }
+            tagSmoke   { system-properties { "test.tag" = "smoke"   } }
+            tagRelease { system-properties { "test.tag" = "release" } }
+            ccOn  { system-properties { "org.gradle.configuration-cache" = "true"  } }
+            ccOff { system-properties { "org.gradle.configuration-cache" = "false" } }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = workflow, scenarios = [workflowA, workflowB] }
+                        { name = tag,      scenarios = [tagSmoke, tagRelease] }
+                        { name = cc,       scenarios = [ccOn, ccOff] }
+                    ]
+                }
+            }
+        """)
+        buildFile.text = "apply plugin: BasePlugin"
+
+        when:
+        runProfiler(scenarioFile, "--group", "matrix_workflowA_ccOn")
+
+        then:
+        outputFile("matrix_workflowA_tagSmoke_ccOn").directory
+        outputFile("matrix_workflowA_tagRelease_ccOn").directory
+        !outputFile("matrix_workflowA_tagSmoke_ccOff").directory
+        !outputFile("matrix_workflowB_tagRelease_ccOn").directory
+    }
+
+    def "system-properties merge across picked scenarios and reach the build (maps merge recursively)"() {
+        given:
+        def scenarioFile = writeScenarioFile('''
+            left {
+                tasks = ["help"]
+                system-properties {
+                    "shared.key" = "left-wins-if-alone"
+                    "left-only"  = "L"
+                }
+            }
+            right {
+                system-properties {
+                    "shared.key" = "right-overrides"
+                    "right-only" = "R"
+                }
+            }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = l, scenarios = [left] }
+                        { name = r, scenarios = [right] }
+                    ]
+                }
+            }
+        ''')
+        buildFile.text = """
+            apply plugin: BasePlugin
+            println "<shared: " + System.getProperty("shared.key") + ">"
+            println "<left-only: " + System.getProperty("left-only") + ">"
+            println "<right-only: " + System.getProperty("right-only") + ">"
+        """
+
+        when:
+        runProfiler(scenarioFile, "matrix_left_right")
+
+        then:
+        logFile.find("<shared: right-overrides>").size() >= 1
+        logFile.find("<left-only: L>").size() >= 1
+        logFile.find("<right-only: R>").size() >= 1
+        !logFile.find("<shared: left-wins-if-alone>")
+    }
+
+    def "later dimension's scenario fully replaces earlier scenario's array values (arrays do not merge)"() {
+        given:
+        def scenarioFile = writeScenarioFile('''
+            left  { tasks = ["assemble", "check"] }
+            right { tasks = ["help"] }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = l, scenarios = [left] }
+                        { name = r, scenarios = [right] }
+                    ]
+                }
+            }
+        ''')
+        buildFile.text = """
+            apply plugin: BasePlugin
+            println "<tasks: " + gradle.startParameter.taskNames + ">"
+        """
+
+        when:
+        runProfiler(scenarioFile, "matrix_left_right")
+
+        then:
+        logFile.find("<tasks: [help]>").size() >= 1
+        !logFile.find("<tasks: [assemble, check, help]>")
+        !logFile.find("<tasks: [assemble, check]>")
+    }
+
+    def "later dimension's scenario overrides earlier scenario's primitive (daemon mode)"() {
+        given:
+        def scenarioFile = writeScenarioFile('''
+            warmFirst {
+                tasks = ["help"]
+                daemon = warm
+            }
+            coldSecond { daemon = cold }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = a, scenarios = [warmFirst] }
+                        { name = b, scenarios = [coldSecond] }
+                    ]
+                }
+            }
+        ''')
+        buildFile.text = "apply plugin: BasePlugin"
+
+        when:
+        runProfiler(scenarioFile, "matrix_warmFirst_coldSecond")
+
+        then:
+        // The profile log surfaces the resolved invoker for each scenario via "Run using:".
+        logFile.find("Run using: Tooling API with cold daemon").size() >= 1
+        !logFile.find("Run using: Tooling API with warm daemon")
+    }
+
+    def "name and title concatenation honor #separatorKind separators"() {
+        given:
+        def scenarioFile = writeScenarioFile("""
+            workflowA {
+                title = "Workflow A"
+                tasks = ["help"]
+            }
+            coldDaemon {
+                title = "Cold Daemon"
+                daemon = cold
+            }
+            standalone { tasks = ["help"] }
+            scenario-matrices {
+                matrix {
+                    title = "Matrix"
+                    ${separatorConfig}
+                    dimensions = [
+                        { name = workflow, scenarios = [workflowA] }
+                        { name = daemon,   scenarios = [coldDaemon] }
+                    ]
+                }
+            }
+        """)
+        buildFile.text = "apply plugin: BasePlugin"
+
+        when:
+        // Run with a second scenario so per-scenario subdirs are created (the profiler uses outputDir directly when only one scenario runs).
+        runProfiler(scenarioFile, expectedScenarioName, "standalone")
+
+        then:
+        outputFile(expectedScenarioName).directory
+        logFile.find("Running scenario ${expectedTitle}").size() >= 1
+
+        where:
+        separatorKind | separatorConfig   | expectedScenarioName          | expectedTitle
+        "default"     | ""                | "matrix_workflowA_coldDaemon" | "Matrix. Workflow A. Cold Daemon"
+        "custom"      | CUSTOM_SEPARATORS | "matrix-workflowA-coldDaemon" | "Matrix | Workflow A | Cold Daemon"
+    }
+
+    def "--dump-scenarios renders both synthesized and picked scenarios with composed values"() {
+        given:
+        def scenarioFile = writeScenarioFile('''
+            workflowA {
+                title = "Workflow A"
+                tasks = ["assemble"]
+                system-properties {
+                    "x" = "1"
+                }
+            }
+            coldDaemon {
+                title = "Cold Daemon"
+                daemon = cold
+                system-properties {
+                    "y" = "2"
+                }
+            }
+            scenario-matrices {
+                matrix {
+                    title = "Matrix"
+                    dimensions = [
+                        { name = workflow, scenarios = [workflowA] }
+                        { name = daemon,   scenarios = [coldDaemon] }
+                    ]
+                }
+            }
+        ''')
+
+        when:
+        dumpScenarios(scenarioFile)
+
+        then:
+        def out = output
+        // Synthesized scenario carries merged values from both scenarios.
+        out.contains("matrix_workflowA_coldDaemon {")
+        out.contains('title="Matrix. Workflow A. Cold Daemon"')
+        out.contains("daemon=cold")
+        out.contains("assemble")
+        out.contains('x="1"')
+        out.contains('y="2"')
+        // Picked scenarios remain individually dumpable.
+        out.contains("workflowA {")
+        out.contains("coldDaemon {")
+        // The scenario-matrices block is consumed by expansion and does not appear in the dump.
+        !out.contains("scenario-matrices")
+        !out.contains("dimensions")
+    }
+
+    def "synthesized scenarios are referenceable from #selectionMechanism"() {
+        given:
+        def scenarioFile = writeScenarioFile("""
+            a { tasks = ["help"] }
+            b { tasks = ["help"] }
+            other { tasks = ["help"] }
+            ${selectionConfig}
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = l, scenarios = [a] }
+                        { name = r, scenarios = [b] }
+                    ]
+                }
+            }
+        """)
+        buildFile.text = "apply plugin: BasePlugin"
+
+        when:
+        runProfiler(scenarioFile, extraArgs as String[])
+
+        then:
+        outputFile("matrix_a_b").directory
+        outputFile("other").directory
+        !outputFile("a").directory
+        !outputFile("b").directory
+
+        where:
+        selectionMechanism  | selectionConfig                                       | extraArgs
+        "default-scenarios" | 'default-scenarios = ["matrix_a_b", "other"]'         | []
+        "scenario-groups"   | 'scenario-groups { smoke = ["matrix_a_b", "other"] }' | ["--group", "smoke"]
+    }
+
+    def "--dump-scenarios reports a clear error for malformed scenario-matrices"() {
+        given:
+        def scenarioFile = writeScenarioFile("""
+            a { tasks = ["a"] }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = l, scenarios = [a] }
+                        { name = r, scenarios = [does_not_exist] }
+                    ]
+                }
+            }
+        """)
+
+        when:
+        dumpScenarios(scenarioFile)
+
+        then:
+        def ex = thrown(IllegalArgumentException)
+        ex.message.contains("does_not_exist")
+        ex.message.contains("matrix")
+    }
+
+    // --- helpers ---
+
+    private File writeScenarioFile(String body) {
+        def f = file("benchmark.conf")
+        f.text = body
+        return f
+    }
+
+    /** Run the profiler in dry-run mode against the latest supported Gradle. */
+    private void runProfiler(File scenarioFile, String... extraArgs) {
+        def args = [
+            "--project-dir", projectDir.absolutePath,
+            "--output-dir", outputDir.absolutePath,
+            "--gradle-version", latestSupportedGradleVersion,
+            "--scenario-file", scenarioFile.absolutePath,
+            "--benchmark",
+            "--dry-run",
+        ]
+        args.addAll(extraArgs as List)
+        new Main().run(args as String[])
+    }
+
+    /** Clear the output directory between runs in tests that exercise multiple invocations. */
+    private void resetOutputDir() {
+        outputDir.deleteDir()
+        outputDir.mkdirs()
+    }
+
+    /** Invoke --dump-scenarios; no build is executed. */
+    private static void dumpScenarios(File scenarioFile, String... extraArgs) {
+        def args = [
+            "--benchmark",
+            "--scenario-file", scenarioFile.absolutePath,
+            "--dump-scenarios",
+        ]
+        args.addAll(extraArgs as List)
+        new Main().run(args as String[])
+    }
+
+    private static final String CUSTOM_SEPARATORS = '''
+        name-separator = "-"
+        title-separator = " | "
+    '''
+}

--- a/src/test/groovy/org/gradle/profiler/ScenarioMatricesTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/ScenarioMatricesTest.groovy
@@ -1,0 +1,697 @@
+package org.gradle.profiler
+
+import com.typesafe.config.Config
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class ScenarioMatricesTest extends Specification {
+    @Rule
+    TemporaryFolder tmpDir = new TemporaryFolder()
+
+    File scenarioFile
+
+    def setup() {
+        scenarioFile = tmpDir.newFile("scenarios.conf")
+    }
+
+    def "leaves config unchanged when no scenario-matrices block"() {
+        when:
+        def expanded = expand("""
+            a { tasks = ["a"] }
+            b { tasks = ["b"] }
+        """)
+
+        then:
+        topLevelScenarioKeys(expanded) == ["a", "b"] as Set
+        !expanded.hasPath("scenario-matrices")
+    }
+
+    def "expands a 2x2 cartesian product and emits fix-one auto-groups"() {
+        given:
+        def config = """
+            a1 { tasks = ["a1"] }
+            a2 { tasks = ["a2"] }
+            b1 { tasks = ["b1"] }
+            b2 { tasks = ["b2"] }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = left,  scenarios = [a1, a2] }
+                        { name = right, scenarios = [b1, b2] }
+                    ]
+                }
+            }
+        """
+
+        when:
+        def expanded = expand(config)
+
+        then:
+        topLevelScenarioKeys(expanded) == [
+            "a1", "a2", "b1", "b2",
+            "matrix_a1_b1", "matrix_a1_b2", "matrix_a2_b1", "matrix_a2_b2",
+        ] as Set
+
+        and: "one fix-one auto-group per scenario, fixing that scenario"
+        def groups = expanded.getConfig("scenario-groups")
+        groups.getStringList("matrix_a1") == ["matrix_a1_b1", "matrix_a1_b2"]
+        groups.getStringList("matrix_a2") == ["matrix_a2_b1", "matrix_a2_b2"]
+        groups.getStringList("matrix_b1") == ["matrix_a1_b1", "matrix_a2_b1"]
+        groups.getStringList("matrix_b2") == ["matrix_a1_b2", "matrix_a2_b2"]
+    }
+
+    def "expands 3 dimensions producing 2x2x2 = 8 scenarios"() {
+        when:
+        def expanded = expand("""
+            a1 {}
+            a2 {}
+            b1 {}
+            b2 {}
+            c1 {}
+            c2 {}
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = x, scenarios = [a1, a2] }
+                        { name = y, scenarios = [b1, b2] }
+                        { name = z, scenarios = [c1, c2] }
+                    ]
+                }
+            }
+        """)
+
+        then:
+        def synthesized = topLevelScenarioKeys(expanded).findAll { it.startsWith("matrix_") }
+        synthesized as Set == [
+            "matrix_a1_b1_c1", "matrix_a1_b1_c2",
+            "matrix_a1_b2_c1", "matrix_a1_b2_c2",
+            "matrix_a2_b1_c1", "matrix_a2_b1_c2",
+            "matrix_a2_b2_c1", "matrix_a2_b2_c2",
+        ] as Set
+    }
+
+    def "dimension order in the list controls dimension order in synthesized names"() {
+        when:
+        def expanded = expand("""
+            a {}
+            b {}
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = right, scenarios = [b] }
+                        { name = left,  scenarios = [a] }
+                    ]
+                }
+            }
+        """)
+
+        then:
+        // The 'right' dimension is declared first, so its scenario (b) appears first in the synthesized name.
+        topLevelScenarioKeys(expanded).contains("matrix_b_a")
+        !topLevelScenarioKeys(expanded).contains("matrix_a_b")
+    }
+
+    def "later dimensions win on conflicts (fold-right withFallback)"() {
+        when:
+        def expanded = expand("""
+            a { daemon = warm }
+            b { daemon = cold }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = left,  scenarios = [a] }
+                        { name = right, scenarios = [b] }
+                    ]
+                }
+            }
+        """)
+
+        then:
+        expanded.getConfig("matrix_a_b").getString("daemon") == "cold"
+    }
+
+    def "maps merge recursively across picked scenarios"() {
+        when:
+        def expanded = expand('''
+            a {
+                system-properties {
+                    x = "1"
+                    y = "2"
+                }
+            }
+            b {
+                system-properties {
+                    y = "20"
+                    z = "3"
+                }
+            }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = left,  scenarios = [a] }
+                        { name = right, scenarios = [b] }
+                    ]
+                }
+            }
+        ''')
+
+        then:
+        def sp = expanded.getConfig("matrix_a_b").getConfig("system-properties")
+        sp.getString("x") == "1"
+        sp.getString("y") == "20"
+        sp.getString("z") == "3"
+    }
+
+    def "arrays are replaced not merged (later wins)"() {
+        when:
+        def expanded = expand("""
+            a { jvm-args = ["-Xmx1g", "-Da=1"] }
+            b { jvm-args = ["-Xmx2g"] }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = left,  scenarios = [a] }
+                        { name = right, scenarios = [b] }
+                    ]
+                }
+            }
+        """)
+
+        then:
+        expanded.getStringList("matrix_a_b.jvm-args") == ["-Xmx2g"]
+    }
+
+    def "mutator keys at distinct paths compose freely"() {
+        when:
+        def expanded = expand("""
+            workflow { apply-abi-change-to = "Foo.java" }
+            cache { clear-build-cache-before = SCENARIO }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = w, scenarios = [workflow] }
+                        { name = c, scenarios = [cache] }
+                    ]
+                }
+            }
+        """)
+
+        then:
+        def merged = expanded.getConfig("matrix_workflow_cache")
+        merged.getString("apply-abi-change-to") == "Foo.java"
+        merged.getString("clear-build-cache-before") == "SCENARIO"
+    }
+
+    def "title composition: #description"() {
+        when:
+        def expanded = expand("""
+            a $aBody
+            b $bBody
+            scenario-matrices {
+                matrix {
+                    $matrixTitle
+                    dimensions = [
+                        { name = left,  scenarios = [a] }
+                        { name = right, scenarios = [b] }
+                    ]
+                }
+            }
+        """)
+
+        then:
+        def synthesized = expanded.getConfig("matrix_a_b")
+        if (expectedTitle == null) {
+            assert !synthesized.hasPath("title")
+        } else {
+            assert synthesized.getString("title") == expectedTitle
+        }
+
+        where:
+        description                                  | aBody                 | bBody                | matrixTitle        | expectedTitle
+        "explicit matrix and scenario titles compose"    | '{ title = "Alpha" }' | '{ title = "Beta" }' | 'title = "Matrix"' | "Matrix. Alpha. Beta"
+        "missing scenario title falls back to scenario name" | '{}'                  | '{ title = "Beta" }' | ''                 | "matrix. a. Beta"
+        "no titles anywhere leaves title unset"      | '{}'                  | '{}'                 | ''                 | null
+        "empty matrix title omits the prefix segment"| '{ title = "Alpha" }' | '{ title = "Beta" }' | 'title = ""'       | "Alpha. Beta"
+        "empty matrix title with one scenario lacking a title" | '{}'           | '{ title = "Beta" }' | 'title = ""'       | "a. Beta"
+    }
+
+    def "honors custom name and title separators"() {
+        when:
+        def expanded = expand('''
+            a { title = "A" }
+            b { title = "B" }
+            scenario-matrices {
+                matrix {
+                    name-separator = "-"
+                    title-separator = " | "
+                    dimensions = [
+                        { name = left,  scenarios = [a] }
+                        { name = right, scenarios = [b] }
+                    ]
+                }
+            }
+        ''')
+
+        then:
+        topLevelScenarioKeys(expanded).contains("matrix-a-b")
+        expanded.getString("\"matrix-a-b\".title") == "matrix | A | B"
+    }
+
+    def "auto-generates fix-all-but-one groups for N>=3 dimensions"() {
+        when:
+        def expanded = expand("""
+            a1 {}
+            a2 {}
+            b1 {}
+            b2 {}
+            c1 {}
+            c2 {}
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = workflow, scenarios = [a1, a2] }
+                        { name = daemon,   scenarios = [b1, b2] }
+                        { name = cc,       scenarios = [c1, c2] }
+                    ]
+                }
+            }
+        """)
+
+        then:
+        def groups = expanded.getConfig("scenario-groups")
+        // Fix-all-but-one: pin workflow+daemon, vary cc.
+        groups.getStringList("matrix_a1_b1") == ["matrix_a1_b1_c1", "matrix_a1_b1_c2"]
+        groups.getStringList("matrix_a2_b2") == ["matrix_a2_b2_c1", "matrix_a2_b2_c2"]
+        // Pin workflow+cc, vary daemon (declaration order preserved, daemon slot omitted).
+        groups.getStringList("matrix_a1_c1") == ["matrix_a1_b1_c1", "matrix_a1_b2_c1"]
+        groups.getStringList("matrix_a2_c2") == ["matrix_a2_b1_c2", "matrix_a2_b2_c2"]
+        // Pin daemon+cc, vary workflow.
+        groups.getStringList("matrix_b1_c1") == ["matrix_a1_b1_c1", "matrix_a2_b1_c1"]
+        groups.getStringList("matrix_b2_c2") == ["matrix_a1_b2_c2", "matrix_a2_b2_c2"]
+        // Fix-one groups still exist alongside.
+        groups.getStringList("matrix_a1").size() == 4
+        groups.getStringList("matrix_c2").size() == 4
+    }
+
+    def "for a single-dimension matrix emits one fix-one group per scenario"() {
+        when:
+        def expanded = expand("""
+            a1 {}
+            a2 {}
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = workflow, scenarios = [a1, a2] }
+                    ]
+                }
+            }
+        """)
+
+        then:
+        def groups = expanded.getConfig("scenario-groups")
+        groups.root().keySet() as Set == ["matrix_a1", "matrix_a2"] as Set
+        groups.getStringList("matrix_a1") == ["matrix_a1"]
+        groups.getStringList("matrix_a2") == ["matrix_a2"]
+    }
+
+    def "for a 2-dimension matrix fix-one and fix-all-but-one auto-groups coincide (no duplicates)"() {
+        when:
+        def expanded = expand("""
+            a1 {}
+            a2 {}
+            b1 {}
+            b2 {}
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = workflow, scenarios = [a1, a2] }
+                        { name = daemon,   scenarios = [b1, b2] }
+                    ]
+                }
+            }
+        """)
+
+        then:
+        def groups = expanded.getConfig("scenario-groups")
+        groups.root().keySet() as Set == [
+            "matrix_a1", "matrix_a2", "matrix_b1", "matrix_b2",
+        ] as Set
+    }
+
+    def "two matrices produce disjoint synthesized scenarios"() {
+        when:
+        def expanded = expand("""
+            a {}
+            b {}
+            c {}
+            d {}
+            scenario-matrices {
+                first {
+                    dimensions = [
+                        { name = l, scenarios = [a] }
+                        { name = r, scenarios = [b] }
+                    ]
+                }
+                second {
+                    dimensions = [
+                        { name = l, scenarios = [c] }
+                        { name = r, scenarios = [d] }
+                    ]
+                }
+            }
+        """)
+
+        then:
+        def keys = topLevelScenarioKeys(expanded)
+        keys.contains("first_a_b")
+        keys.contains("second_c_d")
+    }
+
+    def "preserves existing scenarios alongside synthesized ones"() {
+        when:
+        def expanded = expand("""
+            a {}
+            b {}
+            handwritten { tasks = ["help"] }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = l, scenarios = [a] }
+                        { name = r, scenarios = [b] }
+                    ]
+                }
+            }
+        """)
+
+        then:
+        def keys = topLevelScenarioKeys(expanded)
+        keys.contains("handwritten")
+        keys.contains("matrix_a_b")
+    }
+
+    def "preserves existing scenario-groups and merges synthesized ones"() {
+        when:
+        def expanded = expand("""
+            a {}
+            b {}
+            other {}
+            scenario-groups {
+                preexisting = [other]
+            }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = l, scenarios = [a] }
+                        { name = r, scenarios = [b] }
+                    ]
+                }
+            }
+        """)
+
+        then:
+        def groups = expanded.getConfig("scenario-groups")
+        groups.getStringList("preexisting") == ["other"]
+        groups.getStringList("matrix_a") == ["matrix_a_b"]
+        groups.getStringList("matrix_b") == ["matrix_a_b"]
+    }
+
+    def "rejects unknown scenario reference"() {
+        expect:
+        expansionFailureFor('''
+            a {}
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = l, scenarios = [a] }
+                        { name = r, scenarios = [missing] }
+                    ]
+                }
+            }
+        ''') == "Matrix 'matrix' references unknown scenario 'missing'"
+    }
+
+    def "rejects scenario reference to a reserved key"() {
+        expect:
+        expansionFailureFor('''
+            a {}
+            scenario-groups { g = [a] }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = l, scenarios = [a] }
+                        { name = r, scenarios = ["scenario-groups"] }
+                    ]
+                }
+            }
+        ''') == "Matrix 'matrix' references reserved key 'scenario-groups'"
+    }
+
+    def "rejects scenario reference to another matrix key"() {
+        expect:
+        expansionFailureFor('''
+            a {}
+            b {}
+            scenario-matrices {
+                first {
+                    dimensions = [
+                        { name = l, scenarios = [a] }
+                        { name = r, scenarios = [b] }
+                    ]
+                }
+                second {
+                    dimensions = [
+                        { name = l, scenarios = [a] }
+                        { name = r, scenarios = [first] }
+                    ]
+                }
+            }
+        ''') == "Matrix 'second' references another matrix 'first'; matrices referencing matrices is not supported"
+    }
+
+    def "rejects synthesized scenario name colliding with existing top-level scenario"() {
+        expect:
+        expansionFailureFor('''
+            a {}
+            b {}
+            "matrix_a_b" { tasks = ["already"] }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = l, scenarios = [a] }
+                        { name = r, scenarios = [b] }
+                    ]
+                }
+            }
+        ''') == "Synthesized scenario name 'matrix_a_b' collides with an existing top-level entry"
+    }
+
+    def "rejects synthesized scenario group name colliding with existing group"() {
+        expect:
+        expansionFailureFor('''
+            a {}
+            b {}
+            scenario-groups {
+                "matrix_a" = [a]
+            }
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = l, scenarios = [a] }
+                        { name = r, scenarios = [b] }
+                    ]
+                }
+            }
+        ''') == "Synthesized scenario group 'matrix_a' collides with an existing scenario-groups entry"
+    }
+
+    def "rejects empty scenarios list in a dimension"() {
+        expect:
+        expansionFailureFor('''
+            a {}
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = l, scenarios = [a] }
+                        { name = r, scenarios = [] }
+                    ]
+                }
+            }
+        ''') == "Dimension 'matrix.r.scenarios' must list at least one scenario"
+    }
+
+    def "rejects missing dimensions list on a matrix entry"() {
+        expect:
+        expansionFailureFor('''
+            scenario-matrices {
+                matrix {
+                    name-separator = "_"
+                }
+            }
+        ''') == "Matrix 'matrix' must define a 'dimensions' list"
+    }
+
+    def "rejects dimensions that is not a list"() {
+        expect:
+        expansionFailureFor('''
+            a {}
+            scenario-matrices {
+                matrix {
+                    dimensions { l = [a] }
+                }
+            }
+        ''') == "Matrix 'matrix.dimensions' must be a list of dimensions"
+    }
+
+    def "rejects dimension missing a name"() {
+        expect:
+        expansionFailureFor('''
+            a {}
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { scenarios = [a] }
+                    ]
+                }
+            }
+        ''') == "Dimension 'matrix.dimensions[0]' must define a 'name'"
+    }
+
+    def "rejects dimension missing a scenarios list"() {
+        expect:
+        expansionFailureFor('''
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = lonely }
+                    ]
+                }
+            }
+        ''') == "Dimension 'matrix.lonely' must define a 'scenarios' list"
+    }
+
+    def "rejects two dimensions sharing a name"() {
+        expect:
+        expansionFailureFor('''
+            a {}
+            b {}
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = dup, scenarios = [a] }
+                        { name = dup, scenarios = [b] }
+                    ]
+                }
+            }
+        ''') == "Matrix 'matrix' declares dimension 'dup' more than once"
+    }
+
+    def "rejects unknown key inside a dimension"() {
+        when:
+        def message = expansionFailureFor('''
+            a {}
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = l, scenarios = [a], typo = true }
+                    ]
+                }
+            }
+        ''')
+
+        then:
+        // 'Allowed keys: …' lists the entries of an unordered Set, so only the prefix is stable.
+        message.startsWith("Unrecognized key 'matrix.dimensions[0].typo'. Allowed keys:")
+    }
+
+    def "rejects scenario-matrices that is not an object"() {
+        expect:
+        expansionFailureFor('''
+            scenario-matrices = "oops"
+        ''') == "'scenario-matrices' must be an object mapping matrix names to matrix definitions"
+    }
+
+    def "rejects empty scenario-matrices block"() {
+        expect:
+        expansionFailureFor('''
+            scenario-matrices {}
+        ''') == "'scenario-matrices' is empty — remove it or declare at least one matrix"
+    }
+
+    def "rejects unknown key inside a matrix entry"() {
+        when:
+        def message = expansionFailureFor('''
+            a {}
+            scenario-matrices {
+                matrix {
+                    dimensions = [
+                        { name = l, scenarios = [a] }
+                    ]
+                    dimensoins = "typo"
+                }
+            }
+        ''')
+
+        then:
+        // 'Allowed keys: …' lists the entries of an unordered Set, so only the prefix is stable.
+        message.startsWith("Unrecognized key 'matrix.dimensoins' in 'scenario-matrices'. Allowed keys:")
+    }
+
+    def "rejects empty name-separator"() {
+        expect:
+        expansionFailureFor('''
+            a {}
+            b {}
+            scenario-matrices {
+                matrix {
+                    name-separator = ""
+                    dimensions = [
+                        { name = l, scenarios = [a] }
+                        { name = r, scenarios = [b] }
+                    ]
+                }
+            }
+        ''') == "Matrix 'matrix.name-separator' must not be empty"
+    }
+
+    def "rejects empty dimensions list"() {
+        expect:
+        expansionFailureFor('''
+            scenario-matrices {
+                matrix {
+                    dimensions = []
+                }
+            }
+        ''') == "Matrix 'matrix.dimensions' must declare at least one dimension"
+    }
+
+    def "rejects matrix entry that is not an object"() {
+        expect:
+        expansionFailureFor('''
+            scenario-matrices {
+                matrix = "oops"
+            }
+        ''') == "Matrix 'matrix' must be an object, but got string"
+    }
+
+    private Config expand(String text) {
+        scenarioFile.text = text
+        ScenarioMatrices.expand(ScenarioLoader.parseScenarioFile(scenarioFile), scenarioFile)
+    }
+
+    private static Set<String> topLevelScenarioKeys(Config config) {
+        config.root().keySet().findAll {
+            !(it in ScenarioLoader.RESERVED_TOP_LEVEL_KEYS)
+        } as Set<String>
+    }
+
+    private String expansionFailureFor(String text) {
+        try {
+            expand(text)
+        } catch (IllegalArgumentException ex) {
+            // The full message always ends with " in scenario file <path>"; strip the path so tests don't depend on it.
+            return ex.message.replaceFirst(/ in scenario file .*$/, "")
+        }
+        throw new AssertionError("Expected expansion to throw IllegalArgumentException")
+    }
+}


### PR DESCRIPTION
## Summary

Adds a new top-level `scenario-matrices { }` block to scenario files. Each matrix declares a list of dimensions, each with a list of existing scenarios, and the profiler expands it into one synthesized scenario per tuple of choices — equivalent to what you'd get by hand-merging the picked scenarios with HOCON `${...}` substitution, but without the repetition.

```hocon
assemble { tasks = ["assemble"] }
check    { tasks = ["check"] }
coldDaemon { daemon = cold }
warmDaemon { daemon = warm }
ccOn  { system-properties { "org.gradle.configuration-cache" = "true" } }
ccOff { system-properties { "org.gradle.configuration-cache" = "false" } }

scenario-matrices {
    matrix {
        dimensions = [
            { name = task,   scenarios = [assemble, check] }
            { name = daemon, scenarios = [coldDaemon, warmDaemon] }
            { name = cc,     scenarios = [ccOn, ccOff] }
        ]
    }
}
```

This produces 2 × 2 × 2 = 8 runnable scenarios named `matrix_assemble_coldDaemon_ccOn`, etc.

## Real example

Here is how the IP testbed scenarios can be simplified by removing duplication:
- https://github.com/gradle/isolated-projects-testbed/pull/10

## What you get for free

- **HOCON merge semantics**, applied left-to-right with the rightmost dimension winning on conflicts. Maps merge recursively (`system-properties`, `tooling-api { ... }`); arrays and primitives are replaced (`tasks`, `daemon`); mutators at distinct keys compose freely.
- **Two families of auto-generated `scenario-groups`** for ergonomic selection:
  - *Fix one* — e.g. `--group matrix_coldDaemon` runs the four cold-daemon variants.
  - *Fix all but one* — e.g. `--group matrix_assemble_ccOn` runs the two daemon variants of that otherwise-fixed configuration. (N ≥ 3 only; at N = 2 it coincides with fix-one.)
- **Title composition** via optional `title`, `name-separator`, `title-separator` per matrix. `title = ""` omits the prefix from synthesized titles for brevity.
- **Transparent interop**: synthesized scenarios are valid CLI targets, work in `default-scenarios`, and can be referenced from hand-written `scenario-groups`.
- **Strict, actionable validation**: every error cites the scenario file path and the offending key.

## Design notes

- Implemented as a HOCON pre-processing pass in `ScenarioMatrices.expand` between `parseScenarioFile` and `selectScenarios`. Downstream code (mutators, IDE sync, Bazel/Buck/Maven, version matrix) needs no awareness of matrices — by the time it runs, each synthesized scenario is just a normal `Config` block.
- `dumpScenarios` runs after expansion, so `--dump-scenarios` shows the merged result.
- No public API changes, no new CLI flags.

## Test plan

- `ScenarioMatricesTest` — 38 unit tests on the expander directly: cartesian product shape, merge semantics (maps merge, arrays replace, primitives override), title composition (incl. empty-title), N=1/N=2/N≥3 auto-group shapes, every validation/error path with full message assertions.
- `ScenarioMatricesIntegrationTest` — 11 end-to-end tests via `Main` in `--dry-run` against the latest supported Gradle: output directory creation, mixing synthesized + hand-written scenarios, `--group` selection on both auto-group families, `default-scenarios` and `scenario-groups` interop, `--dump-scenarios` rendering, custom separators, error reporting.