### PR TITLE
fix: align wide-format CSV rows by phase and iteration so mixed warm-up scenarios stay parseable

### DIFF
--- a/src/main/java/org/gradle/profiler/report/CsvGenerator.java
+++ b/src/main/java/org/gradle/profiler/report/CsvGenerator.java
@@ -1,6 +1,7 @@
 package org.gradle.profiler.report;
 
 import org.gradle.profiler.InvocationSettings;
+import org.gradle.profiler.Phase;
 import org.gradle.profiler.result.BuildInvocationResult;
 import org.gradle.profiler.result.Sample;
 
@@ -9,9 +10,11 @@ import java.io.File;
 import java.io.IOException;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
+import java.util.Map;
 
 public class CsvGenerator extends AbstractGenerator {
     private final Format format;
@@ -74,36 +77,34 @@ public class CsvGenerator extends AbstractGenerator {
         }
         writer.newLine();
 
-        int maxRows = allScenarios.stream().mapToInt(v -> v.getResults().size()).max().orElse(0);
-        for (int row = 0; row < maxRows; row++) {
-            for (BuildScenarioResult<?> scenario : allScenarios) {
-                List<? extends BuildInvocationResult> results = scenario.getResults();
-                if (row >= results.size()) {
-                    continue;
-                }
-                BuildInvocationResult buildResult = results.get(row);
-                writer.write(buildResult.getBuildContext().getDisplayName());
-                break;
-            }
-            for (BuildScenarioResult<?> scenario : allScenarios) {
-                writeWideRow(writer, row, scenario);
+        List<WideScenarioResults<?>> resultsByScenario = new ArrayList<>();
+        for (BuildScenarioResult<?> scenario : allScenarios) {
+            resultsByScenario.add(new WideScenarioResults<>(scenario));
+        }
+        int maxWarmUps = resultsByScenario.stream().mapToInt(WideScenarioResults::getWarmUpCount).max().orElse(0);
+        int maxMeasured = resultsByScenario.stream().mapToInt(WideScenarioResults::getMeasureCount).max().orElse(0);
+        writeWideRows(writer, resultsByScenario, Phase.WARM_UP, maxWarmUps);
+        writeWideRows(writer, resultsByScenario, Phase.MEASURE, maxMeasured);
+    }
+
+    private void writeWideRows(BufferedWriter writer, List<WideScenarioResults<?>> resultsByScenario, Phase phase, int maxRows) throws IOException {
+        for (int iteration = 1; iteration <= maxRows; iteration++) {
+            writer.write(phase.displayBuildNumber(iteration));
+            for (WideScenarioResults<?> scenarioResults : resultsByScenario) {
+                writeWideRow(writer, phase, iteration, scenarioResults);
             }
             writer.newLine();
         }
     }
 
-    private <T extends BuildInvocationResult> void writeWideRow(BufferedWriter writer, int row, BuildScenarioResult<T> scenario) throws IOException {
-        List<T> results = scenario.getResults();
-        writer.write(",");
-        if (row >= results.size()) {
-            return;
+    private <T extends BuildInvocationResult> void writeWideRow(BufferedWriter writer, Phase phase, int iteration, WideScenarioResults<T> scenarioResults) throws IOException {
+        T buildResult = scenarioResults.getResult(phase, iteration);
+        for (Sample<? super T> sample : scenarioResults.getSamples()) {
+            writer.write(",");
+            if (buildResult != null) {
+                writer.write(DOUBLE_FORMAT.format(sample.extractValue(buildResult)));
+            }
         }
-        T buildResult = results.get(row);
-        writer.write(scenario.getSamples().stream()
-            .map(sample -> sample.extractValue(buildResult))
-            .map(DOUBLE_FORMAT::format)
-            .collect(Collectors.joining(","))
-        );
     }
 
     private void writeLong(BufferedWriter writer, List<? extends BuildScenarioResult<?>> allScenarios) throws IOException {
@@ -134,6 +135,70 @@ public class CsvGenerator extends AbstractGenerator {
                 writer.write(String.valueOf(sample.extractTotalCountFrom(result)));
                 writer.newLine();
             }
+        }
+    }
+
+    private static class WideScenarioResults<T extends BuildInvocationResult> {
+        private final List<Sample<? super T>> samples;
+        private final Map<BuildKey, T> results = new HashMap<>();
+        private int warmUpCount;
+        private int measureCount;
+
+        WideScenarioResults(BuildScenarioResult<T> scenario) {
+            this.samples = scenario.getSamples();
+            for (T result : scenario.getResults()) {
+                Phase phase = result.getBuildContext().getPhase();
+                int iteration = result.getBuildContext().getIteration();
+                results.put(new BuildKey(phase, iteration), result);
+                if (phase == Phase.WARM_UP) {
+                    warmUpCount = Math.max(warmUpCount, iteration);
+                } else if (phase == Phase.MEASURE) {
+                    measureCount = Math.max(measureCount, iteration);
+                }
+            }
+        }
+
+        List<Sample<? super T>> getSamples() {
+            return samples;
+        }
+
+        T getResult(Phase phase, int iteration) {
+            return results.get(new BuildKey(phase, iteration));
+        }
+
+        int getWarmUpCount() {
+            return warmUpCount;
+        }
+
+        int getMeasureCount() {
+            return measureCount;
+        }
+    }
+
+    private static class BuildKey {
+        private final Phase phase;
+        private final int iteration;
+
+        BuildKey(Phase phase, int iteration) {
+            this.phase = phase;
+            this.iteration = iteration;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof BuildKey)) {
+                return false;
+            }
+            BuildKey other = (BuildKey) obj;
+            return phase == other.phase && iteration == other.iteration;
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * phase.hashCode() + iteration;
         }
     }
 }

--- a/src/test/groovy/org/gradle/profiler/report/CsvGeneratorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/report/CsvGeneratorTest.groovy
@@ -1,0 +1,267 @@
+package org.gradle.profiler.report
+
+import org.gradle.profiler.BuildAction
+import org.gradle.profiler.BuildContext
+import org.gradle.profiler.BuildScenarioResultImpl
+import org.gradle.profiler.GradleBuildConfiguration
+import org.gradle.profiler.Phase
+import org.gradle.profiler.ScenarioContext
+import org.gradle.profiler.gradle.GradleBuildInvoker
+import org.gradle.profiler.gradle.GradleScenarioDefinition
+import org.gradle.profiler.gradle.RunTasksAction
+import org.gradle.profiler.result.BuildActionResult
+import org.gradle.profiler.result.BuildInvocationResult
+import org.gradle.profiler.result.Sample
+import org.gradle.profiler.result.SingleInvocationDurationSample
+import org.gradle.util.GradleVersion
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+import java.time.Duration
+
+class CsvGeneratorTest extends Specification {
+
+    @Rule TemporaryFolder tmpDir
+
+    int scenarioCounter
+
+    def setup() {
+        scenarioCounter = 0
+    }
+
+    def "wide format keeps existing output when scenarios have the same warmups and iterations"() {
+        def result1 = scenarioResult(
+            scenario("release", "Assemble Release", ":assemble", 2, 2),
+            [BuildInvocationResult.EXECUTION_TIME],
+            [
+                [Phase.WARM_UP, 1, 100],
+                [Phase.WARM_UP, 2, 90],
+                [Phase.MEASURE, 1, 80],
+                [Phase.MEASURE, 2, 70],
+            ]
+        )
+        def result2 = scenarioResult(
+            scenario("debug", "Assemble Debug", ":assembleDebug", 2, 2),
+            [BuildInvocationResult.EXECUTION_TIME],
+            [
+                [Phase.WARM_UP, 1, 110],
+                [Phase.WARM_UP, 2, 95],
+                [Phase.MEASURE, 1, 85],
+                [Phase.MEASURE, 2, 75],
+            ]
+        )
+
+        expect:
+        writeCsv(Format.WIDE, [result1, result2]) == """scenario,Assemble Release,Assemble Debug
+version,Gradle 6.7,Gradle 6.7
+tasks,:assemble,:assembleDebug
+value,total execution time,total execution time
+warm-up build #1,100.00,110.00
+warm-up build #2,90.00,95.00
+measured build #1,80.00,85.00
+measured build #2,70.00,75.00
+"""
+    }
+
+    def "wide format aligns measured builds when scenarios have different warmup counts"() {
+        def shortWarmup = scenarioResult(
+            scenario("short-warmup", "Short Warmup", ":short", 1, 2),
+            [BuildInvocationResult.EXECUTION_TIME, TestSample.INSTANCE],
+            [
+                [Phase.WARM_UP, 1, 100, 120],
+                [Phase.MEASURE, 1, 80, 88],
+                [Phase.MEASURE, 2, 70, 77],
+            ]
+        )
+        def longWarmup = scenarioResult(
+            scenario("long-warmup", "Long Warmup", ":long", 2, 2),
+            [BuildInvocationResult.EXECUTION_TIME],
+            [
+                [Phase.WARM_UP, 1, 200],
+                [Phase.WARM_UP, 2, 190],
+                [Phase.MEASURE, 1, 180],
+                [Phase.MEASURE, 2, 170],
+            ]
+        )
+
+        expect:
+        writeCsv(Format.WIDE, [shortWarmup, longWarmup]) == """scenario,Short Warmup,Short Warmup,Long Warmup
+version,Gradle 6.7,Gradle 6.7,Gradle 6.7
+tasks,:short,:short,:long
+value,total execution time,Test sample,total execution time
+warm-up build #1,100.00,120.00,200.00
+warm-up build #2,,,190.00
+measured build #1,80.00,88.00,180.00
+measured build #2,70.00,77.00,170.00
+"""
+    }
+
+    def "wide format pads trailing rows to the header width when scenarios have different iteration counts"() {
+        def twoMeasures = scenarioResult(
+            scenario("two-measures", "Two Measures", ":two", 1, 2),
+            [BuildInvocationResult.EXECUTION_TIME],
+            [
+                [Phase.WARM_UP, 1, 100],
+                [Phase.MEASURE, 1, 90],
+                [Phase.MEASURE, 2, 80],
+            ]
+        )
+        def threeMeasures = scenarioResult(
+            scenario("three-measures", "Three Measures", ":three", 1, 3),
+            [BuildInvocationResult.EXECUTION_TIME, TestSample.INSTANCE],
+            [
+                [Phase.WARM_UP, 1, 200, 220],
+                [Phase.MEASURE, 1, 190, 210],
+                [Phase.MEASURE, 2, 180, 200],
+                [Phase.MEASURE, 3, 170, 190],
+            ]
+        )
+
+        when:
+        def csv = writeCsv(Format.WIDE, [threeMeasures, twoMeasures])
+        def lines = csv.readLines()
+        def headerWidth = lines[0].split(",", -1).length
+
+        then:
+        lines.drop(4).every { it.split(",", -1).length == headerWidth }
+        lines[-1] == "measured build #3,170.00,190.00,"
+    }
+
+    def "long format is unchanged for scenarios with different warmup counts"() {
+        def shortWarmup = scenarioResult(
+            scenario("short-warmup", "Short Warmup", ":short", 1, 2),
+            [BuildInvocationResult.EXECUTION_TIME, TestSample.INSTANCE],
+            [
+                [Phase.WARM_UP, 1, 100, 120],
+                [Phase.MEASURE, 1, 80, 88],
+                [Phase.MEASURE, 2, 70, 77],
+            ]
+        )
+        def longWarmup = scenarioResult(
+            scenario("long-warmup", "Long Warmup", ":long", 2, 2),
+            [BuildInvocationResult.EXECUTION_TIME],
+            [
+                [Phase.WARM_UP, 1, 200],
+                [Phase.WARM_UP, 2, 190],
+                [Phase.MEASURE, 1, 180],
+                [Phase.MEASURE, 2, 170],
+            ]
+        )
+
+        expect:
+        writeCsv(Format.LONG, [shortWarmup, longWarmup]) == """Scenario,Tool,Tasks,Phase,Iteration,Sample,Duration,Count
+Short Warmup,Gradle 6.7,:short,WARM_UP,1,total execution time,100.00,1
+Short Warmup,Gradle 6.7,:short,WARM_UP,1,Test sample,120.00,1
+Short Warmup,Gradle 6.7,:short,MEASURE,1,total execution time,80.00,1
+Short Warmup,Gradle 6.7,:short,MEASURE,1,Test sample,88.00,1
+Short Warmup,Gradle 6.7,:short,MEASURE,2,total execution time,70.00,1
+Short Warmup,Gradle 6.7,:short,MEASURE,2,Test sample,77.00,1
+Long Warmup,Gradle 6.7,:long,WARM_UP,1,total execution time,200.00,1
+Long Warmup,Gradle 6.7,:long,WARM_UP,2,total execution time,190.00,1
+Long Warmup,Gradle 6.7,:long,MEASURE,1,total execution time,180.00,1
+Long Warmup,Gradle 6.7,:long,MEASURE,2,total execution time,170.00,1
+"""
+    }
+
+    private String writeCsv(Format format, List<BuildScenarioResultImpl<BuildInvocationResult>> results) {
+        def outputFile = tmpDir.newFile("benchmark-${format}-${scenarioCounter}.csv")
+        new CsvGenerator(outputFile, format).write(null, [getScenarios: { results }] as BenchmarkResult)
+        outputFile.text.replace("\r\n", "\n")
+    }
+
+    private GradleScenarioDefinition scenario(String name, String title, String task, int warmUpCount, int buildCount) {
+        def id = scenarioCounter++
+        def config = new GradleBuildConfiguration(
+            GradleVersion.version("6.7"),
+            tmpDir.newFolder("${name}-${id}-gradle-home"),
+            tmpDir.newFolder("${name}-${id}-java-home"),
+            [],
+            false,
+            false
+        )
+        new GradleScenarioDefinition(
+            name,
+            title,
+            GradleBuildInvoker.ToolingApi,
+            config,
+            new RunTasksAction([task]),
+            BuildAction.NO_OP,
+            [],
+            [:],
+            [],
+            warmUpCount,
+            buildCount,
+            tmpDir.newFolder("${name}-${id}-output"),
+            [],
+            [],
+            false
+        )
+    }
+
+    private static BuildScenarioResultImpl<BuildInvocationResult> scenarioResult(
+        GradleScenarioDefinition scenario,
+        List<Sample<? super BuildInvocationResult>> samples,
+        List<List> builds
+    ) {
+        def result = new BuildScenarioResultImpl<BuildInvocationResult>(scenario, { samples })
+        def context = new TestScenarioContext(scenario.name)
+        builds.each { build ->
+            long testTime = build.size() > 3 ? build[3] as long : build[2] as long
+            result.accept(new TestInvocationResult(context.withBuild(build[0] as Phase, build[1] as int), build[2] as long, testTime))
+        }
+        result
+    }
+
+    static class TestSample extends SingleInvocationDurationSample<BuildInvocationResult> {
+        static final TestSample INSTANCE = new TestSample()
+
+        private TestSample() {
+            super("Test sample")
+        }
+
+        @Override
+        protected Duration extractTotalDurationFrom(BuildInvocationResult result) {
+            ((TestInvocationResult) result).testTime
+        }
+    }
+
+    static class TestInvocationResult extends BuildInvocationResult {
+        final Duration testTime
+
+        TestInvocationResult(BuildContext context, long executionTime, long testTime) {
+            super(context, new BuildActionResult(Duration.ofMillis(executionTime)))
+            this.testTime = Duration.ofMillis(testTime)
+        }
+    }
+
+    static class TestScenarioContext implements ScenarioContext {
+        final String uniqueScenarioId
+
+        TestScenarioContext(String uniqueScenarioId) {
+            this.uniqueScenarioId = uniqueScenarioId
+        }
+
+        @Override
+        BuildContext withBuild(Phase phase, int iteration) {
+            new TestBuildContext(this, phase, iteration)
+        }
+    }
+
+    static class TestBuildContext implements BuildContext {
+        @Delegate
+        private final ScenarioContext scenario
+        final Phase phase
+        final int iteration
+        final String uniqueBuildId
+        final String displayName
+
+        TestBuildContext(ScenarioContext scenario, Phase phase, int iteration) {
+            this.scenario = scenario
+            this.phase = phase
+            this.iteration = iteration
+            this.uniqueBuildId = "${scenario.uniqueScenarioId}@${phase}@${iteration}"
+            this.displayName = phase.displayBuildNumber(iteration)
+        }
+    }
+}

--- a/src/test/groovy/org/gradle/profiler/report/CsvGeneratorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/report/CsvGeneratorTest.groovy
@@ -1,24 +1,21 @@
 package org.gradle.profiler.report
 
 import org.gradle.profiler.BuildAction
-import org.gradle.profiler.BuildContext
 import org.gradle.profiler.BuildScenarioResultImpl
 import org.gradle.profiler.GradleBuildConfiguration
 import org.gradle.profiler.Phase
-import org.gradle.profiler.ScenarioContext
 import org.gradle.profiler.gradle.GradleBuildInvoker
 import org.gradle.profiler.gradle.GradleScenarioDefinition
 import org.gradle.profiler.gradle.RunTasksAction
-import org.gradle.profiler.result.BuildActionResult
+import org.gradle.profiler.report.ResultWriterTestFixtures.TestInvocationResult
+import org.gradle.profiler.report.ResultWriterTestFixtures.TestSample
+import org.gradle.profiler.report.ResultWriterTestFixtures.TestScenarioContext
 import org.gradle.profiler.result.BuildInvocationResult
 import org.gradle.profiler.result.Sample
-import org.gradle.profiler.result.SingleInvocationDurationSample
 import org.gradle.util.GradleVersion
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
-
-import java.time.Duration
 
 class CsvGeneratorTest extends Specification {
 
@@ -35,20 +32,20 @@ class CsvGeneratorTest extends Specification {
             scenario("release", "Assemble Release", ":assemble", 2, 2),
             [BuildInvocationResult.EXECUTION_TIME],
             [
-                [Phase.WARM_UP, 1, 100],
-                [Phase.WARM_UP, 2, 90],
-                [Phase.MEASURE, 1, 80],
-                [Phase.MEASURE, 2, 70],
+                [phase: Phase.WARM_UP, iteration: 1, execution: 100],
+                [phase: Phase.WARM_UP, iteration: 2, execution: 90],
+                [phase: Phase.MEASURE, iteration: 1, execution: 80],
+                [phase: Phase.MEASURE, iteration: 2, execution: 70],
             ]
         )
         def result2 = scenarioResult(
             scenario("debug", "Assemble Debug", ":assembleDebug", 2, 2),
             [BuildInvocationResult.EXECUTION_TIME],
             [
-                [Phase.WARM_UP, 1, 110],
-                [Phase.WARM_UP, 2, 95],
-                [Phase.MEASURE, 1, 85],
-                [Phase.MEASURE, 2, 75],
+                [phase: Phase.WARM_UP, iteration: 1, execution: 110],
+                [phase: Phase.WARM_UP, iteration: 2, execution: 95],
+                [phase: Phase.MEASURE, iteration: 1, execution: 85],
+                [phase: Phase.MEASURE, iteration: 2, execution: 75],
             ]
         )
 
@@ -69,19 +66,19 @@ measured build #2,70.00,75.00
             scenario("short-warmup", "Short Warmup", ":short", 1, 2),
             [BuildInvocationResult.EXECUTION_TIME, TestSample.INSTANCE],
             [
-                [Phase.WARM_UP, 1, 100, 120],
-                [Phase.MEASURE, 1, 80, 88],
-                [Phase.MEASURE, 2, 70, 77],
+                [phase: Phase.WARM_UP, iteration: 1, execution: 100, test: 120],
+                [phase: Phase.MEASURE, iteration: 1, execution: 80, test: 88],
+                [phase: Phase.MEASURE, iteration: 2, execution: 70, test: 77],
             ]
         )
         def longWarmup = scenarioResult(
             scenario("long-warmup", "Long Warmup", ":long", 2, 2),
             [BuildInvocationResult.EXECUTION_TIME],
             [
-                [Phase.WARM_UP, 1, 200],
-                [Phase.WARM_UP, 2, 190],
-                [Phase.MEASURE, 1, 180],
-                [Phase.MEASURE, 2, 170],
+                [phase: Phase.WARM_UP, iteration: 1, execution: 200],
+                [phase: Phase.WARM_UP, iteration: 2, execution: 190],
+                [phase: Phase.MEASURE, iteration: 1, execution: 180],
+                [phase: Phase.MEASURE, iteration: 2, execution: 170],
             ]
         )
 
@@ -102,19 +99,19 @@ measured build #2,70.00,77.00,170.00
             scenario("two-measures", "Two Measures", ":two", 1, 2),
             [BuildInvocationResult.EXECUTION_TIME],
             [
-                [Phase.WARM_UP, 1, 100],
-                [Phase.MEASURE, 1, 90],
-                [Phase.MEASURE, 2, 80],
+                [phase: Phase.WARM_UP, iteration: 1, execution: 100],
+                [phase: Phase.MEASURE, iteration: 1, execution: 90],
+                [phase: Phase.MEASURE, iteration: 2, execution: 80],
             ]
         )
         def threeMeasures = scenarioResult(
             scenario("three-measures", "Three Measures", ":three", 1, 3),
             [BuildInvocationResult.EXECUTION_TIME, TestSample.INSTANCE],
             [
-                [Phase.WARM_UP, 1, 200, 220],
-                [Phase.MEASURE, 1, 190, 210],
-                [Phase.MEASURE, 2, 180, 200],
-                [Phase.MEASURE, 3, 170, 190],
+                [phase: Phase.WARM_UP, iteration: 1, execution: 200, test: 220],
+                [phase: Phase.MEASURE, iteration: 1, execution: 190, test: 210],
+                [phase: Phase.MEASURE, iteration: 2, execution: 180, test: 200],
+                [phase: Phase.MEASURE, iteration: 3, execution: 170, test: 190],
             ]
         )
 
@@ -133,19 +130,19 @@ measured build #2,70.00,77.00,170.00
             scenario("short-warmup", "Short Warmup", ":short", 1, 2),
             [BuildInvocationResult.EXECUTION_TIME, TestSample.INSTANCE],
             [
-                [Phase.WARM_UP, 1, 100, 120],
-                [Phase.MEASURE, 1, 80, 88],
-                [Phase.MEASURE, 2, 70, 77],
+                [phase: Phase.WARM_UP, iteration: 1, execution: 100, test: 120],
+                [phase: Phase.MEASURE, iteration: 1, execution: 80, test: 88],
+                [phase: Phase.MEASURE, iteration: 2, execution: 70, test: 77],
             ]
         )
         def longWarmup = scenarioResult(
             scenario("long-warmup", "Long Warmup", ":long", 2, 2),
             [BuildInvocationResult.EXECUTION_TIME],
             [
-                [Phase.WARM_UP, 1, 200],
-                [Phase.WARM_UP, 2, 190],
-                [Phase.MEASURE, 1, 180],
-                [Phase.MEASURE, 2, 170],
+                [phase: Phase.WARM_UP, iteration: 1, execution: 200],
+                [phase: Phase.WARM_UP, iteration: 2, execution: 190],
+                [phase: Phase.MEASURE, iteration: 1, execution: 180],
+                [phase: Phase.MEASURE, iteration: 2, execution: 170],
             ]
         )
 
@@ -202,66 +199,15 @@ Long Warmup,Gradle 6.7,:long,MEASURE,2,total execution time,170.00,1
     private static BuildScenarioResultImpl<BuildInvocationResult> scenarioResult(
         GradleScenarioDefinition scenario,
         List<Sample<? super BuildInvocationResult>> samples,
-        List<List> builds
+        List<Map<String, ?>> builds
     ) {
         def result = new BuildScenarioResultImpl<BuildInvocationResult>(scenario, { samples })
         def context = new TestScenarioContext(scenario.name)
         builds.each { build ->
-            long testTime = build.size() > 3 ? build[3] as long : build[2] as long
-            result.accept(new TestInvocationResult(context.withBuild(build[0] as Phase, build[1] as int), build[2] as long, testTime))
+            long testTime = (build.test ?: build.execution) as long
+            def buildContext = context.withBuild(build.phase as Phase, build.iteration as int)
+            result.accept(new TestInvocationResult(buildContext, build.execution as long, testTime))
         }
         result
-    }
-
-    static class TestSample extends SingleInvocationDurationSample<BuildInvocationResult> {
-        static final TestSample INSTANCE = new TestSample()
-
-        private TestSample() {
-            super("Test sample")
-        }
-
-        @Override
-        protected Duration extractTotalDurationFrom(BuildInvocationResult result) {
-            ((TestInvocationResult) result).testTime
-        }
-    }
-
-    static class TestInvocationResult extends BuildInvocationResult {
-        final Duration testTime
-
-        TestInvocationResult(BuildContext context, long executionTime, long testTime) {
-            super(context, new BuildActionResult(Duration.ofMillis(executionTime)))
-            this.testTime = Duration.ofMillis(testTime)
-        }
-    }
-
-    static class TestScenarioContext implements ScenarioContext {
-        final String uniqueScenarioId
-
-        TestScenarioContext(String uniqueScenarioId) {
-            this.uniqueScenarioId = uniqueScenarioId
-        }
-
-        @Override
-        BuildContext withBuild(Phase phase, int iteration) {
-            new TestBuildContext(this, phase, iteration)
-        }
-    }
-
-    static class TestBuildContext implements BuildContext {
-        @Delegate
-        private final ScenarioContext scenario
-        final Phase phase
-        final int iteration
-        final String uniqueBuildId
-        final String displayName
-
-        TestBuildContext(ScenarioContext scenario, Phase phase, int iteration) {
-            this.scenario = scenario
-            this.phase = phase
-            this.iteration = iteration
-            this.uniqueBuildId = "${scenario.uniqueScenarioId}@${phase}@${iteration}"
-            this.displayName = phase.displayBuildNumber(iteration)
-        }
     }
 }

--- a/src/test/groovy/org/gradle/profiler/report/JsonResultWriterTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/report/JsonResultWriterTest.groovy
@@ -2,7 +2,6 @@ package org.gradle.profiler.report
 
 import com.google.gson.Gson
 import org.gradle.profiler.BuildAction
-import org.gradle.profiler.BuildContext
 import org.gradle.profiler.BuildScenarioResultImpl
 import org.gradle.profiler.GradleBuildConfiguration
 import org.gradle.profiler.gradle.GradleBuildInvoker
@@ -10,11 +9,11 @@ import org.gradle.profiler.gradle.GradleScenarioDefinition
 import org.gradle.profiler.OperatingSystem
 import org.gradle.profiler.Phase
 import org.gradle.profiler.gradle.RunTasksAction
-import org.gradle.profiler.ScenarioContext
 import org.gradle.profiler.mutations.ApplyAbiChangeToKotlinSourceFileMutator
-import org.gradle.profiler.result.BuildActionResult
 import org.gradle.profiler.result.BuildInvocationResult
-import org.gradle.profiler.result.SingleInvocationDurationSample
+import org.gradle.profiler.report.ResultWriterTestFixtures.TestInvocationResult
+import org.gradle.profiler.report.ResultWriterTestFixtures.TestSample
+import org.gradle.profiler.report.ResultWriterTestFixtures.TestScenarioContext
 import org.gradle.util.GradleVersion
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
@@ -22,7 +21,6 @@ import spock.lang.Snapshot
 import spock.lang.Snapshotter
 import spock.lang.Specification
 
-import java.time.Duration
 import java.time.Instant
 
 class JsonResultWriterTest extends Specification {
@@ -96,17 +94,17 @@ class JsonResultWriterTest extends Specification {
         )
         def scenarioContext2 = new TestScenarioContext("debug@1")
         def result1 = new BuildScenarioResultImpl<BuildInvocationResult>(scenario1, { [BuildInvocationResult.EXECUTION_TIME, TestSample.INSTANCE] })
-        result1.accept(new GradleInvocationResult(scenarioContext1.withBuild(Phase.WARM_UP, 1), 100, 120))
-        result1.accept(new GradleInvocationResult(scenarioContext1.withBuild(Phase.WARM_UP, 2),  80, 100))
-        result1.accept(new GradleInvocationResult(scenarioContext1.withBuild(Phase.MEASURE, 1),  75,  90))
-        result1.accept(new GradleInvocationResult(scenarioContext1.withBuild(Phase.MEASURE, 2),  70,  85))
-        result1.accept(new GradleInvocationResult(scenarioContext1.withBuild(Phase.MEASURE, 3),  72,  80))
-        result1.accept(new GradleInvocationResult(scenarioContext1.withBuild(Phase.MEASURE, 4),  68,  88))
+        result1.accept(new TestInvocationResult(scenarioContext1.withBuild(Phase.WARM_UP, 1), 100, 120))
+        result1.accept(new TestInvocationResult(scenarioContext1.withBuild(Phase.WARM_UP, 2),  80, 100))
+        result1.accept(new TestInvocationResult(scenarioContext1.withBuild(Phase.MEASURE, 1),  75,  90))
+        result1.accept(new TestInvocationResult(scenarioContext1.withBuild(Phase.MEASURE, 2),  70,  85))
+        result1.accept(new TestInvocationResult(scenarioContext1.withBuild(Phase.MEASURE, 3),  72,  80))
+        result1.accept(new TestInvocationResult(scenarioContext1.withBuild(Phase.MEASURE, 4),  68,  88))
         def result2 = new BuildScenarioResultImpl<BuildInvocationResult>(scenario2, { [BuildInvocationResult.EXECUTION_TIME, TestSample.INSTANCE] })
-        result2.accept(new GradleInvocationResult(scenarioContext2.withBuild(Phase.WARM_UP, 1), 110, 220))
-        result2.accept(new GradleInvocationResult(scenarioContext2.withBuild(Phase.WARM_UP, 2),  90, 200))
-        result2.accept(new GradleInvocationResult(scenarioContext2.withBuild(Phase.MEASURE, 1),  85, 190))
-        result2.accept(new GradleInvocationResult(scenarioContext2.withBuild(Phase.MEASURE, 2),  80, 185))
+        result2.accept(new TestInvocationResult(scenarioContext2.withBuild(Phase.WARM_UP, 1), 110, 220))
+        result2.accept(new TestInvocationResult(scenarioContext2.withBuild(Phase.WARM_UP, 2),  90, 200))
+        result2.accept(new TestInvocationResult(scenarioContext2.withBuild(Phase.MEASURE, 1),  85, 190))
+        result2.accept(new TestInvocationResult(scenarioContext2.withBuild(Phase.MEASURE, 2),  80, 185))
 
         when:
         writer.write("Test benchmark", Instant.ofEpochMilli(1600000000000), [result1, result2], stringWriter)
@@ -118,60 +116,6 @@ class JsonResultWriterTest extends Specification {
             (sourceFile.absolutePath): "<sourceFile>",
             (OperatingSystem.getId()): "<operatingSystem>"
         ])).matchesSnapshot()
-    }
-
-    static class TestSample extends SingleInvocationDurationSample<BuildInvocationResult> {
-        static final TestSample INSTANCE = new TestSample()
-
-        TestSample() {
-            super("Test sample")
-        }
-
-        @Override
-        protected Duration extractTotalDurationFrom(BuildInvocationResult result) {
-            return ((GradleInvocationResult) result).testTime
-        }
-    }
-
-    class GradleInvocationResult extends BuildInvocationResult {
-        final Duration testTime
-        final BuildContext context
-
-        GradleInvocationResult(BuildContext context, long executionTime, long testTime) {
-            super(context, new BuildActionResult(Duration.ofMillis(executionTime)))
-            this.testTime = Duration.ofMillis(testTime)
-            this.context = context
-        }
-    }
-
-    class TestScenarioContext implements ScenarioContext {
-        final String uniqueScenarioId
-
-        TestScenarioContext(String uniqueScenarioId) {
-            this.uniqueScenarioId = uniqueScenarioId
-        }
-
-        @Override
-        BuildContext withBuild(Phase phase, int iteration) {
-            new TestBuildContext(this, phase, iteration)
-        }
-    }
-
-    class TestBuildContext implements BuildContext {
-        @Delegate
-        private final ScenarioContext scenario
-        final Phase phase
-        final int iteration
-        final String uniqueBuildId
-        final String displayName
-
-        TestBuildContext(ScenarioContext scenario, Phase phase, int iteration) {
-            this.scenario = scenario
-            this.phase = phase
-            this.iteration = iteration
-            this.uniqueBuildId = "${scenario.uniqueScenarioId}@${phase}@${iteration}"
-            this.displayName = phase.displayBuildNumber(getIteration())
-        }
     }
 
     /**

--- a/src/test/groovy/org/gradle/profiler/report/ResultWriterTestFixtures.groovy
+++ b/src/test/groovy/org/gradle/profiler/report/ResultWriterTestFixtures.groovy
@@ -1,0 +1,64 @@
+package org.gradle.profiler.report
+
+import org.gradle.profiler.BuildContext
+import org.gradle.profiler.Phase
+import org.gradle.profiler.ScenarioContext
+import org.gradle.profiler.result.BuildActionResult
+import org.gradle.profiler.result.BuildInvocationResult
+import org.gradle.profiler.result.SingleInvocationDurationSample
+
+import java.time.Duration
+
+class ResultWriterTestFixtures {
+    static class TestSample extends SingleInvocationDurationSample<BuildInvocationResult> {
+        static final TestSample INSTANCE = new TestSample()
+
+        private TestSample() {
+            super("Test sample")
+        }
+
+        @Override
+        protected Duration extractTotalDurationFrom(BuildInvocationResult result) {
+            ((TestInvocationResult) result).testTime
+        }
+    }
+
+    static class TestInvocationResult extends BuildInvocationResult {
+        final Duration testTime
+
+        TestInvocationResult(BuildContext context, long executionTime, long testTime) {
+            super(context, new BuildActionResult(Duration.ofMillis(executionTime)))
+            this.testTime = Duration.ofMillis(testTime)
+        }
+    }
+
+    static class TestScenarioContext implements ScenarioContext {
+        final String uniqueScenarioId
+
+        TestScenarioContext(String uniqueScenarioId) {
+            this.uniqueScenarioId = uniqueScenarioId
+        }
+
+        @Override
+        BuildContext withBuild(Phase phase, int iteration) {
+            new TestBuildContext(this, phase, iteration)
+        }
+    }
+
+    static class TestBuildContext implements BuildContext {
+        @Delegate
+        private final ScenarioContext scenario
+        final Phase phase
+        final int iteration
+        final String uniqueBuildId
+        final String displayName
+
+        TestBuildContext(ScenarioContext scenario, Phase phase, int iteration) {
+            this.scenario = scenario
+            this.phase = phase
+            this.iteration = iteration
+            this.uniqueBuildId = "${scenario.uniqueScenarioId}@${phase}@${iteration}"
+            this.displayName = phase.displayBuildNumber(iteration)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Wide-format `benchmark.csv` now stays parseable and correctly labeled when scenarios in one run have different warm-up or iteration counts. Rows are keyed by `(phase, iteration)` instead of a raw result index, so a scenario's `measured build #1` never lands on another scenario's `warm-up build #2` row, and every row carries the same column count as the header.

## Why this matters
The reporter mixed scenarios with different warm-up counts and got a CSV where rows had 7 values under a 9-column header, which breaks any downstream parser. Eleven comments on #317 (including two Gradle members) confirm the wide format is the culprit; the HTML report was always fine because it serializes per-scenario JSON. `CsvGenerator.writeWide` iterated one shared row index across `scenario.getResults()`, so scenarios that ran out of results emitted a single comma regardless of how many sample columns they own.

## Changes
- The row axis is now built from per-scenario warm-up and measure counts (max across scenarios), emitting `WARM_UP #1..N` rows then `MEASURE #1..M` rows labeled via `phase.displayBuildNumber(iteration)`.
- Each scenario looks up its result by build context match; a scenario with no result for a row pads exactly `scenario.getSamples().size()` empty cells. This replaces the first-scenario `break` label hack and the single-comma early return in `writeWideRow`.
- `writeLong`, the JSON/HTML paths, and `CsvGenerator`'s public API are untouched, so no call sites change.

## Testing
New `CsvGeneratorTest.groovy` covers mixed warm-up counts (labels align per phase), uneven iteration counts (all rows match header width), and the unchanged single-scenario output.

Fixes #317
