### PR TITLE
Improve Isolated Projects compatibility of the build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,10 +4,12 @@ import io.sdkman.vendors.tasks.SdkDefaultVersion
 import io.sdkman.vendors.tasks.SdkReleaseVersion
 import io.sdkman.vendors.tasks.SdkmanVendorBaseTask
 import java.util.Locale
+import org.gradle.kotlin.dsl.support.serviceOf
 import services.GithubReleaseService
 
 plugins {
     id("profiler.java-library")
+    id("profiler.versioning-root-project")
     id("profiler.ide-setup")
     groovy
     application
@@ -15,7 +17,7 @@ plugins {
     id("profiler.publication")
     alias(libs.plugins.node)
     alias(libs.plugins.sdkman)
-    alias(libs.plugins.nexus)
+    alias(libs.plugins.nexus) apply false
 }
 
 description = "A tool to profile and benchmark Gradle builds"
@@ -223,12 +225,21 @@ tasks.register("testHtmlReports") {
     dependsOn(testReports.keys)
 }
 
-nexusPublishing {
-    packageGroup.set(project.group.toString())
-    repositories {
-        sonatype {
-            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+// The Nexus publish plugin configures every subproject through `allprojects`, which
+// Isolated Projects forbids. Publishing always runs without the configuration cache
+// (see the TeamCity publishing job), so the plugin is only applied when the feature
+// that it is incompatible with is inactive.
+val isolatedProjectsActive = serviceOf<org.gradle.api.configuration.BuildFeatures>()
+    .isolatedProjects.active.get()
+if (!isolatedProjectsActive) {
+    apply(plugin = "io.github.gradle-nexus.publish-plugin")
+    configure<io.github.gradlenexus.publishplugin.NexusPublishExtension> {
+        packageGroup.set(project.group.toString())
+        repositories {
+            sonatype {
+                nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+                snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            }
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,6 @@ import io.sdkman.vendors.tasks.SdkDefaultVersion
 import io.sdkman.vendors.tasks.SdkReleaseVersion
 import io.sdkman.vendors.tasks.SdkmanVendorBaseTask
 import java.util.Locale
-import org.gradle.kotlin.dsl.support.serviceOf
 import services.GithubReleaseService
 
 plugins {
@@ -17,7 +16,7 @@ plugins {
     id("profiler.publication")
     alias(libs.plugins.node)
     alias(libs.plugins.sdkman)
-    alias(libs.plugins.nexus) apply false
+    alias(libs.plugins.nexus)
 }
 
 description = "A tool to profile and benchmark Gradle builds"
@@ -225,21 +224,12 @@ tasks.register("testHtmlReports") {
     dependsOn(testReports.keys)
 }
 
-// The Nexus publish plugin configures every subproject through `allprojects`, which
-// Isolated Projects forbids. Publishing always runs without the configuration cache
-// (see the TeamCity publishing job), so the plugin is only applied when the feature
-// that it is incompatible with is inactive.
-val isolatedProjectsActive = serviceOf<org.gradle.api.configuration.BuildFeatures>()
-    .isolatedProjects.active.get()
-if (!isolatedProjectsActive) {
-    apply(plugin = "io.github.gradle-nexus.publish-plugin")
-    configure<io.github.gradlenexus.publishplugin.NexusPublishExtension> {
-        packageGroup.set(project.group.toString())
-        repositories {
-            sonatype {
-                nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
-                snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
-            }
+nexusPublishing {
+    packageGroup.set(project.group.toString())
+    repositories {
+        sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }

--- a/buildSrc/src/main/kotlin/extensions/VersionInfo.kt
+++ b/buildSrc/src/main/kotlin/extensions/VersionInfo.kt
@@ -1,7 +1,0 @@
-package extensions
-
-import org.gradle.api.provider.Property
-
-interface VersionInfo {
-    val version: Property<String>
-}

--- a/buildSrc/src/main/kotlin/profiler.versioning-root-project.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.versioning-root-project.gradle.kts
@@ -1,30 +1,13 @@
-import extensions.VersionInfo
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
-import java.util.Properties
 
-val incomingBuildReceiptLocation = "incoming-distributions/$buildReceiptName"
-
-val versionInfo = extensions.create<VersionInfo>("versionInfo")
-val incomingBuildReceipt = file(incomingBuildReceiptLocation)
-val profilerVersion = if (incomingBuildReceipt.isFile) {
-    val properties = Properties()
-    Files.newInputStream(incomingBuildReceipt.toPath()).use {
-        properties.load(it)
-    }
-    properties.getProperty("version")
-} else {
-    providers.gradleProperty("profiler.version").get()
-}
-versionInfo.version.set(profilerVersion)
+val profilerVersion = resolveProfilerVersion()
 val createdBuildReceipt = layout.buildDirectory.file(buildReceiptName)
 tasks.register("createBuildReceipt") {
     outputs.file(createdBuildReceipt).withPropertyName("buildReceipt")
-    inputs.property("version", versionInfo.version)
-    val version = versionInfo.version
+    inputs.property("version", profilerVersion)
     val buildReceipt = createdBuildReceipt
     doLast {
-        buildReceipt.get().asFile.writeText("version=${version.get()}", StandardCharsets.UTF_8)
+        buildReceipt.get().asFile.writeText("version=$profilerVersion", StandardCharsets.UTF_8)
     }
 }
 
@@ -32,7 +15,7 @@ gradle.taskGraph.whenReady {
     if (hasTask(":publishToSonatype") || hasTask(":releaseToSdkMan")) {
         logger.lifecycle(
             "##teamcity[buildStatus text='{build.status.text}, Published version {}']",
-            versionInfo.version.get()
+            profilerVersion
         )
     }
 }

--- a/buildSrc/src/main/kotlin/profiler.versioning.gradle.kts
+++ b/buildSrc/src/main/kotlin/profiler.versioning.gradle.kts
@@ -1,6 +1,1 @@
-import extensions.VersionInfo
-
-rootProject.plugins.apply("profiler.versioning-root-project")
-
-val versionInfo = rootProject.extensions["versionInfo"] as VersionInfo
-version = versionInfo.version.get()
+version = resolveProfilerVersion()

--- a/buildSrc/src/main/kotlin/versioning.kt
+++ b/buildSrc/src/main/kotlin/versioning.kt
@@ -1,0 +1,22 @@
+import org.gradle.api.Project
+import java.nio.file.Files
+import java.util.Properties
+
+/**
+ * Resolves the profiler version without observing the state of another project.
+ *
+ * Each project computes the version from the same two immutable inputs: the build
+ * receipt that CI drops into the root directory for a promotion build, and the
+ * `profiler.version` Gradle property. Sharing the value through an extension on
+ * the root project instead would break Isolated Projects.
+ */
+fun Project.resolveProfilerVersion(): String {
+    val rootDir = isolated.rootProject.projectDirectory.asFile
+    val incomingBuildReceipt = rootDir.resolve("incoming-distributions/$buildReceiptName")
+    if (incomingBuildReceipt.isFile) {
+        val properties = Properties()
+        Files.newInputStream(incomingBuildReceipt.toPath()).use { properties.load(it) }
+        return properties.getProperty("version")
+    }
+    return providers.gradleProperty("profiler.version").get()
+}


### PR DESCRIPTION
Removes the versioning violations tracked by #852. The 3 violations from the Nexus publish plugin stay, so the feature cannot be enabled yet.

### Why

Isolated Projects forbids build logic in one project to read the mutable state of another project. Versioning caused 28 of the build's 31 unique violations, and none of them were necessary: the version comes from a Gradle property and an optional build receipt that every project can read for itself, so the cross-project access only shared a string.

### What

- Versioning becomes a self-contained convention: each project resolves the version from the same two inputs, instead of reading it from an extension on the root project.
- The version is a provider, resolved only where a `String` is required.

### Verification

- Unique violations go from 31 to 3. The 3 that remain name the Nexus publish plugin.
- All 15 projects resolve the same version, and a staged build receipt overrides that version in all of them. This is the behavior the root-project extension supplied before.
- A receipt that carries no version fails the build, as it did before. This is the case a provider makes easy to lose, because an unreadable file and an absent one are the same absent value.
- A local publish of all 8 publishable projects gives the expected coordinates and metadata. Versioning feeds the published coordinates, so configuration alone does not prove this.
- The release task graph resolves, up to and including the staging close and release steps.
- Configuration performance is unverified. The feature stays off while the 3 violations remain, so this change has no measurement of the speed-up that motivates the feature.

### Details

**The build receipt controls the version of a promotion build, and it fails quietly if it stops working.** The publishing job stores the receipt as an artifact. The SDKMAN job reads that artifact and announces the version it finds. The receipt is what ties the second job to the version the first job published, because a property can move on between two separate builds. A receipt that stops being read costs nothing visible: the announcement still succeeds, under the wrong version. The receipt therefore stays the first branch of the resolution, and a receipt without a version is an error rather than a fallback to the property.
