### PR TITLE
Fix task start measurement under configuration cache reuse

### DIFF
--- a/src/test/groovy/org/gradle/profiler/BuildOperationInstrumentationGradleCrossVersionTest.groovy
+++ b/src/test/groovy/org/gradle/profiler/BuildOperationInstrumentationGradleCrossVersionTest.groovy
@@ -8,6 +8,7 @@ import static org.hamcrest.CoreMatchers.*
 import static org.hamcrest.MatcherAssert.assertThat
 import static org.hamcrest.Matchers.greaterThan
 import static org.hamcrest.Matchers.lessThan
+import static org.hamcrest.Matchers.lessThanOrEqualTo
 import static org.junit.Assert.assertTrue
 
 @Requires({ it.instance.gradleVersionWithAdvancedBenchmarking() })
@@ -164,6 +165,18 @@ class BuildOperationInstrumentationGradleCrossVersionTest extends AbstractGradle
         def taskStart = lines.get(10) =~ /measured build #1,$SAMPLE,($SAMPLE)/
         taskStart.matches()
         Double.valueOf(taskStart[0][1]) > 0
+
+        and:
+        // The task start time is measured from the start of the current build request, so it can never
+        // exceed the total execution time of the same build. With configuration cache reuse, a stale
+        // build start time would make the task start grow by one build duration per invocation.
+        lines.subList(4, lines.size()).collect { it.tokenize(',') }.each { row ->
+            assertThat(
+                "task start should not exceed total execution time for '${row.get(0)}'",
+                Double.valueOf(row.get(2)),
+                lessThanOrEqualTo(Double.valueOf(row.get(1)))
+            )
+        }
 
         where:
         configurationCache << [false, true]
@@ -564,6 +577,18 @@ class BuildOperationInstrumentationGradleCrossVersionTest extends AbstractGradle
         assertTrue("different execution times", executions.size() == 9)
         assertTrue("different task start times", taskStarts.size() == 9)
         assertTrue("different build-op times", buildOps.size() == 9)
+
+        and:
+        // The task start time is measured from the start of the current build request, so it can never
+        // exceed the total execution time of the same build. With configuration cache reuse, a stale
+        // build start time would make the task start grow by one build duration per invocation.
+        [executions, taskStarts].transpose().each { execution, taskStart ->
+            assertThat(
+                "task start should not exceed total execution time",
+                taskStart,
+                lessThanOrEqualTo(execution)
+            )
+        }
 
         where:
         configurationCache << [false, true]

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/BuildOperationMeasurer.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/BuildOperationMeasurer.java
@@ -1,41 +1,46 @@
 package org.gradle.trace.buildops;
 
-import org.gradle.internal.operations.OperationFinishEvent;
 import org.gradle.profiler.buildops.BuildOperationMeasurementKind;
 
 import java.time.Duration;
+import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * Implements the correct calculation based on what {@link BuildOperationMeasurementKind} is requested.
  * Must be thread-safe.
  */
 interface BuildOperationMeasurer {
-    static BuildOperationMeasurer createForKind(BuildOperationMeasurementKind kind, long buildStartTime) {
+    static BuildOperationMeasurer createForKind(BuildOperationMeasurementKind kind) {
         switch (kind) {
             case CUMULATIVE_TIME:
                 return new CumulativeTimeBuildOperationMeasurer();
             case WALL_CLOCK_TIME:
                 return new WallClockTimeBuildOperationMeasurer();
             case TIME_TO_LAST_INCLUSIVE:
-                return new TimeToLastInclusiveBuildOperationMeasurer(buildStartTime);
+                return new TimeToLastInclusiveBuildOperationMeasurer();
             case TIME_TO_FIRST_EXCLUSIVE:
-                return new TimeToFirstExclusiveBuildOperationMeasurer(buildStartTime);
+                return new TimeToFirstExclusiveBuildOperationMeasurer();
             default:
                 throw new IllegalArgumentException("Unsupported BuildOperationMeasurementKind: " + kind);
         }
     }
 
     /**
-     * Update the measurer with data from the finished operation.
+     * Update the measurer with data from a finished operation.
      *
-     * @param event the finished operation event
+     * @param startTime the absolute timestamp at which the operation started
+     * @param endTime the absolute timestamp at which the operation ended
      */
-    void update(OperationFinishEvent event);
+    void update(long startTime, long endTime);
 
     /**
      * Compute the final measured value.
      *
-     * @return the final measured value
+     * @param buildStartTime the absolute timestamp at which the current build invocation started,
+     * used as the reference point for measurement kinds that report a time within the build.
+     * May be absent if it could not be observed, e.g. on configuration failure.
+     * @return the final measured value, or empty if the build start time is required but absent
      */
-    Duration computeFinalValue();
+    Optional<Duration> computeFinalValue(OptionalLong buildStartTime);
 }

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/BuildOperationTrace.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/BuildOperationTrace.java
@@ -7,14 +7,12 @@ import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.internal.GradleInternal;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
-import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.services.BuildService;
 import org.gradle.api.services.BuildServiceParameters;
 import org.gradle.api.services.BuildServiceRegistry;
 import org.gradle.execution.RunRootBuildWorkBuildOperationType;
-import org.gradle.initialization.BuildRequestMetaData;
 import org.gradle.internal.build.event.BuildEventListenerRegistryInternal;
 import org.gradle.internal.file.PathToFileResolver;
 import org.gradle.internal.operations.BuildOperationDescriptor;
@@ -40,8 +38,11 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -97,7 +98,6 @@ public class BuildOperationTrace {
                     BuildOperationMeasurementKind.TIME_TO_FIRST_EXCLUSIVE
                 )
             );
-            spec.getParameters().getBuildStartTime().set(gradle.getServices().get(BuildRequestMetaData.class).getStartTime());
         });
         registry.onOperationCompletion(listenerProvider);
         return this;
@@ -106,7 +106,6 @@ public class BuildOperationTrace {
     public BuildOperationTrace measureBuildOperations(List<InternalBuildOpMeasurementRequest> capturedBuildOperations) {
         Provider<BuildOperationDurationRecordingListener> listenerProvider = sharedServices.registerIfAbsent("measure-build-operations", BuildOperationDurationRecordingListener.class, spec -> {
             spec.getParameters().getCapturedBuildOperations().set(capturedBuildOperations);
-            spec.getParameters().getBuildStartTime().set(gradle.getServices().get(BuildRequestMetaData.class).getStartTime());
         });
         registry.onOperationCompletion(listenerProvider);
         return this;
@@ -207,11 +206,20 @@ public class BuildOperationTrace {
     public static abstract class BuildOperationDurationRecordingListener implements BuildService<BuildOperationDurationRecordingListener.Params>, BuildOperationListener, AutoCloseable {
         interface Params extends BuildServiceParameters {
             ListProperty<InternalBuildOpMeasurementRequest> getCapturedBuildOperations();
-
-            Property<Long> getBuildStartTime();
         }
 
         private final List<BuildOperationCollector> collectors;
+
+        /**
+         * The start time of the current build invocation, observed from the root build work operation.
+         * This must be observed per invocation rather than captured when the build service is registered:
+         * the registration only runs when the init script is executed, so with configuration cache reuse
+         * a captured value would be restored from the cache snapshot and belong to the build that created
+         * the cache entry. Operation details are created freshly for every invocation, so
+         * {@link RunRootBuildWorkBuildOperationType.Details#getBuildStartTime()} always reflects the
+         * current build request. Absent if the operation did not fire, e.g. on configuration failure.
+         */
+        private final AtomicReference<OptionalLong> observedBuildStartTime = new AtomicReference<>(OptionalLong.empty());
 
         @Inject
         public BuildOperationDurationRecordingListener(ObjectFactory objectFactory) {
@@ -226,11 +234,7 @@ public class BuildOperationTrace {
                     continue;
                 }
 
-                BuildOperationMeasurer measurer = BuildOperationMeasurer.createForKind(
-                    request.getMeasurementKind(),
-                    getParameters().getBuildStartTime().get()
-                );
-
+                BuildOperationMeasurer measurer = BuildOperationMeasurer.createForKind(request.getMeasurementKind());
                 collectors.add(new BuildOperationCollector(detailsType, request.getOutputFile(), measurer));
             }
         }
@@ -249,6 +253,9 @@ public class BuildOperationTrace {
             if (details == null) {
                 return;
             }
+            if (details instanceof RunRootBuildWorkBuildOperationType.Details) {
+                observedBuildStartTime.set(OptionalLong.of(((RunRootBuildWorkBuildOperationType.Details) details).getBuildStartTime()));
+            }
             for (BuildOperationCollector collector : collectors) {
                 collector.collect(details, operationFinishEvent);
             }
@@ -256,19 +263,21 @@ public class BuildOperationTrace {
 
         @Override
         public void close() throws IOException {
+            OptionalLong buildStartTime = observedBuildStartTime.get();
             for (BuildOperationCollector collector : collectors) {
-                collector.write();
+                collector.write(buildStartTime);
             }
         }
     }
 
-    private static class BuildOperationCollector {
+    // Visible for testing
+    static class BuildOperationCollector {
         private final Class<?> detailsType;
         private final Path outputFile;
         private final BuildOperationMeasurer measurer;
         private final AtomicInteger buildOperationCount = new AtomicInteger(0);
 
-        private BuildOperationCollector(Class<?> detailsType, Path outputFile, BuildOperationMeasurer measurer) {
+        BuildOperationCollector(Class<?> detailsType, Path outputFile, BuildOperationMeasurer measurer) {
             this.detailsType = detailsType;
             this.outputFile = outputFile;
             this.measurer = measurer;
@@ -276,14 +285,20 @@ public class BuildOperationTrace {
 
         public void collect(Object details, OperationFinishEvent operationFinishEvent) {
             if (detailsType.isAssignableFrom(details.getClass())) {
-                measurer.update(operationFinishEvent);
+                measurer.update(operationFinishEvent.getStartTime(), operationFinishEvent.getEndTime());
                 buildOperationCount.incrementAndGet();
             }
         }
 
-        public void write() throws IOException {
-            Duration value = measurer.computeFinalValue();
-            writeToFile(outputFile, value.toMillis(), buildOperationCount.get());
+        public void write(OptionalLong buildStartTime) throws IOException {
+            Optional<Duration> value = measurer.computeFinalValue(buildStartTime);
+            if (value.isPresent()) {
+                writeToFile(outputFile, value.get().toMillis(), buildOperationCount.get());
+            } else {
+                // Truncate the file so a value from a previous invocation is not mistaken
+                // for a result of this one. The profiler treats an empty file as a missing sample.
+                Files.write(outputFile, new byte[0]);
+            }
         }
     }
 }

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/CumulativeTimeBuildOperationMeasurer.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/CumulativeTimeBuildOperationMeasurer.java
@@ -1,8 +1,8 @@
 package org.gradle.trace.buildops;
 
-import org.gradle.internal.operations.OperationFinishEvent;
-
 import java.time.Duration;
+import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicLong;
 
 final class CumulativeTimeBuildOperationMeasurer implements BuildOperationMeasurer {
@@ -12,13 +12,12 @@ final class CumulativeTimeBuildOperationMeasurer implements BuildOperationMeasur
     }
 
     @Override
-    public void update(OperationFinishEvent event) {
-        long duration = event.getEndTime() - event.getStartTime();
-        buildOperationTime.addAndGet(duration);
+    public void update(long startTime, long endTime) {
+        buildOperationTime.addAndGet(endTime - startTime);
     }
 
     @Override
-    public Duration computeFinalValue() {
-        return Duration.ofMillis(buildOperationTime.get());
+    public Optional<Duration> computeFinalValue(OptionalLong buildStartTime) {
+        return Optional.of(Duration.ofMillis(buildOperationTime.get()));
     }
 }

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/TimeToFirstExclusiveBuildOperationMeasurer.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/TimeToFirstExclusiveBuildOperationMeasurer.java
@@ -1,21 +1,15 @@
 package org.gradle.trace.buildops;
 
-import org.gradle.internal.operations.OperationFinishEvent;
-
 import java.time.Duration;
+import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicLong;
 
 final class TimeToFirstExclusiveBuildOperationMeasurer implements BuildOperationMeasurer {
-    private final long buildStartTime;
     private final AtomicLong minStartTime = new AtomicLong(Long.MIN_VALUE);
 
-    TimeToFirstExclusiveBuildOperationMeasurer(long buildStartTime) {
-        this.buildStartTime = buildStartTime;
-    }
-
     @Override
-    public void update(OperationFinishEvent event) {
-        long startTime = event.getStartTime();
+    public void update(long startTime, long endTime) {
         minStartTime.getAndUpdate(existing -> {
             if (existing == Long.MIN_VALUE) {
                 // First update, initialize to the start time of the first operation
@@ -26,12 +20,16 @@ final class TimeToFirstExclusiveBuildOperationMeasurer implements BuildOperation
     }
 
     @Override
-    public Duration computeFinalValue() {
-        long minStart = minStartTime.get();
-        if (minStart < buildStartTime) {
-            // No operations were recorded, or all operations started before the build start time
-            return Duration.ZERO;
+    public Optional<Duration> computeFinalValue(OptionalLong buildStartTime) {
+        if (!buildStartTime.isPresent()) {
+            // No reference point to measure against
+            return Optional.empty();
         }
-        return Duration.ofMillis(minStartTime.get() - buildStartTime);
+        long minStart = minStartTime.get();
+        if (minStart == Long.MIN_VALUE || minStart < buildStartTime.getAsLong()) {
+            // No operations were recorded, or all operations started before the build start time
+            return Optional.of(Duration.ZERO);
+        }
+        return Optional.of(Duration.ofMillis(minStart - buildStartTime.getAsLong()));
     }
 }

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/TimeToLastInclusiveBuildOperationMeasurer.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/TimeToLastInclusiveBuildOperationMeasurer.java
@@ -1,28 +1,29 @@
 package org.gradle.trace.buildops;
 
-import org.gradle.internal.operations.OperationFinishEvent;
-
 import java.time.Duration;
+import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.atomic.AtomicLong;
 
 final class TimeToLastInclusiveBuildOperationMeasurer implements BuildOperationMeasurer {
-    private final long buildStartTime;
-    private final AtomicLong maxEndTime;
-
-    TimeToLastInclusiveBuildOperationMeasurer(long buildStartTime) {
-        this.buildStartTime = buildStartTime;
-        // Make sure we're never earlier than the build start time, even if no operations are recorded
-        this.maxEndTime = new AtomicLong(buildStartTime);
-    }
+    private final AtomicLong maxEndTime = new AtomicLong(Long.MIN_VALUE);
 
     @Override
-    public void update(OperationFinishEvent event) {
-        long endTime = event.getEndTime();
+    public void update(long startTime, long endTime) {
         maxEndTime.getAndUpdate(existing -> Math.max(existing, endTime));
     }
 
     @Override
-    public Duration computeFinalValue() {
-        return Duration.ofMillis(maxEndTime.get() - buildStartTime);
+    public Optional<Duration> computeFinalValue(OptionalLong buildStartTime) {
+        if (!buildStartTime.isPresent()) {
+            // No reference point to measure against
+            return Optional.empty();
+        }
+        long maxEnd = maxEndTime.get();
+        if (maxEnd == Long.MIN_VALUE || maxEnd < buildStartTime.getAsLong()) {
+            // No operations were recorded, or all operations ended before the build start time
+            return Optional.of(Duration.ZERO);
+        }
+        return Optional.of(Duration.ofMillis(maxEnd - buildStartTime.getAsLong()));
     }
 }

--- a/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/WallClockTimeBuildOperationMeasurer.java
+++ b/subprojects/build-operations/src/main/java/org/gradle/trace/buildops/WallClockTimeBuildOperationMeasurer.java
@@ -3,9 +3,10 @@ package org.gradle.trace.buildops;
 import com.google.common.collect.Range;
 import com.google.common.collect.RangeSet;
 import com.google.common.collect.TreeRangeSet;
-import org.gradle.internal.operations.OperationFinishEvent;
 
 import java.time.Duration;
+import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.concurrent.locks.ReentrantLock;
 
 final class WallClockTimeBuildOperationMeasurer implements BuildOperationMeasurer {
@@ -15,8 +16,8 @@ final class WallClockTimeBuildOperationMeasurer implements BuildOperationMeasure
     private final ReentrantLock lock = new ReentrantLock();
 
     @Override
-    public void update(OperationFinishEvent event) {
-        Range<Long> eventRange = Range.closed(event.getStartTime(), event.getEndTime());
+    public void update(long startTime, long endTime) {
+        Range<Long> eventRange = Range.closed(startTime, endTime);
 
         lock.lock();
         try {
@@ -27,7 +28,7 @@ final class WallClockTimeBuildOperationMeasurer implements BuildOperationMeasure
     }
 
     @Override
-    public Duration computeFinalValue() {
+    public Optional<Duration> computeFinalValue(OptionalLong buildStartTime) {
         long totalTime = 0;
         lock.lock();
         try {
@@ -37,6 +38,6 @@ final class WallClockTimeBuildOperationMeasurer implements BuildOperationMeasure
         } finally {
             lock.unlock();
         }
-        return Duration.ofMillis(totalTime);
+        return Optional.of(Duration.ofMillis(totalTime));
     }
 }

--- a/subprojects/build-operations/src/test/groovy/org/gradle/trace/buildops/BuildOperationCollectorTest.groovy
+++ b/subprojects/build-operations/src/test/groovy/org/gradle/trace/buildops/BuildOperationCollectorTest.groovy
@@ -1,0 +1,44 @@
+package org.gradle.trace.buildops
+
+import org.gradle.internal.operations.OperationFinishEvent
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+import static org.gradle.profiler.buildops.BuildOperationMeasurementKind.TIME_TO_FIRST_EXCLUSIVE
+
+class BuildOperationCollectorTest extends Specification {
+
+    @TempDir
+    Path tempDir
+
+    def "write overwrites the previous run's content when the measured value is present"() {
+        given:
+        def outputFile = tempDir.resolve("output.txt")
+        Files.write(outputFile, ["12345,1"])
+        def collector = new BuildOperationTrace.BuildOperationCollector(Object, outputFile, BuildOperationMeasurer.createForKind(TIME_TO_FIRST_EXCLUSIVE))
+        collector.collect(new Object(), new OperationFinishEvent(250, 400, null, null))
+
+        when:
+        collector.write(OptionalLong.of(100))
+
+        then:
+        Files.readAllLines(outputFile) == ["150,1"]
+    }
+
+    def "write truncates the previous run's content when the measured value is absent"() {
+        given:
+        def outputFile = tempDir.resolve("output.txt")
+        Files.write(outputFile, ["12345,1"])
+        def collector = new BuildOperationTrace.BuildOperationCollector(Object, outputFile, BuildOperationMeasurer.createForKind(TIME_TO_FIRST_EXCLUSIVE))
+        collector.collect(new Object(), new OperationFinishEvent(250, 400, null, null))
+
+        when:
+        collector.write(OptionalLong.empty())
+
+        then:
+        Files.size(outputFile) == 0
+    }
+}

--- a/subprojects/build-operations/src/test/groovy/org/gradle/trace/buildops/BuildOperationMeasurerTest.groovy
+++ b/subprojects/build-operations/src/test/groovy/org/gradle/trace/buildops/BuildOperationMeasurerTest.groovy
@@ -1,10 +1,11 @@
 package org.gradle.trace.buildops
 
-import org.gradle.internal.operations.OperationFinishEvent
 import org.gradle.profiler.buildops.BuildOperationMeasurementKind
 import spock.lang.Specification
 
 import java.time.Duration
+import java.util.Optional
+import java.util.OptionalLong
 
 import static org.gradle.profiler.buildops.BuildOperationMeasurementKind.CUMULATIVE_TIME
 import static org.gradle.profiler.buildops.BuildOperationMeasurementKind.TIME_TO_FIRST_EXCLUSIVE
@@ -15,7 +16,7 @@ class BuildOperationMeasurerTest extends Specification {
 
     def "can create measurer for valid measurement kind '#kind'"() {
         expect:
-        BuildOperationMeasurer.createForKind(kind, 0L) != null
+        BuildOperationMeasurer.createForKind(kind) != null
 
         where:
         kind << BuildOperationMeasurementKind.values()
@@ -23,188 +24,250 @@ class BuildOperationMeasurerTest extends Specification {
 
     // --- CUMULATIVE_TIME ---
 
+    def "cumulative time is measured even when build start time is absent"() {
+        given:
+        def measurer = BuildOperationMeasurer.createForKind(CUMULATIVE_TIME)
+
+        when:
+        measurer.update(100, 300)
+
+        then:
+        measurer.computeFinalValue(OptionalLong.empty()) == Optional.of(Duration.ofMillis(200))
+    }
+
     def "cumulative time with no events returns zero"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(CUMULATIVE_TIME, 0L)
+        def measurer = BuildOperationMeasurer.createForKind(CUMULATIVE_TIME)
 
         expect:
-        measurer.computeFinalValue() == Duration.ZERO
+        measurer.computeFinalValue(OptionalLong.of(0L)) == Optional.of(Duration.ZERO)
     }
 
     def "cumulative time with single event returns its duration"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(CUMULATIVE_TIME, 0L)
+        def measurer = BuildOperationMeasurer.createForKind(CUMULATIVE_TIME)
 
         when:
-        measurer.update(event(100, 300))
+        measurer.update(100, 300)
 
         then:
-        measurer.computeFinalValue() == Duration.ofMillis(200)
+        measurer.computeFinalValue(OptionalLong.of(0L)) == Optional.of(Duration.ofMillis(200))
     }
 
     def "cumulative time sums all event durations"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(CUMULATIVE_TIME, 0L)
+        def measurer = BuildOperationMeasurer.createForKind(CUMULATIVE_TIME)
 
         when:
-        measurer.update(event(100, 200))
-        measurer.update(event(300, 500))
+        measurer.update(100, 200)
+        measurer.update(300, 500)
 
         then:
-        measurer.computeFinalValue() == Duration.ofMillis(300)
+        measurer.computeFinalValue(OptionalLong.of(0L)) == Optional.of(Duration.ofMillis(300))
     }
 
     def "cumulative time counts overlapping durations multiple times"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(CUMULATIVE_TIME, 0L)
+        def measurer = BuildOperationMeasurer.createForKind(CUMULATIVE_TIME)
 
         when:
-        measurer.update(event(100, 300))
-        measurer.update(event(200, 400))
+        measurer.update(100, 300)
+        measurer.update(200, 400)
 
         then:
-        measurer.computeFinalValue() == Duration.ofMillis(400)
+        measurer.computeFinalValue(OptionalLong.of(0L)) == Optional.of(Duration.ofMillis(400))
     }
 
     def "cumulative time sums correctly when events arrive out of order"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(CUMULATIVE_TIME, 0L)
+        def measurer = BuildOperationMeasurer.createForKind(CUMULATIVE_TIME)
 
         when:
-        measurer.update(event(300, 500))
-        measurer.update(event(100, 200))
+        measurer.update(300, 500)
+        measurer.update(100, 200)
 
         then:
-        measurer.computeFinalValue() == Duration.ofMillis(300)
+        measurer.computeFinalValue(OptionalLong.of(0L)) == Optional.of(Duration.ofMillis(300))
     }
 
     // --- WALL_CLOCK_TIME ---
 
+    def "wall clock time is measured even when build start time is absent"() {
+        given:
+        def measurer = BuildOperationMeasurer.createForKind(WALL_CLOCK_TIME)
+
+        when:
+        measurer.update(100, 300)
+
+        then:
+        measurer.computeFinalValue(OptionalLong.empty()) == Optional.of(Duration.ofMillis(200))
+    }
+
     def "wall clock time with no events returns zero"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(WALL_CLOCK_TIME, 0L)
+        def measurer = BuildOperationMeasurer.createForKind(WALL_CLOCK_TIME)
 
         expect:
-        measurer.computeFinalValue() == Duration.ZERO
+        measurer.computeFinalValue(OptionalLong.of(0L)) == Optional.of(Duration.ZERO)
     }
 
     def "wall clock time with single event returns its duration"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(WALL_CLOCK_TIME, 0L)
+        def measurer = BuildOperationMeasurer.createForKind(WALL_CLOCK_TIME)
 
         when:
-        measurer.update(event(100, 300))
+        measurer.update(100, 300)
 
         then:
-        measurer.computeFinalValue() == Duration.ofMillis(200)
+        measurer.computeFinalValue(OptionalLong.of(0L)) == Optional.of(Duration.ofMillis(200))
     }
 
     def "wall clock time sums non-overlapping event durations"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(WALL_CLOCK_TIME, 0L)
+        def measurer = BuildOperationMeasurer.createForKind(WALL_CLOCK_TIME)
 
         when:
-        measurer.update(event(100, 200))
-        measurer.update(event(300, 500))
+        measurer.update(100, 200)
+        measurer.update(300, 500)
 
         then:
-        measurer.computeFinalValue() == Duration.ofMillis(300)
+        measurer.computeFinalValue(OptionalLong.of(0L)) == Optional.of(Duration.ofMillis(300))
     }
 
     def "wall clock time merges overlapping events"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(WALL_CLOCK_TIME, 0L)
+        def measurer = BuildOperationMeasurer.createForKind(WALL_CLOCK_TIME)
 
         when:
-        measurer.update(event(100, 300))
-        measurer.update(event(200, 400))
+        measurer.update(100, 300)
+        measurer.update(200, 400)
 
         then:
-        measurer.computeFinalValue() == Duration.ofMillis(300)
+        measurer.computeFinalValue(OptionalLong.of(0L)) == Optional.of(Duration.ofMillis(300))
     }
 
     def "wall clock time merges overlapping events arriving out of order"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(WALL_CLOCK_TIME, 0L)
+        def measurer = BuildOperationMeasurer.createForKind(WALL_CLOCK_TIME)
 
         when:
-        measurer.update(event(100, 300))
-        measurer.update(event(400, 600))
-        measurer.update(event(250, 350))
+        measurer.update(100, 300)
+        measurer.update(400, 600)
+        measurer.update(250, 350)
 
         then:
-        measurer.computeFinalValue() == Duration.ofMillis(450)
+        measurer.computeFinalValue(OptionalLong.of(0L)) == Optional.of(Duration.ofMillis(450))
     }
 
     // --- TIME_TO_FIRST_EXCLUSIVE ---
 
     def "time to first exclusive with no events returns zero"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_FIRST_EXCLUSIVE, 100L)
+        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_FIRST_EXCLUSIVE)
 
         expect:
-        measurer.computeFinalValue() == Duration.ZERO
+        measurer.computeFinalValue(OptionalLong.of(100L)) == Optional.of(Duration.ZERO)
     }
 
     def "time to first exclusive with single event returns time from build start to event start"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_FIRST_EXCLUSIVE, 100L)
+        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_FIRST_EXCLUSIVE)
 
         when:
-        measurer.update(event(250, 400))
+        measurer.update(250, 400)
 
         then:
-        measurer.computeFinalValue() == Duration.ofMillis(150)
+        measurer.computeFinalValue(OptionalLong.of(100L)) == Optional.of(Duration.ofMillis(150))
     }
 
     def "time to first exclusive returns time to earliest event start"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_FIRST_EXCLUSIVE, 100L)
+        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_FIRST_EXCLUSIVE)
 
         when:
-        measurer.update(event(400, 500))
-        measurer.update(event(200, 300))
-        measurer.update(event(300, 450))
+        measurer.update(400, 500)
+        measurer.update(200, 300)
+        measurer.update(300, 450)
 
         then:
-        measurer.computeFinalValue() == Duration.ofMillis(100)
+        measurer.computeFinalValue(OptionalLong.of(100L)) == Optional.of(Duration.ofMillis(100))
+    }
+
+    def "time to first exclusive returns empty when build start time is absent"() {
+        given:
+        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_FIRST_EXCLUSIVE)
+
+        when:
+        measurer.update(250, 400)
+
+        then:
+        measurer.computeFinalValue(OptionalLong.empty()) == Optional.empty()
+    }
+
+    def "time to first exclusive returns zero when all events started before the build start time"() {
+        given:
+        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_FIRST_EXCLUSIVE)
+
+        when:
+        measurer.update(50, 300)
+
+        then:
+        measurer.computeFinalValue(OptionalLong.of(100L)) == Optional.of(Duration.ZERO)
     }
 
     // --- TIME_TO_LAST_INCLUSIVE ---
 
     def "time to last inclusive with no events returns zero"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_LAST_INCLUSIVE, 100L)
+        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_LAST_INCLUSIVE)
 
         expect:
-        measurer.computeFinalValue() == Duration.ZERO
+        measurer.computeFinalValue(OptionalLong.of(100L)) == Optional.of(Duration.ZERO)
     }
 
     def "time to last inclusive with single event returns time from build start to event end"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_LAST_INCLUSIVE, 100L)
+        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_LAST_INCLUSIVE)
 
         when:
-        measurer.update(event(200, 500))
+        measurer.update(200, 500)
 
         then:
-        measurer.computeFinalValue() == Duration.ofMillis(400)
+        measurer.computeFinalValue(OptionalLong.of(100L)) == Optional.of(Duration.ofMillis(400))
     }
 
     def "time to last inclusive returns time to latest event end"() {
         given:
-        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_LAST_INCLUSIVE, 100L)
+        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_LAST_INCLUSIVE)
 
         when:
-        measurer.update(event(200, 300))
-        measurer.update(event(250, 600))
-        measurer.update(event(400, 500))
+        measurer.update(200, 300)
+        measurer.update(250, 600)
+        measurer.update(400, 500)
 
         then:
-        measurer.computeFinalValue() == Duration.ofMillis(500)
+        measurer.computeFinalValue(OptionalLong.of(100L)) == Optional.of(Duration.ofMillis(500))
     }
 
-    private static OperationFinishEvent event(long startTime, long endTime) {
-        return new OperationFinishEvent(startTime, endTime, null, null)
+    def "time to last inclusive returns empty when build start time is absent"() {
+        given:
+        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_LAST_INCLUSIVE)
+
+        when:
+        measurer.update(200, 500)
+
+        then:
+        measurer.computeFinalValue(OptionalLong.empty()) == Optional.empty()
+    }
+
+    def "time to last inclusive returns zero when all events ended before the build start time"() {
+        given:
+        def measurer = BuildOperationMeasurer.createForKind(TIME_TO_LAST_INCLUSIVE)
+
+        when:
+        measurer.update(20, 50)
+
+        then:
+        measurer.computeFinalValue(OptionalLong.of(100L)) == Optional.of(Duration.ZERO)
     }
 }


### PR DESCRIPTION
The build start time captured when the build service is registered is restored from the configuration cache snapshot on reuse, so it belongs to the build that created the cache entry. This made the task start measurement grow by roughly one build duration per invocation.

Prefer the build start time carried by the operation details, which is created fresh for every invocation. Falls back to the captured value for operation types whose details do not expose a build start time.

Fixes #739 