### PR TITLE
Disable automatic SDKMAN! publishing

### DIFF
--- a/.teamcity/src/main/kotlin/GradleProfilerPublishToSdkMan.kt
+++ b/.teamcity/src/main/kotlin/GradleProfilerPublishToSdkMan.kt
@@ -16,6 +16,7 @@ class GradleProfilerPublishToSdkMan(publishingBuild: GradleProfilerPublishing) :
 
     triggers {
         finishBuildTrigger {
+            enabled = false
             buildType = publishingBuild.id.toString()
             successfulOnly = true
             branchFilter = "+:master"


### PR DESCRIPTION
- Disable the finish build trigger on the `Gradle profiler Publish to SDKman` TeamCity build — we don't have SDKMAN! vendor keys available currently.
- Nothing else changes: the build config, its credential params, the `releaseToSdkMan` task and the `sdkman {}` block are untouched, so re-enabling is a one-line revert once the keys are back.