### PR TITLE
Make Kotlin mutations compatible with the explicit ABI mode

### DIFF
--- a/src/main/java/org/gradle/profiler/mutations/ApplyAbiChangeToKotlinSourceFileMutator.java
+++ b/src/main/java/org/gradle/profiler/mutations/ApplyAbiChangeToKotlinSourceFileMutator.java
@@ -13,7 +13,7 @@ public class ApplyAbiChangeToKotlinSourceFileMutator extends AbstractKotlinSourc
     @Override
     protected void applyChangeTo(BuildContext context, StringBuilder text) {
         text.append("\n\n")
-            .append("fun _m")
+            .append("public fun _m")
             .append(context.getUniqueBuildId())
             .append("() {}");
     }

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToKotlinSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToKotlinSourceFileMutatorTest.groovy
@@ -2,7 +2,7 @@ package org.gradle.profiler.mutations
 
 class ApplyAbiChangeToKotlinSourceFileMutatorTest extends AbstractMutatorTest {
 
-    def "adds and replaces public method at end of source file"() {
+    def "adds and replaces explicitly public method at end of source file"() {
         def sourceFile = tmpDir.newFile("Thing.kt")
         sourceFile.text = "class Thing { fun existingMethod() { }}"
         def mutator = new ApplyAbiChangeToKotlinSourceFileMutator(sourceFile)
@@ -12,7 +12,7 @@ class ApplyAbiChangeToKotlinSourceFileMutatorTest extends AbstractMutatorTest {
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}\n\nfun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7() {}"
+        sourceFile.text == "class Thing { fun existingMethod() { }}\n\npublic fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7() {}"
     }
 
     def "reverts changes when nothing has been applied"() {

--- a/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToSourceFileMutatorTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/mutations/ApplyAbiChangeToSourceFileMutatorTest.groovy
@@ -2,7 +2,7 @@ package org.gradle.profiler.mutations
 
 class ApplyAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest implements JavaParserFixture {
 
-    def "adds and replaces public method at end of Kotlin source file"() {
+    def "adds and replaces explicitly public method at end of Kotlin source file"() {
         def sourceFile = tmpDir.newFile("Thing.kt")
         sourceFile.text = "class Thing { fun existingMethod() { }}"
         def mutator = new ApplyAbiChangeToSourceFileMutator(sourceFile)
@@ -12,7 +12,7 @@ class ApplyAbiChangeToSourceFileMutatorTest extends AbstractMutatorTest implemen
         mutator.beforeBuild(buildContext)
 
         then:
-        sourceFile.text == "class Thing { fun existingMethod() { }}\n\nfun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7() {}"
+        sourceFile.text == "class Thing { fun existingMethod() { }}\n\npublic fun _m_276d92f3_16ac_4064_9a18_5f1dfd67992f_testScenario_3c4925d7_MEASURE_7() {}"
     }
 
     def "adds and replaces public method at end of Java source file"() {


### PR DESCRIPTION
ABI changes in Kotlin files don't add a `public` visibility modifier. This fails to compile, if Kotlin's explicit ABI mode is enabled:
```
Visibility must be specified in explicit API mode.
```

Adding the `public` modifier by default is a safe change. If the explicit ABI mode is enabled, then the code now successfully compiles. If the explicit ABI mode is disabled, then the optional modifier doesn't produce any warning. Only the IDE would highlight it as redundant.

Fixes #504