### PR TITLE
Wait for SDKMAN download URL before releasing, with a clear error

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ import io.sdkman.vendors.tasks.SdkDefaultVersion
 import io.sdkman.vendors.tasks.SdkReleaseVersion
 import io.sdkman.vendors.tasks.SdkmanVendorBaseTask
 import java.util.Locale
+import tasks.AwaitUrlTask
 
 plugins {
     id("profiler.java-library")
@@ -264,18 +265,36 @@ val gitPushTag = tasks.register<Exec>("gitPushTag") {
 
 fun Project.isSnapshot() = version.toString().endsWith("-SNAPSHOT")
 
+val sdkmanDownloadUrl = "https://repo1.maven.org/maven2/org/gradle/profiler/gradle-profiler/$version/gradle-profiler-$version.zip"
+
 sdkman {
     api = "https://vendors.sdkman.io"
     candidate = "gradleprofiler"
     hashtag = "#gradleprofiler"
     version = project.version.toString()
-    url = "https://repo1.maven.org/maven2/org/gradle/profiler/gradle-profiler/$version/gradle-profiler-$version.zip"
+    url = sdkmanDownloadUrl
     consumerKey = project.findProperty("sdkmanKey") as String?
     consumerToken = project.findProperty("sdkmanToken") as String?
 }
 
+// SDKMAN's release API downloads the artifact URL itself and rejects the release with an opaque
+// `HTTP 400 Bad Request` if it cannot resolve it (the plugin then hides the real "URL cannot be
+// resolved" message). Right after a Maven Central publish the artifact often hasn't propagated yet,
+// so we wait for the URL to become available first and fail with a clear message if it never does.
+val awaitSdkmanArtifact = tasks.register<AwaitUrlTask>("awaitSdkmanArtifact") {
+    description = "Waits until the SDKMAN download URL is resolvable before releasing to SDKMAN."
+    mustRunAfter(gitPushTag)
+    url = sdkmanDownloadUrl
+    timeoutMinutes = 10L
+    pollIntervalSeconds = 15L
+}
+
 tasks.withType<SdkmanVendorBaseTask>().configureEach {
     mustRunAfter(gitPushTag)
+}
+
+tasks.withType<SdkReleaseVersion>().configureEach {
+    dependsOn(awaitSdkmanArtifact)
 }
 
 tasks.withType<SdkDefaultVersion>().configureEach {

--- a/buildSrc/src/main/kotlin/tasks/AwaitUrlTask.kt
+++ b/buildSrc/src/main/kotlin/tasks/AwaitUrlTask.kt
@@ -1,0 +1,83 @@
+package tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import java.net.HttpURLConnection
+import java.net.URI
+
+/**
+ * Polls [url] with HEAD requests until it resolves (HTTP 2xx) or [timeoutMinutes] elapses.
+ *
+ * This exists to front the SDKMAN release: SDKMAN's API downloads the release URL itself and rejects
+ * the release with an opaque `HTTP 400 Bad Request` if it cannot resolve it (the Gradle plugin then
+ * hides the real "URL cannot be resolved" message). Right after a Maven Central publish the artifact
+ * often hasn't propagated yet, so we wait here and, if it never becomes available, fail with a clear
+ * message that names the actual problem instead of leaving a confusing 400 behind.
+ */
+@DisableCachingByDefault(because = "Polls a remote URL; nothing to cache")
+abstract class AwaitUrlTask : DefaultTask() {
+
+    init {
+        description = "Waits until a URL resolves before dependent tasks run."
+    }
+
+    @get:Input
+    abstract val url: Property<String>
+
+    @get:Input
+    abstract val timeoutMinutes: Property<Long>
+
+    @get:Input
+    abstract val pollIntervalSeconds: Property<Long>
+
+    @TaskAction
+    fun await() {
+        val downloadUrl = url.get()
+        val target = URI(downloadUrl).toURL()
+        val pollIntervalMillis = pollIntervalSeconds.get() * 1_000
+        val deadline = System.currentTimeMillis() + timeoutMinutes.get() * 60_000
+        var attempt = 0
+        var lastProblem: String
+        while (true) {
+            attempt++
+            lastProblem = try {
+                val connection = (target.openConnection() as HttpURLConnection).apply {
+                    requestMethod = "HEAD"
+                    connectTimeout = 15_000
+                    readTimeout = 15_000
+                    instanceFollowRedirects = true
+                }
+                val code = try {
+                    connection.responseCode
+                } finally {
+                    connection.disconnect()
+                }
+                if (code in 200..299) {
+                    logger.lifecycle("URL is available (attempt $attempt): $downloadUrl")
+                    return
+                }
+                "HTTP $code"
+            } catch (e: Exception) {
+                e.message ?: e.toString()
+            }
+            if (System.currentTimeMillis() + pollIntervalMillis >= deadline) {
+                throw GradleException(
+                    "URL is not accessible after ${timeoutMinutes.get()} minutes: $downloadUrl\n" +
+                        "Last check failed with: $lastProblem.\n" +
+                        "This is the real reason a SDKMAN release fails here: its API downloads this URL and " +
+                        "rejects the release with 'HTTP 400 Bad Request (URL cannot be resolved)'. The artifact " +
+                        "has most likely not propagated to Maven Central yet — re-run once it is available."
+                )
+            }
+            logger.lifecycle(
+                "URL not available yet (attempt $attempt, $lastProblem): $downloadUrl — " +
+                    "retrying in ${pollIntervalSeconds.get()}s"
+            )
+            Thread.sleep(pollIntervalMillis)
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The `Publish to SDKMan` build [failed publishing 0.25.0](https://builds.gradle.org/buildConfiguration/GradleProfiler_GradleProfilerPublishToSdkMan/114878118) with an opaque error:

```
> Task :sdkReleaseVersion FAILED
Releasing gradleprofiler 0.25.0 for UNIVERSAL...
Response: 400: Bad Request...
> Response: 400 Bad Request
```

### Root cause

The SDKMAN vendor API (`POST https://vendors.sdkman.io/versions`) **downloads the release URL itself** and validates it. Its [`validateUrl`](https://github.com/sdkman/vendor-release/blob/master/src/main/scala/io/sdkman/vendor/release/routes/Validation.scala) returns `400 Bad Request` with body `"URL cannot be resolved: <url>"` when it can't fetch the artifact. For our payload (`platform=UNIVERSAL`, no checksums, plain version `0.25.0`) that URL check is the *only* validation that can 400 — and it did, because the `gradle-profiler-0.25.0.zip` had only just been published to Maven Central (06:28 UTC) and hadn't propagated when the release ran (06:29 UTC).

Two things made this painful:
1. The release fires before the artifact is reliably resolvable from Maven Central.
2. The `io.sdkman.vendors` plugin **hides the real message** — it drops the response body (`"URL cannot be resolved"`) and only surfaces `Response: 400 Bad Request`.

Note: re-running the SDKMAN publish for 0.25.0 does **not** need a version bump — SDKMAN only stores metadata pointing at the existing Central artifact; it never re-uploads. 0.25.0 is not registered on SDKMAN yet, so there's no conflict.

## Fix

- New `AwaitUrlTask` (buildSrc) polls the download URL with HEAD requests (10 min timeout, 15 s interval).
- `:sdkReleaseVersion` now `dependsOn` it, so the release only runs once the URL resolves.
- If the URL never resolves, the task **fails with a message naming the real cause** instead of a confusing 400:

  ```
  URL is not accessible after 10 minutes: <url>
  Last check failed with: HTTP 404.
  This is the real reason a SDKMAN release fails here: its API downloads this URL and
  rejects the release with 'HTTP 400 Bad Request (URL cannot be resolved)'. The artifact
  has most likely not propagated to Maven Central yet — re-run once it is available.
  ```

## Testing

- Configuration-cache compatible (verified `Configuration cache entry stored`, no CC problems).
- Task graph verified: `:awaitSdkmanArtifact` runs before `:sdkReleaseVersion`.
- Functionally exercised both paths:
  - Reachable URL (0.24.0 zip) → `URL is available (attempt 1)`, BUILD SUCCESSFUL.
  - Unreachable URL (nonexistent 9.9.9 zip) → fails with the clear message above.