### PR TITLE
Update signing configuration for PGP subkey

### DIFF
--- a/.teamcity/src/main/kotlin/GradleProfilerPublishing.kt
+++ b/.teamcity/src/main/kotlin/GradleProfilerPublishing.kt
@@ -23,6 +23,7 @@ object GradleProfilerPublishing : BuildType({
         param("env.ORG_GRADLE_PROJECT_sdkmanToken", "%gradleprofiler.sdkman.token%")
         param("env.GRADLE_CACHE_REMOTE_USERNAME", "%gradle.cache.remote.username%")
         param("env.GRADLE_CACHE_REMOTE_PASSWORD", "%gradle.cache.remote.password%")
+        param("env.PGP_SIGNING_KEY_ID", "%pgpSigningKeyId%")
         param("env.PGP_SIGNING_KEY", "%pgpSigningKey%")
         param("env.PGP_SIGNING_KEY_PASSPHRASE", "%pgpSigningPassphrase%")
         param("env.ORG_GRADLE_PROJECT_sonatypeUsername", "%mavenCentralStagingRepoUser%")

--- a/buildSrc/src/main/kotlin/profiler.publication.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.publication.gradle.kts
@@ -61,6 +61,8 @@ tasks.withType<Sign>().configureEach { isEnabled = signArtifacts }
 
 signing {
     useInMemoryPgpKeys(
+        // Key ID required when signing with a subkey
+        project.providers.environmentVariable("PGP_SIGNING_KEY_ID").orNull,
         project.providers.environmentVariable("PGP_SIGNING_KEY").orNull,
         project.providers.environmentVariable("PGP_SIGNING_KEY_PASSPHRASE").orNull
     )


### PR DESCRIPTION
After the move to a signing subkey following the August 14 security incident, `useInMemoryPgpKeys` needs the key ID as its first argument — without it the signing plugin falls back to the primary key.

This adds the key ID to the `signing {}` block and makes the publishing build configuration pass it as `env.PGP_SIGNING_KEY_ID`, matching what was already done in gradle/gradle#38874, gradle/gradle-promote#382 and gradle/gradle-pom-properties#20.

The `pgpSigningKeyId` TeamCity parameter is already defined on the parent project, so no new secret is needed.

Docs: https://docs.gradle.org/current/userguide/signing_plugin.html#sec:subkeys
Part of gradle/gradle-private#5321