### PR TITLE
Upgrade build to Gradle 9.7.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,8 +20,8 @@ plugins {
 
 description = "A tool to profile and benchmark Gradle builds"
 
-val gradleRuntime by configurations.creating
-val profilerPlugins by configurations.creating
+val gradleRuntime = configurations.create("gradleRuntime")
+val profilerPlugins = configurations.create("profilerPlugins")
 
 dependencies {
     // gradle/gradle uses these as part of Gradle Profiler-as-a-library

--- a/buildSrc/src/main/kotlin/profiler.ide-setup.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.ide-setup.gradle.kts
@@ -51,8 +51,8 @@ val intellijExtension = extensions.create<IntellijTestExtension>("intellijTests"
     headlessMode.convention(false)
 }
 
-val androidStudioRuntime by configurations.creating
-val intellijRuntime by configurations.creating
+val androidStudioRuntime = configurations.create("androidStudioRuntime")
+val intellijRuntime = configurations.create("intellijRuntime")
 
 dependencies {
     val androidStudioFileExtension = when {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
### Summary

Move the build to the current Gradle release, and remove the Kotlin DSL syntax that Gradle 10 will delete.

### Why

The build was three releases behind. No issue tracked this: routine wrapper bumps in this repo land as plain commits, and Dependabot does not watch the wrapper.

The upgrade then forced a second change. Gradle 9.6 deprecated the `by creating` container delegate, so the build started to declare itself incompatible with Gradle 10. This was invisible before the bump, because 9.4.1 does not warn about it.

### What

- Wrapper `9.4.1` → `9.7.1`, applied with the `wrapper` task.
- Configuration declarations in the root build and the IDE setup convention plugin use the container `create` API instead of the deprecated property delegate.

### Verification

- CI covers the full matrix of 3 operating systems and 3 JDKs.
- Deprecation count went from 4 to 0, measured with `--warning-mode all` across the sanity check, assemble, test compilation, publishing and IDE provisioning paths, with and without the configuration cache.

### Details

**The Tooling API stays at 8.14.3.** It is the client that drives profiled builds from Gradle 6.x to 9.x, so its version is independent of the version this project builds with. A wider client version does not widen the supported target range. Revisit it when a target version needs an API that 8.14.3 does not have.

**The delegate replacement keeps the same types.** The declarations still produce `Configuration` instances, so the artifact filtering in the root build and the distribution wiring in the IDE setup plugin are unaffected. The upgrade guide offers a lazy `register` alternative; the eager form was kept because each of these configurations is consumed in the file that declares it, so deferring creation adds no value.

**Two red checks are pre-existing, not caused by this change.**

- `dependency-review` reports two advisories for a transitive `jackson-core@2.20.2`. This repo declares no Jackson dependency, and the same check failed on an unrelated branch on the same day.
- `macOS - Java 25` fails one async-profiler cold-daemon scenario, where `asprof` cannot attach to the target JVM. The same failure occurred on `master` on 9 August and on `update-signing-configuration` 4 hours before this branch ran. Across those three runs the profiled target version differs (6.9.4, 8.14.4) and the scenario differs, while the agent stays the same. This points at the agent rather than at any target version, and the wrapper version cannot reach it. No tracker issue covers it yet.
