### PR TITLE
Publish CLI distribution ZIP to GitHub Releases instead of Maven Central

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -20,7 +20,7 @@ exclude-labels:
 template: |
     $CHANGES
 
-    Prebuilt version available from [here](https://repo1.maven.org/maven2/org/gradle/profiler/gradle-profiler/$NEXT_MINOR_VERSION/gradle-profiler-$NEXT_MINOR_VERSION.zip)
+    Prebuilt version available from [here](https://github.com/gradle/gradle-profiler/releases/download/v$NEXT_MINOR_VERSION/gradle-profiler-$NEXT_MINOR_VERSION.zip)
 
     Install Gradle profiler $NEXT_MINOR_VERSION with [SDKMAN!](http://sdkman.io/):
 

--- a/.teamcity/src/main/kotlin/GradleProfilerPublishToSdkMan.kt
+++ b/.teamcity/src/main/kotlin/GradleProfilerPublishToSdkMan.kt
@@ -1,7 +1,6 @@
 import jetbrains.buildServer.configs.kotlin.BuildType
 import jetbrains.buildServer.configs.kotlin.buildSteps.gradle
 import jetbrains.buildServer.configs.kotlin.triggers.finishBuildTrigger
-import jetbrains.buildServer.configs.kotlin.triggers.retryBuild
 
 class GradleProfilerPublishToSdkMan(publishingBuild: GradleProfilerPublishing) : BuildType({
     name = "Gradle profiler Publish to SDKman"
@@ -20,11 +19,6 @@ class GradleProfilerPublishToSdkMan(publishingBuild: GradleProfilerPublishing) :
             buildType = publishingBuild.id.toString()
             successfulOnly = true
             branchFilter = "+:master"
-        }
-        retryBuild {
-            delaySeconds = 30 * 60 // Wait for half an hour for the artifact to appear on Maven Central
-            attempts = 1
-            retryWithTheSameRevisions = true
         }
     }
 

--- a/.teamcity/src/main/kotlin/GradleProfilerPublishing.kt
+++ b/.teamcity/src/main/kotlin/GradleProfilerPublishing.kt
@@ -33,7 +33,7 @@ object GradleProfilerPublishing : BuildType({
         gradle {
             // No CC since https://github.com/gradle-nexus/publish-plugin/issues/221, which is
             // waiting for https://github.com/gradle/gradle/issues/22779
-            tasks = "--no-configuration-cache clean createBuildReceipt publishToSonatype closeAndReleaseSonatypeStagingRepository gitPushTag %additional.gradle.parameters%"
+            tasks = "--no-configuration-cache clean createBuildReceipt publishToSonatype closeAndReleaseSonatypeStagingRepository gitPushTag publishToGithubReleases %additional.gradle.parameters%"
             gradleParams = toolchainConfiguration(os, arch) + " -Dgradle.cache.remote.push=true"
             buildFile = ""
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ import io.sdkman.vendors.tasks.SdkDefaultVersion
 import io.sdkman.vendors.tasks.SdkReleaseVersion
 import io.sdkman.vendors.tasks.SdkmanVendorBaseTask
 import java.util.Locale
+import services.GithubReleaseService
 
 plugins {
     id("profiler.java-library")
@@ -217,22 +218,6 @@ tasks.register("testHtmlReports") {
     dependsOn(testReports.keys)
 }
 
-val profilerDistribution = artifacts.add("archives", tasks.distZip.flatMap { it.archiveFile }) {
-    type = "zip"
-}
-
-publishing {
-    publications {
-        named<MavenPublication>("mavenJava") {
-            artifact(profilerDistribution)
-            pom {
-                // For some reason adding the zip artifact changes the packaging to "pom"
-                packaging = "jar"
-            }
-        }
-    }
-}
-
 nexusPublishing {
     packageGroup.set(project.group.toString())
     repositories {
@@ -264,12 +249,37 @@ val gitPushTag = tasks.register<Exec>("gitPushTag") {
 
 fun Project.isSnapshot() = version.toString().endsWith("-SNAPSHOT")
 
+gradle.sharedServices.registerIfAbsent("githubRelease", GithubReleaseService::class) {
+    parameters.githubToken = providers.gradleProperty("githubToken")
+}
+
+tasks.register<tasks.PublishToGithubReleasesTask>("publishToGithubReleases") {
+    mustRunAfter(gitPushTag)
+
+    val versionString = project.version.toString()
+    repository = "gradle/gradle-profiler"
+    releaseVersion = versionString
+    // Wiring the ZIP file provider also carries the task dependency on distZip.
+    // The GithubReleaseService is auto-wired via @ServiceReference on the task.
+    distributionZip = tasks.distZip.flatMap { it.archiveFile }
+
+    // Mirror the alpha/snapshot check in releaseToSdkMan: alphas/snapshots have no drafter
+    // draft and SDKMAN skips them, so they get no GitHub release ZIP.
+    onlyIf {
+        !versionString.lowercase(Locale.US).run { contains("snapshot") || contains("alpha") }
+    }
+}
+
 sdkman {
+    // Use a local val for the version: inside this block `version` refers to the extension's
+    // Property<String>, so interpolating "$version" in the URL would embed the property's
+    // toString() ("extension 'sdkman' property 'version'") instead of the value.
+    val profilerVersion = project.version.toString()
     api = "https://vendors.sdkman.io"
     candidate = "gradleprofiler"
     hashtag = "#gradleprofiler"
-    version = project.version.toString()
-    url = "https://repo1.maven.org/maven2/org/gradle/profiler/gradle-profiler/$version/gradle-profiler-$version.zip"
+    version = profilerVersion
+    url = "https://github.com/gradle/gradle-profiler/releases/download/v$profilerVersion/gradle-profiler-$profilerVersion.zip"
     consumerKey = project.findProperty("sdkmanKey") as String?
     consumerToken = project.findProperty("sdkmanToken") as String?
 }

--- a/buildSrc/src/main/kotlin/services/GithubReleaseService.kt
+++ b/buildSrc/src/main/kotlin/services/GithubReleaseService.kt
@@ -1,0 +1,97 @@
+package services
+
+import groovy.json.JsonSlurper
+import org.gradle.api.GradleException
+import org.gradle.api.provider.Property
+import org.gradle.api.services.BuildService
+import org.gradle.api.services.BuildServiceParameters
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Path
+
+/**
+ * Encapsulates the GitHub REST calls needed to publish a release asset, hiding the [HttpClient]
+ * and auth handling from the tasks that use it.
+ */
+abstract class GithubReleaseService : BuildService<GithubReleaseService.Params> {
+
+    interface Params : BuildServiceParameters {
+        /** GitHub token with `contents: write` on the target repository. */
+        val githubToken: Property<String>
+    }
+
+    private val token: String
+        get() = parameters.githubToken.orNull
+            ?: throw GradleException("The 'githubToken' property is required to publish to GitHub Releases.")
+
+    private val client: HttpClient = HttpClient.newHttpClient()
+
+    /**
+     * Attaches [asset] (named [assetName]) to the release-drafter draft tagged [tag] in [repo] and
+     * flips that draft to a published, latest release. Idempotent: a pre-existing asset with the
+     * same name is replaced. Fails loudly if no matching draft exists or any call is non-2xx.
+     */
+    fun publishReleaseAsset(repo: String, tag: String, assetName: String, asset: Path) {
+        val (releaseId, existingAssets) = findDraftRelease(repo, tag)
+        existingAssets
+            .filter { it["name"] == assetName }
+            .forEach { deleteAsset(repo, (it["id"] as Number).toLong()) }
+        uploadAsset(repo, releaseId, assetName, asset)
+        publishRelease(repo, releaseId)
+    }
+
+    private fun findDraftRelease(repo: String, tag: String): Pair<Long, List<Map<String, Any?>>> {
+        val response = send(
+            authorizedRequest("https://api.github.com/repos/$repo/releases?per_page=100").GET().build(),
+            "Listing releases"
+        )
+        @Suppress("UNCHECKED_CAST")
+        val releases = JsonSlurper().parseText(response.body()) as List<Map<String, Any?>>
+        val release = releases.firstOrNull { it["tag_name"] == tag && it["draft"] == true }
+            ?: throw GradleException("No draft release found with tag '$tag' in $repo. release-drafter should have created one before publishing.")
+        @Suppress("UNCHECKED_CAST")
+        val assets = release["assets"] as? List<Map<String, Any?>> ?: emptyList()
+        return (release["id"] as Number).toLong() to assets
+    }
+
+    private fun deleteAsset(repo: String, assetId: Long) {
+        send(
+            authorizedRequest("https://api.github.com/repos/$repo/releases/assets/$assetId").DELETE().build(),
+            "Deleting existing asset $assetId"
+        )
+    }
+
+    private fun uploadAsset(repo: String, releaseId: Long, assetName: String, asset: Path) {
+        send(
+            authorizedRequest("https://uploads.github.com/repos/$repo/releases/$releaseId/assets?name=$assetName")
+                .header("Content-Type", "application/zip")
+                .POST(HttpRequest.BodyPublishers.ofFile(asset))
+                .build(),
+            "Uploading asset $assetName"
+        )
+    }
+
+    private fun publishRelease(repo: String, releaseId: Long) {
+        send(
+            authorizedRequest("https://api.github.com/repos/$repo/releases/$releaseId")
+                .header("Content-Type", "application/json")
+                .method("PATCH", HttpRequest.BodyPublishers.ofString("""{"draft": false, "make_latest": "true"}"""))
+                .build(),
+            "Publishing release $releaseId"
+        )
+    }
+
+    private fun authorizedRequest(uri: String) = HttpRequest.newBuilder(URI.create(uri))
+        .header("Authorization", "Bearer $token")
+        .header("Accept", "application/vnd.github+json")
+
+    private fun send(request: HttpRequest, description: String): HttpResponse<String> {
+        val response = client.send(request, HttpResponse.BodyHandlers.ofString())
+        if (response.statusCode() !in 200..299) {
+            throw GradleException("$description failed: HTTP ${response.statusCode()}\n${response.body()}")
+        }
+        return response
+    }
+}

--- a/buildSrc/src/main/kotlin/tasks/PublishToGithubReleasesTask.kt
+++ b/buildSrc/src/main/kotlin/tasks/PublishToGithubReleasesTask.kt
@@ -1,0 +1,54 @@
+package tasks
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.services.ServiceReference
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import org.gradle.work.DisableCachingByDefault
+import services.GithubReleaseService
+
+/**
+ * Publishes the CLI distribution ZIP to the project's GitHub Releases.
+ *
+ * The release notes are curated by release-drafter, which keeps an unpublished *draft* release
+ * for the upcoming version. This task finds that draft, attaches the distribution ZIP, and flips
+ * it to a published (non-draft) release so the asset is reachable at the public
+ * `releases/download/...` URL that SDKMAN fetches. The actual REST/HTTP work lives in
+ * [GithubReleaseService].
+ */
+@DisableCachingByDefault(because = "Publishes an artifact to GitHub, nothing to cache")
+abstract class PublishToGithubReleasesTask : DefaultTask() {
+
+    /** The `owner/repo` slug to publish to, e.g. `gradle/gradle-profiler`. */
+    @get:Input
+    abstract val repository: Property<String>
+
+    /** The release version (without the leading `v`); the tag is `v$releaseVersion`. */
+    @get:Input
+    abstract val releaseVersion: Property<String>
+
+    /** The distribution ZIP to upload as a release asset. */
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val distributionZip: RegularFileProperty
+
+    @get:ServiceReference("githubRelease")
+    abstract val githubReleaseService: Property<GithubReleaseService>
+
+    @TaskAction
+    fun publish() {
+        val repo = repository.get()
+        val version = releaseVersion.get()
+        val tag = "v$version"
+        val assetName = "gradle-profiler-$version.zip"
+
+        githubReleaseService.get().publishReleaseAsset(repo, tag, assetName, distributionZip.get().asFile.toPath())
+
+        logger.lifecycle("Published GitHub release $tag in $repo with asset $assetName")
+    }
+}


### PR DESCRIPTION
Closes https://github.com/gradle/gradle-profiler/issues/817

## Why

The gradle-profiler **CLI distribution ZIP** (`gradle-profiler-$version.zip`) is published to Maven Central purely to give SDKMAN a stable, unauthenticated download URL. This large binary is driving a Maven Central quota problem.

This PR moves *only the distribution ZIP* to GitHub Releases and points SDKMAN at the release asset. The **library JARs** (subprojects + the main `gradle-profiler` jar/sources/javadoc) keep publishing to Maven Central unchanged — gradle/gradle consumes Gradle-Profiler-as-a-library from there.

## What changed

- **`build.gradle.kts`**
  - Removed the ZIP from the `mavenJava` Maven publication (and the now-unused `archives` artifact).
  - Added a `publishToGithubReleases` task (plain GitHub REST calls via `java.net.http.HttpClient` + `groovy.json.JsonSlurper`, no new plugins/deps). It finds the existing release-drafter **draft** for `v$version`, (idempotently) deletes any stale same-named asset, uploads the `distZip`, then flips the release to published (`draft: false`, `make_latest: true`). Guarded by `onlyIf` to skip snapshots/alphas; `dependsOn(distZip)`, `mustRunAfter(gitPushTag)`. Fails loudly on a missing draft or any non-2xx response.
  - Pointed the SDKMAN `url` at `https://github.com/gradle/gradle-profiler/releases/download/v$version/gradle-profiler-$version.zip`.
- **`.teamcity/.../GradleProfilerPublishing.kt`** — run `publishToGithubReleases` in the publishing build (after `gitPushTag`).
- **`.teamcity/.../GradleProfilerPublishToSdkMan.kt`** — dropped the 30-minute `retryBuild` that waited for Maven Central sync; the GitHub asset is public immediately.
- **`.github/release-drafter.yml`** — prebuilt-download link now points at the GitHub release asset.

## Design note

CI publishes the *existing* release-drafter draft (uploads the asset + flips draft→published), preserving the curated release notes. GitHub draft-release assets aren't reachable at the public `releases/download/...` URL, so the release must be published (non-draft) with the ZIP attached before `releaseToSdkMan` runs.

## Verification

Verified in https://builds.gradle.org/buildConfiguration/GradleProfiler_GradleProfilerPublishToSdkMan/115000529?buildTab=log

- `./gradlew publishToGithubReleases --dry-run -Pprofiler.version=test` → task graph wires `distZip` → `publishToGithubReleases`.
- `./gradlew publishMavenJavaPublicationToMavenLocal -Pprofiler.version=test` → local repo has `.jar`, `-sources.jar`, `-javadoc.jar`, `.pom`, `.module` and **no `.zip`**; pom/module contain no zip references.
- `mvn -f .teamcity/pom.xml compile` → succeeds.
